### PR TITLE
#16: Recent changes by N4JS committers (correction)

### DIFF
--- a/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/parser/ES_07_09_AutomaticSemicolonInsertionParserTest.xtend
+++ b/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/parser/ES_07_09_AutomaticSemicolonInsertionParserTest.xtend
@@ -139,86 +139,58 @@ class ES_07_09_AutomaticSemicolonInsertionParserTest extends AbstractParserTest 
 	}
 
 	/*
+	 * The following examples (testOneVsTwoStatements..) are similar to those described at 
 	 * http://lucumr.pocoo.org/2011/2/6/automatic-semicolon-insertion/
-	 *
-	 * Excerpt regarding testBlogExample_01-03:
-	 *
-	 * Like Python, JavaScript has array literals ([1, 2, 3, 4]) and uses a very similar syntax to access items
-	 * of objects and arrays (foo[index]). Unfortunately that particular little pseudo-ambiguity becomes a problem
-	 * when you forget to place semicolons. Take the following piece of JavaScript code as example:
-	 *
-	 *     var name = "World"
-	 *     ["Hello", "Goodbye"].forEach(function(value) {
-	 *       document.write(value + " " + name + "<br>")
-	 *     })
-	 *
-	 * That is not a syntax error, but it will fail with an odd error. Why is that? The problem is that JavaScript
-	 * will insert semicolons after the document.write() call and after the .forEach() call, but not before the array
-	 * literal. In fact, it will attempt to use the array literal as indexer operator to the string from the line before.
-	 *
-	 * (c) Copyright 2014 by Armin Ronacher.
+	 * by Armin Ronacher. More information about the effects see blog entry.
 	 */
+	
 	@Test
-	def void testBlogExample_01() {
-		val parseResult = parseSuccessfully("var name = \"World\"\n" +
-				"[\"Hello\", \"Goodbye\"].forEach(function(value) {\n" +
-				"  document.write(value + \" \" + name + \"<br>\")\n" +
-				"})");
+	def void testOneVsTwoStatements_01_ASI() {
+		val parseResult = '''
+			let x = 1
+			[0];
+		'''.parseSuccessfully
 		parseResult.hasChildren(1)
 	}
 	@Test
-	def void testBlogExample_02() {
-		val parseResult = parseSuccessfully("var name = \"World\";\n" +
-				"[\"Hello\", \"Goodbye\"].forEach(function(value) {\n" +
-				"  document.write(value + \" \" + name + \"<br>\")\n" +
-				"})");
+	def void testOneVsTwoStatements_01_WithSem() {
+		val parseResult = '''
+			let x = 1;
+			[0];
+		'''.parseSuccessfully
 		parseResult.hasChildren(2)
 	}
 	@Test
-	def void testBlogExample_03() {
-		parseSuccessfully("var name = \"World\";/*\n*/" +
-				"[\"Hello\", \"Goodbye\"].forEach(function(value) {\n" +
-				"  document.write(value + \" \" + name + \"<br>\")\n" +
-				"})");
-	}
-
-	@Test
-	def void testBlogExample_04() {
-		parseSuccessfully("namespace.makeCounter = function() {\n" +
-				"  var counter = 0\n" +
-				"  return function() {\n" +
-				"    return counter++\n" +
-				"  }\n" +
-				"}\n" +
-				"(function() {\n" +
-				"  namespace.exportedObject = function() {\n" +
-				"    1+2\n" +
-				"  }\n" +
-				"})()");
-	}
-	@Test
-	def void testBlogExample_05() {
-		val parseResult = parseSuccessfully("/* this works */\n" +
-				"var foo = 1 + 2\n" +
-				"something.method(foo) + 42");
-		parseResult.hasChildren(2)
-	}
-	@Test
-	def void testBlogExample_06() {
-		val parseResult = parseSuccessfully("/* this does not work, will try to call 2(...) */\n" +
-				"var foo = 1 + 2\n" +
-				"(something.method(foo) + 42).print()");
+	def void testOneVsTwoStatements_02_ASI() {
+		val parseResult = '''
+			let f = function (){}
+			(1)		
+		'''.parseSuccessfully
 		parseResult.hasChildren(1)
 	}
 	@Test
-	def void testBlogExample_07() {
-		val parseResult = parseSuccessfully("var x=function(){}\n" +
-				"var y=function(){}");
+	def void testOneVsTwoStatements_02_WithSem() {
+		val parseResult = '''
+			let f = function (){};
+			(1)
+		'''.parseSuccessfully
 		parseResult.hasChildren(2)
 	}
 	@Test
-	def void testBlogExample_08() {
-		parseWithError("var x=function(){}var y=function(){}");
+	def void testOneVsTwoStatements_03_ASI() {
+		val parseResult = '''
+			1
+			(1)
+		'''.parseSuccessfully
+		parseResult.hasChildren(1)
+	}
+	@Test
+	def void testOneVsTwoStatements_03_WithSem() {
+		val parseResult = '''
+			1;
+			(1)
+		'''.parseSuccessfully
+		parseResult.hasChildren(2)
 	}
 
 	@Test


### PR DESCRIPTION
The single commit of this PR re-applies a change* that was part of PR #7 which was
accidentally reverted in PR #17.

for original change see: https://github.com/eclipse/n4js/pull/7/commits/a409637a3dcbe97d373b40c3f71550ea368e882f