### PR TITLE
#124: omit AST access if possible (in the context of outline view)

### DIFF
--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/labeling/N4JSStylers.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/labeling/N4JSStylers.java
@@ -23,6 +23,11 @@ import org.eclipse.swt.graphics.RGB;
 public class N4JSStylers {
 
 	/**
+	 * Color used for styling type refs. Used by {@link N4JSStylers#TYPEREF_STYLER} and defined in same class to ensure
+	 * static initialization.
+	 */
+	public final static String TYPEREF_COLOR_NAME = "org.eclipse.n4js.ui.labeling.TYPEREF_COLOR_NAME";
+	/**
 	 * Color used for styling origin of inherited members. Used by {@link N4JSStylers#INHERITED_MEMBERS_STYLER} and
 	 * defined in same class to ensure static initialization.
 	 */
@@ -40,11 +45,18 @@ public class N4JSStylers {
 
 	static {
 		ColorRegistry colorRegistry = JFaceResources.getColorRegistry();
-		colorRegistry.put(INHERITED_MEMBER_COLOR_NAME, new RGB(0, 0, 200));
-		colorRegistry.put(CONSUMED_MEMBER_COLOR_NAME, new RGB(0, 150, 0));
-		colorRegistry.put(POLYFILLED_MEMBER_COLOR_NAME, new RGB(150, 0, 0));
+		colorRegistry.put(TYPEREF_COLOR_NAME, new RGB(140, 140, 140)); // color we use in editor as well
+		colorRegistry.put(INHERITED_MEMBER_COLOR_NAME, new RGB(180, 180, 255));
+		colorRegistry.put(CONSUMED_MEMBER_COLOR_NAME, new RGB(255, 180, 180));
+		colorRegistry.put(POLYFILLED_MEMBER_COLOR_NAME, new RGB(255, 255, 180));
 	}
 
+	/**
+	 * Styler used to style origin of inherited members. Used by
+	 * {@link StyledTextCalculationHelper#dispatchGetStyledText(Object)} for EObjectWithContext.
+	 */
+	public final static Styler TYPEREF_STYLER = StyledString.createColorRegistryStyler(
+			TYPEREF_COLOR_NAME, null);
 	/**
 	 * Styler used to style origin of inherited members. Used by
 	 * {@link StyledTextCalculationHelper#dispatchGetStyledText(Object)} for EObjectWithContext.

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/labeling/helper/LabelCalculationHelper.xtend
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/labeling/helper/LabelCalculationHelper.xtend
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */
@@ -39,7 +39,7 @@ import org.eclipse.xtext.ui.label.AbstractLabelProvider
  * Xtend dispatch methods. Here the dispatch of labels to be shown e.g. in
  * the outline view is done. It is called in {@link N4JSLabelProvider#doGetText}.
  * <br /><br />
- * General pattern is to delegate from an AST element to the types elmenent
+ * General pattern is to delegate from an AST element to the types element
  * as in the types model the required information to calculate the name
  * is better provided.
  * <br /><br />
@@ -64,25 +64,26 @@ import org.eclipse.xtext.ui.label.AbstractLabelProvider
 class LabelCalculationHelper {
 
 	/* dispatchDoGetText AST -> delegates to types model, as information is easier to retrieve there */
-
 	def dispatch String dispatchDoGetText(Void _null) {
 		return "*null*";
 	}
 
-
 	def dispatch String dispatchDoGetText(EObjectWithContext objectWithContext) {
 		var label = dispatchDoGetText(objectWithContext.obj);
 
-		if (objectWithContext.obj instanceof N4MemberDeclaration) {
-			val TMember member = (objectWithContext.obj as N4MemberDeclaration).definedTypeElement;
-			if (member !== null && member.containingType !== null &&
-				member.containingType != objectWithContext.context) {
-				label += " from " + dispatchDoGetText(member.containingType);		
-			}
+		val TMember member = if (objectWithContext.obj instanceof N4MemberDeclaration) {
+				(objectWithContext.obj as N4MemberDeclaration).definedTypeElement
+			} else if (objectWithContext.obj instanceof TMember) {
+				objectWithContext.obj as TMember
+			} else
+				null;
+
+		if (member !== null && member.containingType !== null && member.containingType != objectWithContext.context) {
+			label += " from " + dispatchDoGetText(member.containingType);
 		}
-		
+
 		return label;
-		
+
 	}
 
 	def dispatch String dispatchDoGetText(Script script) {
@@ -93,15 +94,17 @@ class LabelCalculationHelper {
 	// e.g. imports from mypack/MyModule/A or imports from mypack/MyModule/A: A
 	def dispatch String dispatchDoGetText(ImportDeclaration importDelaration) {
 		return "imports from " + getModuleSpecifier(importDelaration.module) +
-			(if(importDelaration.importSpecifiers.size == 1 &&
+			(if (importDelaration.importSpecifiers.size == 1 &&
 				!(importDelaration.importSpecifiers.head instanceof NamespaceImportSpecifier))
-					": "  + importDelaration.importSpecifiers.head.dispatchDoGetText else "")
+				": " + importDelaration.importSpecifiers.head.dispatchDoGetText
+			else
+				"")
 	}
 
 	// name and if given alias, e.g. A as B
 	def dispatch String dispatchDoGetText(NamedImportSpecifier namedImportSpecifier) {
 		return namedImportSpecifier.importedElement?.name +
-			(if(namedImportSpecifier.alias !== null) " as " + namedImportSpecifier.alias else "")
+			(if (namedImportSpecifier.alias !== null) " as " + namedImportSpecifier.alias else "")
 	}
 
 	def dispatch String dispatchDoGetText(N4ClassifierDeclaration it) {
@@ -116,30 +119,37 @@ class LabelCalculationHelper {
 		return dispatchDoGetText(n4SetterDeclaration.definedSetter)
 	}
 
-	// comma separated list of all contained variable names
+	/** 
+	 * comma separated list of all contained variable names
+	 */
 	def dispatch String dispatchDoGetText(ExportedVariableStatement vs) {
-		 return vs.varDecl.map[name].join(", ")
+		return vs.varDecl.map[name].join(", ")
 	}
 
 	def dispatch String dispatchDoGetText(NamedElement namedElement) {
-		 namedElement.name
+		namedElement.name
 	}
 
-	/* dispatchDoGetText types model */
-
-	// the fully qualified module specifier, e.g. mypack/MyFile
+	/** 
+	 * dispatchDoGetText types model
+	 * the fully qualified module specifier, e.g. mypack/MyFile
+	 */
 	def dispatch String dispatchDoGetText(TModule tModule) {
 		return getModuleSpecifier(tModule)
 	}
 
-	// name + optional type variables, e.g. A<T, U>
+	/** 
+	 * name + optional type variables, e.g. A<T, U>
+	 */
 	def dispatch String dispatchDoGetText(TClassifier tClassifier) {
 		return tClassifier.name + handleTypeVars(tClassifier)
 	}
 
 	def private handleTypeVars(TClassifier tClassifier) {
-		if(tClassifier.typeVars.size > 0)
-				"<" + tClassifier.typeVars.map[name].join(", ") + ">" else ""
+		if (tClassifier.typeVars.size > 0)
+			"<" + tClassifier.typeVars.map[name].join(", ") + ">"
+		else
+			""
 	}
 
 	def dispatch String dispatchDoGetText(TGetter tGetter) {
@@ -155,8 +165,8 @@ class LabelCalculationHelper {
 	}
 
 	def dispatch String dispatchDoGetText(IEObjectDescription d) {
-		if (TypesPackage.eINSTANCE.TN4Classifier.isSuperTypeOf(d.EClass)
-			|| TypesPackage.eINSTANCE.TEnum.isSuperTypeOf(d.EClass)) {
+		if (TypesPackage.eINSTANCE.TN4Classifier.isSuperTypeOf(d.EClass) ||
+			TypesPackage.eINSTANCE.TEnum.isSuperTypeOf(d.EClass)) {
 			return d.qualifiedName.lastSegment;
 		} else {
 			return "<unknown>"
@@ -169,6 +179,6 @@ class LabelCalculationHelper {
 	}
 
 	def private getModuleSpecifier(TModule tModule) {
-		if( tModule?.qualifiedName !== null) tModule.moduleSpecifier else "<unknown>"
+		if (tModule?.qualifiedName !== null) tModule.moduleSpecifier else "<unknown>"
 	}
 }

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/labeling/helper/LabelCalculationHelper.xtend
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/labeling/helper/LabelCalculationHelper.xtend
@@ -142,10 +142,10 @@ class LabelCalculationHelper {
 	 * name + optional type variables, e.g. A<T, U>
 	 */
 	def dispatch String dispatchDoGetText(TClassifier tClassifier) {
-		return tClassifier.name + handleTypeVars(tClassifier)
+		return tClassifier.name + getTypeVarDescriptions(tClassifier)
 	}
 
-	def private handleTypeVars(TClassifier tClassifier) {
+	def private getTypeVarDescriptions(TClassifier tClassifier) {
 		if (tClassifier.typeVars.size > 0)
 			"<" + tClassifier.typeVars.map[name].join(", ") + ">"
 		else

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/labeling/helper/StyledTextCalculationHelper.xtend
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/labeling/helper/StyledTextCalculationHelper.xtend
@@ -82,7 +82,9 @@ class StyledTextCalculationHelper {
 		return new StyledString("*error*")
 	}
 
-	// fallback
+	/**
+	 * fallback
+	 */
 	def dispatch StyledString dispatchGetStyledText(Object element) {
 		getLabelProvider.getSuperStyledText(element)
 	}
@@ -118,16 +120,17 @@ class StyledTextCalculationHelper {
 		return styledText;
 	}
 
-	// produces e.g. functionName(param1TypeName, param2TypeName) : returnTypeName
+	/**
+	 * produces e.g. functionName(param1TypeName, param2TypeName) : returnTypeName
+	 */
 	def dispatch StyledString dispatchGetStyledText(FunctionDefinition functionDefinition) {
 		val definedType = functionDefinition.definedType;
 		if (definedType instanceof TFunction) {
 			return dispatchGetStyledText(definedType);
-		}	
+		}
 		getLabelProvider.getSuperStyledText(functionDefinition);
 	}
-	
-	
+
 	/**
 	 * Does not access AST. 
 	 */
@@ -140,28 +143,31 @@ class StyledTextCalculationHelper {
 		if (!tfunction.constructor && tfunction.returnTypeRef !== null)
 			typeStr = " : " + getTypeRefDescription(tfunction.returnTypeRef)
 
-		
 		styledText = styledText.append(typeStr)
-		
+
 		return styledText;
 	}
 
-	// produces e.g. <T, U>
+	/**
+	 * produces e.g. <T, U>
+	 */
 	def private handleTypeVars(List<TypeVariable> typeVars) {
 		if (typeVars.size > 0) " <" + typeVars.map[name].join(", ") + ">" else "";
 	}
 
-	// produces e.g. getterName() : returnTypeName
+	/**
+	 * produces e.g. getterName() : returnTypeName
+	 */
 	def dispatch StyledString dispatchGetStyledText(N4GetterDeclaration n4GetterDeclaration) {
-		if (n4GetterDeclaration.definedGetter!==null)
+		if (n4GetterDeclaration.definedGetter !== null)
 			return dispatchGetStyledText(n4GetterDeclaration.definedGetter);
-	
-		return getLabelProvider.getSuperStyledText(n4GetterDeclaration);
+
+		return getLabelProvider().getSuperStyledText(n4GetterDeclaration);
 
 	}
 
 	/**
-	 * Returns the styled text for the given getter, does not accesses the AST.
+	 * Returns the styled text for the given getter, does not access the AST.
 	 */
 	def dispatch StyledString dispatchGetStyledText(TGetter tgetter) {
 		var styledText = getLabelProvider.getSuperStyledText(tgetter);
@@ -174,11 +180,13 @@ class StyledTextCalculationHelper {
 		return styledText;
 	}
 
-	/** produces e.g. setterName: paramTypeName */
+	/** 
+	 * produces e.g. setterName: paramTypeName 
+	 */
 	def dispatch StyledString dispatchGetStyledText(N4SetterDeclaration n4SetterDeclaration) {
-		if (n4SetterDeclaration.definedSetter!==null)
+		if (n4SetterDeclaration.definedSetter !== null)
 			return dispatchGetStyledText(n4SetterDeclaration.definedSetter);
-		
+
 		return getLabelProvider.getSuperStyledText(n4SetterDeclaration);
 	}
 
@@ -188,20 +196,21 @@ class StyledTextCalculationHelper {
 	def dispatch StyledString dispatchGetStyledText(TSetter tsetter) {
 		var styledText = getLabelProvider.getSuperStyledText(tsetter)
 		if (tsetter.fpar !== null && tsetter.fpar !== null) {
-			styledText.append(" : ").append(
-				getStyledTextForFormalParameter(tsetter.fpar))
+			styledText.append(" : ").append(getStyledTextForFormalParameter(tsetter.fpar))
 		}
 
 	}
 
-	// produces e.g. fieldName : fieldTypeName
+	/**
+	 * produces e.g. fieldName : fieldTypeName
+	 */
 	def dispatch StyledString dispatchGetStyledText(N4FieldDeclaration n4FieldDeclaration) {
-		if (n4FieldDeclaration.definedField!==null)
+		if (n4FieldDeclaration.definedField !== null)
 			return dispatchGetStyledText(n4FieldDeclaration.definedField);
-		
+
 		return getLabelProvider.getSuperStyledText(n4FieldDeclaration);
 	}
-	
+
 	/**
 	 * Returns the styled text for the given field, does not accesses the AST.
 	 */
@@ -214,7 +223,9 @@ class StyledTextCalculationHelper {
 		return styledText;
 	}
 
-	// produces e.g. variableName : variableTypeName
+	/**
+	 * produces e.g. variableName : variableTypeName
+	 */
 	def dispatch StyledString dispatchGetStyledText(ExportedVariableDeclaration variableDeclaration) {
 		var styledText = getLabelProvider.getSuperStyledText(variableDeclaration)
 		val definedVariable = variableDeclaration.definedVariable
@@ -227,11 +238,13 @@ class StyledTextCalculationHelper {
 		return styledText;
 	}
 
-	// produces e.g. (param1TypeName, param2TypeName)
+	/**
+	 * produces e.g. (param1TypeName, param2TypeName)
+	 */
 	def private appendStyledTextForFormalParameters(StyledString styledText, TFunction tFunction) {
 		(styledText.append("(") => [
 			if (tFunction.fpars.size > 0) {
-				it.append((0 .. tFunction.fpars.size - 1).map [i|
+				it.append((0 .. tFunction.fpars.size - 1).map [ i |
 					getStyledTextForFormalParameter(tFunction.fpars.get(i))
 				].reduce(l, r|l.append(", ").append(r)))
 			}
@@ -268,22 +281,28 @@ class StyledTextCalculationHelper {
 		}
 	}
 
-	// appends the simple type name to the styled string
+	/**
+	 * appends the simple type name to the styled string
+	 */
 	def dispatch private void dispatchGetTypeRefDescription(TypeRef ref, StyledString styledString) {
 		val name = ref.declaredType?.name;
-		if(name === null) {
+		if (name === null) {
 			styledString.append("<unknown>")
 		} else {
 			styledString.append(name);
 		}
 	}
 
-	// produces 'this' for ThisType references
+	/**
+	 * produces 'this' for ThisType references
+	 */
 	def dispatch private void dispatchGetTypeRefDescription(ThisTypeRef ref, StyledString styledString) {
 		styledString.append("this");
 	}
 
-	// produces (param1, param2,...) => returnType
+	/**
+	 * produces (param1, param2,...) => returnType
+	 */
 	def dispatch private void dispatchGetTypeRefDescription(FunctionTypeExpression ref, StyledString styledString) {
 		styledString.append("(");
 
@@ -302,7 +321,9 @@ class StyledTextCalculationHelper {
 		styledString.append(returnTypeString);
 	}
 
-	// produces type{typeName} or constructor{typeName}
+	/**
+	 * produces type{typeName} or constructor{typeName}
+	 */
 	def dispatch private void dispatchGetTypeRefDescription(TypeTypeRef ref, StyledString styledString) {
 		val typeName = switch ref.typeArg {
 			ThisTypeRef:
@@ -317,7 +338,9 @@ class StyledTextCalculationHelper {
 		}
 	}
 
-	// produces union{type1, type2, ...} or intersection{type1, type2, ...}
+	/**
+	 * produces union{type1, type2, ...} or intersection{type1, type2, ...}
+	 */
 	def dispatch private void dispatchGetTypeRefDescription(ComposedTypeRef ref, StyledString styledString) {
 		if (ref instanceof UnionTypeExpression) {
 			styledString.append("union{");
@@ -329,7 +352,9 @@ class StyledTextCalculationHelper {
 		styledString.append("}");
 	}
 
-	// produces a comma separated TypeRef description list element by element
+	/**
+	 * produces a comma separated TypeRef description list element by element
+	 */
 	def private void appendCommaSeparatedTypeRefList(Iterable<TypeRef> refs, StyledString styledString, boolean first) {
 		if (!refs.iterator.hasNext) {
 			return;

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/outline/N4JSOutlineTreeProvider.xtend
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/outline/N4JSOutlineTreeProvider.xtend
@@ -28,6 +28,7 @@ import org.eclipse.n4js.n4JS.N4FieldDeclaration
 import org.eclipse.n4js.n4JS.N4MemberDeclaration
 import org.eclipse.n4js.n4JS.Script
 import org.eclipse.n4js.ts.types.TClassifier
+import org.eclipse.n4js.ts.types.TMember
 import org.eclipse.n4js.ui.labeling.EObjectWithContext
 import org.eclipse.n4js.ui.labeling.N4JSLabelProvider
 import org.eclipse.n4js.utils.ContainerTypesHelper
@@ -91,6 +92,7 @@ class N4JSOutlineTreeProvider extends BackgroundOutlineTreeProvider implements I
 	 */
 	override IOutlineNode createRoot(IXtextDocument document, CancelIndicator cancelIndicator) {
 		try {
+			// Thread.sleep(5000);
 			getN4JSLabelProvider.establishCancelIndicator(cancelIndicator);
 			return super.createRoot(document, cancelIndicator);
 		} finally {
@@ -147,17 +149,15 @@ class N4JSOutlineTreeProvider extends BackgroundOutlineTreeProvider implements I
 	 * If not turned off, also inherited (and consumed or polyfilled) members are shown.
 	 */
 	def dispatch protected void createChildren_(IOutlineNode parentNode, N4ClassifierDefinition classifierDefinition) {
-
-		val t = classifierDefinition.definedType as TClassifier;
-		if (t !== null && showInherited) {
-			val members = containerTypesHelper.fromContext(classifierDefinition).members(t, false, true);
+		val tclassifier = classifierDefinition.definedType as TClassifier;
+		if (tclassifier !== null && showInherited) {
+			val members = containerTypesHelper.fromContext(tclassifier).members(tclassifier, false, true);
+			
 			for (tchild : members.filterNull) {
-				if (tchild.astElement !== null) {
-					val node = createNodeForObjectWithContext(parentNode, new EObjectWithContext(tchild.astElement, t));
-					if (node instanceof N4JSEObjectNode && tchild.containingType !== null &&
-						tchild.containingType != t) {
-						(node as N4JSEObjectNode).isInherited = true;
-					}
+				val node = createNodeForObjectWithContext(parentNode, new EObjectWithContext(tchild, tclassifier));
+				if (node instanceof N4JSEObjectNode && tchild.containingType !== null &&
+					tchild.containingType != tclassifier) {
+					(node as N4JSEObjectNode).isInherited = true;
 				}
 			}
 		} else {
@@ -230,22 +230,32 @@ class N4JSOutlineTreeProvider extends BackgroundOutlineTreeProvider implements I
 		!script.eContents.exists[isInstanceOfExpectedScriptChildren]
 	}
 
-	/*
-	 * suppress + symbol in outline when classifier has no members
-	 * or we have a broken AST and the defined type of the classifier is not available yet
+	/**
+	 * Suppress + symbol in outline when classifier has no members
+	 * or we have a broken AST and the defined type of the classifier is not available yet.
+	 * 
+	 * This method directly works on AST, because the outline is called with the AST.
 	 */
 	def dispatch protected boolean isLeaf(N4ClassifierDefinition classifierDefinition) {
-		val t = classifierDefinition.definedType as TClassifier;
-		if (t === null) {
+		val tclassifier = classifierDefinition.definedType as TClassifier;
+		if (tclassifier === null) {
 			return true;
 		}
 		if (showInherited) {
-			val members = containerTypesHelper.fromContext(classifierDefinition).members(t, false, true);
+			val members = containerTypesHelper.fromContext(tclassifier).members(tclassifier, false, true);
 			return members.isNullOrEmpty;
 		} else {
 			return !classifierDefinition.eContents.exists[isInstanceOfExpectedClassifierChildren]
 		}
 	}
+	
+	/**
+	 * Type model members are always leaves. 
+	 */
+	def dispatch protected boolean isLeaf(TMember member) {
+		return true;
+	}
+
 
 	// fields should have never children
 	def dispatch protected boolean isLeaf(N4FieldDeclaration md) {

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/outline/N4JSOutlineTreeProvider.xtend
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/outline/N4JSOutlineTreeProvider.xtend
@@ -92,7 +92,6 @@ class N4JSOutlineTreeProvider extends BackgroundOutlineTreeProvider implements I
 	 */
 	override IOutlineNode createRoot(IXtextDocument document, CancelIndicator cancelIndicator) {
 		try {
-			// Thread.sleep(5000);
 			getN4JSLabelProvider.establishCancelIndicator(cancelIndicator);
 			return super.createRoot(document, cancelIndicator);
 		} finally {

--- a/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/outline/N4JSOutlineWorkbenchPluginUITest.xtend
+++ b/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/outline/N4JSOutlineWorkbenchPluginUITest.xtend
@@ -67,27 +67,27 @@ class N4JSOutlineWorkbenchPluginUITest extends AbstractOutlineWorkbenchTest {
 			interface I2 {}
 			
 			class OutlineTest {
-				field : intersection{I1<int, int, int>, I2}
-				fieldWithLongTypeDescription : union{int, intersection{int, union{int, string}}}
-				a(param : union{int, string}) {}
-				b(param : intersection{I1<int, int, int>, I2}) {}
-				c(param : type{I1}) {}
-				d(param : constructor{I1}) {}
-				e(param : {function(union{int, string}) : int}) : void {}
-				f(param : (intersection{I1<string, string, string>, I2}) => int) {}
+				field: intersection{I1<int, int, int>, I2}
+				fieldWithLongTypeDescription: union{int, intersection{int, union{int, string}}}
+				a(param: union{int, string}) {}
+				b(param: intersection{I1<int, int, int>, I2}) {}
+				c(param: type{I1}) {}
+				d(param: constructor{I1}) {}
+				e(param: {function(union{int, string}): int}): void {}
+				f(param: (intersection{I1<string, string, string>, I2}) => int) {}
 			}
 			
-			function a(param : union{int, string}) {}
-			function <B extends I2> b(param0: int, param : intersection{I1<B, union{string, int}, string>, I2}, param2 : number) {}
-			function c(param : type{I1}) {}
-			function d(param : constructor{I1}) {}
-			function e(param : {function(union{int, string}) : int}) {}
-			function f(param : (union{int, string, intersection{number,int, string}, int}) => union{int, string, intersection{number,int, string}, int}) : union{int, string, intersection{number,int, string}, int}{return 1;}
-			function g(param : union{int, string, intersection{number,int, string}, int}) : union{int, string, intersection{int, string, number}, int} { return 3; }
-			function g1(param : union{int, string, intersection{number,int, string},number}) : union{int, string, intersection{int, string, number}, string} { return 3; }
-			function none(fct : () => void) {}
+			function a(param: union{int, string}) {}
+			function <B extends I2> b(param0: int, param: intersection{I1<B, union{string, int}, string>, I2}, param2: number) {}
+			function c(param: type{I1}) {}
+			function d(param: constructor{I1}) {}
+			function e(param: {function(union{int, string}): int}) {}
+			function f(param: (union{int, string, intersection{number,int, string}, int}) => union{int, string, intersection{number,int, string}, int}): union{int, string, intersection{number,int, string}, int}{return 1;}
+			function g(param: union{int, string, intersection{number,int, string}, int}): union{int, string, intersection{int, string, number}, int} { return 3; }
+			function g1(param: union{int, string, intersection{number,int, string},number}): union{int, string, intersection{int, string, number}, string} { return 3; }
+			function none(fct: () => void) {}
 			export public var fct = 3;
-			export var c : constructor{? super OutlineTest}
+			export var c: constructor{? super OutlineTest}
 		'''
 		val rootNode = assertNoException(model);
 		assertEquals("There is only one top level node", rootNode.children.length, 1);
@@ -99,29 +99,29 @@ class N4JSOutlineWorkbenchPluginUITest extends AbstractOutlineWorkbenchTest {
 			"I1<T1, T2, T3>",
 			"I2",
 			"OutlineTest",
-			"a(union{int, string}) : void",
-			"b(int, intersection{I1, I2}, number) <B> : void",
-			"c(type{I1}) : void",
-			"d(constructor{I1}) : void",
-			"e((union{int, string}) => int) : void",
-			"f((union{int, string, intersection{...},...}) => union{int, string, intersection{...},...}) : union{int, string, intersection{...},...}",
-			"g(union{int, string, intersection{...},...}) : union{int, string, intersection{...},...}",
-			"g1(union{int, string, intersection{...},...}) : union{int, string, intersection{...},...}",
-			"none(() => void) : void",
-			"fct : int",
-			"c : constructor{? super OutlineTest}"
+			"a(union{int, string}): void",
+			"b(int, intersection{I1, I2}, number) <B>: void",
+			"c(type{I1}): void",
+			"d(constructor{I1}): void",
+			"e((union{int, string}) => int): void",
+			"f((union{int, string, intersection{number, int, string},...}) => union{int, string, intersection{number, int, string},...}): union{int, string, intersection{number, int, string},...}",
+			"g(union{int, string, intersection{number, int, string},...}): union{int, string, intersection{int, string, number},...}",
+			"g1(union{int, string, intersection{number, int, string},...}): union{int, string, intersection{int, string, number},...}",
+			"none(() => void): void",
+			"fct: int",
+			"c: constructor{? super OutlineTest}"
 		]);
 
 		// test class level nodes
 		assertNodeChildrenText(documentNode.children.get(2), #[
-			"field : intersection{I1, I2}",
-			"fieldWithLongTypeDescription : union{int, intersection{int, union{...}}}",
-			"a(union{int, string}) : void",
-			"b(intersection{I1, I2}) : void",
-			"c(type{I1}) : void",
-			"d(constructor{I1}) : void",
-			"e((union{int, string}) => int) : void",
-			"f((intersection{I1, I2}) => int) : void"
+			"field: intersection{I1, I2}",
+			"fieldWithLongTypeDescription: union{int, intersection{int, union{int, string}}}",
+			"a(union{int, string}): void",
+			"b(intersection{I1, I2}): void",
+			"c(type{I1}): void",
+			"d(constructor{I1}): void",
+			"e((union{int, string}) => int): void",
+			"f((intersection{I1, I2}) => int): void"
 		])
 	}
 
@@ -141,7 +141,7 @@ class N4JSOutlineWorkbenchPluginUITest extends AbstractOutlineWorkbenchTest {
 		assertEquals("The number of children wasn't correct.", textExpectations.keySet.length, nodeChildren.length);
 
 		var int typeIndex = 0;
-		for (Entry<String, List<String>> typeExpectation : textExpectations.entrySet) {
+		for (Entry<String, List<String>> typeExpectation: textExpectations.entrySet) {
 			val String typeName = typeExpectation.key;
 			val List<String> memberExpectations = typeExpectation.value;
 			val IOutlineNode typeNode = nodeChildren.get(typeIndex);
@@ -158,7 +158,7 @@ class N4JSOutlineWorkbenchPluginUITest extends AbstractOutlineWorkbenchTest {
 	def void testClassWithTypedField() throws Exception {
 		val model = '''
 			class A {
-				field1 : string;
+				field1: string;
 			}
 		'''
 		val rootNode = assertNoException(model)
@@ -168,9 +168,9 @@ class N4JSOutlineWorkbenchPluginUITest extends AbstractOutlineWorkbenchTest {
 		val classNode = moduleNode.children.get(0)
 		assertNode(classNode, "A", 1)
 		val fieldNode = classNode.children.get(0)
-		assertNode(fieldNode, "field1 : string", 0)
-		assertEquals(model.lastIndexOf("field1 : string"), fieldNode.getFullTextRegion.getOffset)
-		assertEquals("field1 : string;".length, fieldNode.getFullTextRegion.getLength)
+		assertNode(fieldNode, "field1: string", 0)
+		assertEquals(model.lastIndexOf("field1: string"), fieldNode.getFullTextRegion.getOffset)
+		assertEquals("field1: string;".length, fieldNode.getFullTextRegion.getLength)
 		assertEquals(model.lastIndexOf("field1"), fieldNode.getSignificantTextRegion.getOffset)
 		assertEquals("field1".length, fieldNode.getSignificantTextRegion.getLength)
 	}
@@ -212,7 +212,7 @@ class N4JSOutlineWorkbenchPluginUITest extends AbstractOutlineWorkbenchTest {
 	}
 
 	/**
-	 * Tests different modes (with and without inherited members). Since the tests directly tests
+	 * Tests different modes (with and without - inherited members). Since the tests directly tests
 	 * the IOutlineTreeProvider (and not the displayed test), the modes used for toggling the quick out line 
 	 * view are used to test the result of this provider. In the "normal" outline view, these items are filtered
 	 * via a toggle button after creation -- this filter is not tested here.
@@ -233,11 +233,11 @@ class N4JSOutlineWorkbenchPluginUITest extends AbstractOutlineWorkbenchTest {
 
 		// test document level nodes
 		assertNodeChildrenTextDeep(documentNode, newLinkedHashMap(
-			"I" -> #["fooI() : void"],
-			"J" -> #["fooJ() : void"],
-			"A" -> #["fooA() : void"],
-			"B" -> #["fooB() : void", "fooI() : void"],
-			"C" -> #["fooC() : void"]
+			"I" -> #["fooI(): void"],
+			"J" -> #["fooJ(): void"],
+			"A" -> #["fooA(): void"],
+			"B" -> #["fooB(): void", "fooI(): void"],
+			"C" -> #["fooC(): void"]
 		));
 
 		rootNode = assertNoException(model, "inherited");
@@ -247,19 +247,19 @@ class N4JSOutlineWorkbenchPluginUITest extends AbstractOutlineWorkbenchTest {
 
 		// test document level nodes
 		assertNodeChildrenTextDeep(documentNode, newLinkedHashMap(
-			"I" -> #["fooI() : void"],
-			"J" -> #["fooJ() : void", "fooI() : void inherited from I"],
-			"A" -> #["fooA() : void", "fooJ() : void consumed from J", "fooI() : void consumed from I"],
+			"I" -> #["fooI(): void"],
+			"J" -> #["fooJ(): void", "fooI(): void - inherited from I"],
+			"A" -> #["fooA(): void", "fooJ(): void - consumed from J", "fooI(): void - consumed from I"],
 			"B" ->
-				#["fooB() : void", "fooI() : void", "fooA() : void inherited from A", "fooJ() : void consumed from J"],
+				#["fooB(): void", "fooI(): void", "fooA(): void - inherited from A", "fooJ(): void - consumed from J"],
 			"C" ->
-				#["fooC() : void", "fooB() : void inherited from B", "fooI() : void inherited from B",
-					"fooA() : void inherited from A", "fooJ() : void consumed from J"]
+				#["fooC(): void", "fooB(): void - inherited from B", "fooI(): void - inherited from B",
+					"fooA(): void - inherited from A", "fooJ(): void - consumed from J"]
 		));
 	}
 
 	/**
-	 * Special case for inherited case, basically testing N4JSOutlineTree#isLeaf.
+	 * Special case for - inherited case, basically testing N4JSOutlineTree#isLeaf.
 	 */
 	@Test
 	def void testModesWithMemberlessSubclass() throws Exception {
@@ -274,7 +274,7 @@ class N4JSOutlineWorkbenchPluginUITest extends AbstractOutlineWorkbenchTest {
 
 		// test document level nodes
 		assertNodeChildrenTextDeep(documentNode, newLinkedHashMap(
-			"A" -> #["foo : any"],
+			"A" -> #["foo: any"],
 			"B" -> #[]
 		));
 
@@ -285,8 +285,8 @@ class N4JSOutlineWorkbenchPluginUITest extends AbstractOutlineWorkbenchTest {
 
 		// test document level nodes
 		assertNodeChildrenTextDeep(documentNode, newLinkedHashMap(
-			"A" -> #["foo : any"],
-			"B" -> #["foo : any inherited from A"]
+			"A" -> #["foo: any"],
+			"B" -> #["foo: any - inherited from A"]
 		));
 	}
 


### PR DESCRIPTION
#124 , follow up (bug) of #99 

removed all AST access in outline view related label providers

- [x] build