### PR TITLE
#12 GH-12 fixed compilation errors in the new Xpect files

### DIFF
--- a/plugins/org.eclipse.n4js.xpect/src/org/eclipse/n4js/xpect/methods/scoping/N4JSCommaSeparatedValuesExpectation.java
+++ b/plugins/org.eclipse.n4js.xpect/src/org/eclipse/n4js/xpect/methods/scoping/N4JSCommaSeparatedValuesExpectation.java
@@ -5,10 +5,10 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *******************************************************************************/
-package eu.numberfour.n4js.xpect.methods.scoping;
+package org.eclipse.n4js.xpect.methods.scoping;
 
-import static eu.numberfour.n4js.xpect.methods.scoping.EObjectDescriptionToNameWithPositionMapper.descriptionToNameWithPosition;
-import static eu.numberfour.n4js.xpect.methods.scoping.EObjectDescriptionToNameWithPositionMapper.getNameFromNameWithPosition;
+import static org.eclipse.n4js.xpect.methods.scoping.EObjectDescriptionToNameWithPositionMapper.descriptionToNameWithPosition;
+import static org.eclipse.n4js.xpect.methods.scoping.EObjectDescriptionToNameWithPositionMapper.getNameFromNameWithPosition;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/plugins/org.eclipse.n4js.xpect/src/org/eclipse/n4js/xpect/methods/scoping/ScopeXpectMethod.java
+++ b/plugins/org.eclipse.n4js.xpect/src/org/eclipse/n4js/xpect/methods/scoping/ScopeXpectMethod.java
@@ -8,12 +8,15 @@
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */
-package eu.numberfour.n4js.xpect.methods.scoping;
+package org.eclipse.n4js.xpect.methods.scoping;
 
 import java.util.Collections;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
+import org.eclipse.n4js.n4JS.ParameterizedPropertyAccessExpression;
+import org.eclipse.n4js.ts.types.IdentifiableElement;
+import org.eclipse.n4js.ts.types.TMember;
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.naming.IQualifiedNameConverter;
 import org.eclipse.xtext.resource.IEObjectDescription;
@@ -27,10 +30,6 @@ import org.xpect.xtext.lib.tests.ScopingTest;
 import org.xpect.xtext.lib.util.XtextOffsetAdapter.ICrossEReferenceAndEObject;
 
 import com.google.inject.Inject;
-
-import eu.numberfour.n4js.n4JS.ParameterizedPropertyAccessExpression;
-import eu.numberfour.n4js.ts.types.IdentifiableElement;
-import eu.numberfour.n4js.ts.types.TMember;
 
 /**
  */


### PR DESCRIPTION
In `ScopeXpectMethod` and `N4JSCommaSeparatedValuesExpectation` fixed
* package declarations
* import statements 
