### PR TITLE
#10: add place-holder file for CQ-13814

### DIFF
--- a/plugins/org.eclipse.n4js.ui/contents/GH_10_TODO.txt
+++ b/plugins/org.eclipse.n4js.ui/contents/GH_10_TODO.txt
@@ -1,0 +1,1 @@
+TODO GH-10: add the N4JS Tasks Example sources at this location, once CQ-13814 is approved.


### PR DESCRIPTION
This place-holder file is required, because otherwise builds will fail due to a missing folder.

NOTE: merging this PR does *not* resolve #10 !