### PR TITLE
#81: Fix syntax of copyright header comments in markdown files

### DIFF
--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft.reporter.ide/messages.md
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft.reporter.ide/messages.md
@@ -1,4 +1,4 @@
-////
+<!--
 Copyright (c) 2017 NumberFour AG.
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
@@ -7,7 +7,7 @@ http://www.eclipse.org/legal/epl-v10.html
 
 Contributors:
   NumberFour AG - Initial API and implementation
-////
+-->
 
 # HTTP Reporter Messages
 

--- a/plugins/org.eclipse.n4js.external.libraries/shipped-code/mangelhaft/org.eclipse.n4js.mangelhaft.reporter.ide/messages.md
+++ b/plugins/org.eclipse.n4js.external.libraries/shipped-code/mangelhaft/org.eclipse.n4js.mangelhaft.reporter.ide/messages.md
@@ -1,4 +1,4 @@
-////
+<!--
 Copyright (c) 2017 NumberFour AG.
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License v1.0
@@ -7,7 +7,7 @@ http://www.eclipse.org/legal/epl-v10.html
 
 Contributors:
   NumberFour AG - Initial API and implementation
-////
+-->
 
 # HTTP Reporter Messages
 


### PR DESCRIPTION
__Task https://github.com/eclipse/n4js/issues/81__