### PR TITLE
#126: rewire TModule loaded from index after resolving AST

### DIFF
--- a/plugins/org.eclipse.n4js.ts.model/emf-gen/org/eclipse/n4js/ts/types/TModule.java
+++ b/plugins/org.eclipse.n4js.ts.model/emf-gen/org/eclipse/n4js/ts/types/TModule.java
@@ -39,6 +39,7 @@ import org.eclipse.emf.common.util.EList;
  *   <li>{@link org.eclipse.n4js.ts.types.TModule#getVariables <em>Variables</em>}</li>
  *   <li>{@link org.eclipse.n4js.ts.types.TModule#getInternalTypes <em>Internal Types</em>}</li>
  *   <li>{@link org.eclipse.n4js.ts.types.TModule#getExposedInternalTypes <em>Exposed Internal Types</em>}</li>
+ *   <li>{@link org.eclipse.n4js.ts.types.TModule#getAstMD5 <em>Ast MD5</em>}</li>
  *   <li>{@link org.eclipse.n4js.ts.types.TModule#getModuleSpecifier <em>Module Specifier</em>}</li>
  * </ul>
  *
@@ -365,6 +366,41 @@ public interface TModule extends SyntaxRelatedTElement, TAnnotableElement {
 	 * @generated
 	 */
 	EList<Type> getExposedInternalTypes();
+
+	/**
+	 * Returns the value of the '<em><b>Ast MD5</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * *
+	 * MD5 hash (hex) of the AST from which this type model was created. This can be used to quickly
+	 * compare two type models created from -- maybe -- different versions of the same AST.
+	 * <p>
+	 * The MD5 is used since this is the fastest and easiest solution to compare the AST. More elegant
+	 * methods may would use the AST (in order to ignore comments and whitespaces), however this
+	 * is rather complicated to implement: No proxies must be resolved and the hash must be stable between
+	 * different runs (and between different machines to enable stable tests). This is rather hard to
+	 * achieve with traversing the AST.
+	 * 
+	 * @see org.eclipse.n4js.typesbuilder.N4JSTypesBuilder.md5Hex(String)
+	 * <!-- end-model-doc -->
+	 * @return the value of the '<em>Ast MD5</em>' attribute.
+	 * @see #setAstMD5(String)
+	 * @see org.eclipse.n4js.ts.types.TypesPackage#getTModule_AstMD5()
+	 * @model unique="false"
+	 * @generated
+	 */
+	String getAstMD5();
+
+	/**
+	 * Sets the value of the '{@link org.eclipse.n4js.ts.types.TModule#getAstMD5 <em>Ast MD5</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Ast MD5</em>' attribute.
+	 * @see #getAstMD5()
+	 * @generated
+	 */
+	void setAstMD5(String value);
 
 	/**
 	 * Returns the value of the '<em><b>Module Specifier</b></em>' attribute.

--- a/plugins/org.eclipse.n4js.ts.model/emf-gen/org/eclipse/n4js/ts/types/TypesPackage.java
+++ b/plugins/org.eclipse.n4js.ts.model/emf-gen/org/eclipse/n4js/ts/types/TypesPackage.java
@@ -298,13 +298,22 @@ public interface TypesPackage extends EPackage {
 	int TMODULE__EXPOSED_INTERNAL_TYPES = SYNTAX_RELATED_TELEMENT_FEATURE_COUNT + 13;
 
 	/**
+	 * The feature id for the '<em><b>Ast MD5</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int TMODULE__AST_MD5 = SYNTAX_RELATED_TELEMENT_FEATURE_COUNT + 14;
+
+	/**
 	 * The feature id for the '<em><b>Module Specifier</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int TMODULE__MODULE_SPECIFIER = SYNTAX_RELATED_TELEMENT_FEATURE_COUNT + 14;
+	int TMODULE__MODULE_SPECIFIER = SYNTAX_RELATED_TELEMENT_FEATURE_COUNT + 15;
 
 	/**
 	 * The number of structural features of the '<em>TModule</em>' class.
@@ -313,7 +322,7 @@ public interface TypesPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int TMODULE_FEATURE_COUNT = SYNTAX_RELATED_TELEMENT_FEATURE_COUNT + 15;
+	int TMODULE_FEATURE_COUNT = SYNTAX_RELATED_TELEMENT_FEATURE_COUNT + 16;
 
 	/**
 	 * The number of operations of the '<em>TModule</em>' class.
@@ -11691,6 +11700,17 @@ public interface TypesPackage extends EPackage {
 	EReference getTModule_ExposedInternalTypes();
 
 	/**
+	 * Returns the meta object for the attribute '{@link org.eclipse.n4js.ts.types.TModule#getAstMD5 <em>Ast MD5</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Ast MD5</em>'.
+	 * @see org.eclipse.n4js.ts.types.TModule#getAstMD5()
+	 * @see #getTModule()
+	 * @generated
+	 */
+	EAttribute getTModule_AstMD5();
+
+	/**
 	 * Returns the meta object for the attribute '{@link org.eclipse.n4js.ts.types.TModule#getModuleSpecifier <em>Module Specifier</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -14386,6 +14406,14 @@ public interface TypesPackage extends EPackage {
 		 * @generated
 		 */
 		EReference TMODULE__EXPOSED_INTERNAL_TYPES = eINSTANCE.getTModule_ExposedInternalTypes();
+
+		/**
+		 * The meta object literal for the '<em><b>Ast MD5</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute TMODULE__AST_MD5 = eINSTANCE.getTModule_AstMD5();
 
 		/**
 		 * The meta object literal for the '<em><b>Module Specifier</b></em>' attribute feature.

--- a/plugins/org.eclipse.n4js.ts.model/emf-gen/org/eclipse/n4js/ts/types/impl/TModuleImpl.java
+++ b/plugins/org.eclipse.n4js.ts.model/emf-gen/org/eclipse/n4js/ts/types/impl/TModuleImpl.java
@@ -54,6 +54,7 @@ import org.eclipse.n4js.ts.types.TypesPackage;
  *   <li>{@link org.eclipse.n4js.ts.types.impl.TModuleImpl#getVariables <em>Variables</em>}</li>
  *   <li>{@link org.eclipse.n4js.ts.types.impl.TModuleImpl#getInternalTypes <em>Internal Types</em>}</li>
  *   <li>{@link org.eclipse.n4js.ts.types.impl.TModuleImpl#getExposedInternalTypes <em>Exposed Internal Types</em>}</li>
+ *   <li>{@link org.eclipse.n4js.ts.types.impl.TModuleImpl#getAstMD5 <em>Ast MD5</em>}</li>
  *   <li>{@link org.eclipse.n4js.ts.types.impl.TModuleImpl#getModuleSpecifier <em>Module Specifier</em>}</li>
  * </ul>
  *
@@ -289,6 +290,26 @@ public class TModuleImpl extends SyntaxRelatedTElementImpl implements TModule {
 	 * @ordered
 	 */
 	protected EList<Type> exposedInternalTypes;
+
+	/**
+	 * The default value of the '{@link #getAstMD5() <em>Ast MD5</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getAstMD5()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final String AST_MD5_EDEFAULT = null;
+
+	/**
+	 * The cached value of the '{@link #getAstMD5() <em>Ast MD5</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getAstMD5()
+	 * @generated
+	 * @ordered
+	 */
+	protected String astMD5 = AST_MD5_EDEFAULT;
 
 	/**
 	 * The default value of the '{@link #getModuleSpecifier() <em>Module Specifier</em>}' attribute.
@@ -573,6 +594,27 @@ public class TModuleImpl extends SyntaxRelatedTElementImpl implements TModule {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public String getAstMD5() {
+		return astMD5;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setAstMD5(String newAstMD5) {
+		String oldAstMD5 = astMD5;
+		astMD5 = newAstMD5;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, TypesPackage.TMODULE__AST_MD5, oldAstMD5, astMD5));
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public String getModuleSpecifier() {
 		return this.getQualifiedName();
 	}
@@ -635,6 +677,8 @@ public class TModuleImpl extends SyntaxRelatedTElementImpl implements TModule {
 				return getInternalTypes();
 			case TypesPackage.TMODULE__EXPOSED_INTERNAL_TYPES:
 				return getExposedInternalTypes();
+			case TypesPackage.TMODULE__AST_MD5:
+				return getAstMD5();
 			case TypesPackage.TMODULE__MODULE_SPECIFIER:
 				return getModuleSpecifier();
 		}
@@ -697,6 +741,9 @@ public class TModuleImpl extends SyntaxRelatedTElementImpl implements TModule {
 				getExposedInternalTypes().clear();
 				getExposedInternalTypes().addAll((Collection<? extends Type>)newValue);
 				return;
+			case TypesPackage.TMODULE__AST_MD5:
+				setAstMD5((String)newValue);
+				return;
 		}
 		super.eSet(featureID, newValue);
 	}
@@ -751,6 +798,9 @@ public class TModuleImpl extends SyntaxRelatedTElementImpl implements TModule {
 			case TypesPackage.TMODULE__EXPOSED_INTERNAL_TYPES:
 				getExposedInternalTypes().clear();
 				return;
+			case TypesPackage.TMODULE__AST_MD5:
+				setAstMD5(AST_MD5_EDEFAULT);
+				return;
 		}
 		super.eUnset(featureID);
 	}
@@ -791,6 +841,8 @@ public class TModuleImpl extends SyntaxRelatedTElementImpl implements TModule {
 				return internalTypes != null && !internalTypes.isEmpty();
 			case TypesPackage.TMODULE__EXPOSED_INTERNAL_TYPES:
 				return exposedInternalTypes != null && !exposedInternalTypes.isEmpty();
+			case TypesPackage.TMODULE__AST_MD5:
+				return AST_MD5_EDEFAULT == null ? astMD5 != null : !AST_MD5_EDEFAULT.equals(astMD5);
 			case TypesPackage.TMODULE__MODULE_SPECIFIER:
 				return MODULE_SPECIFIER_EDEFAULT == null ? getModuleSpecifier() != null : !MODULE_SPECIFIER_EDEFAULT.equals(getModuleSpecifier());
 		}
@@ -857,6 +909,8 @@ public class TModuleImpl extends SyntaxRelatedTElementImpl implements TModule {
 		result.append(mainModule);
 		result.append(", preLinkingPhase: ");
 		result.append(preLinkingPhase);
+		result.append(", astMD5: ");
+		result.append(astMD5);
 		result.append(')');
 		return result.toString();
 	}

--- a/plugins/org.eclipse.n4js.ts.model/emf-gen/org/eclipse/n4js/ts/types/impl/TypesPackageImpl.java
+++ b/plugins/org.eclipse.n4js.ts.model/emf-gen/org/eclipse/n4js/ts/types/impl/TypesPackageImpl.java
@@ -742,8 +742,17 @@ public class TypesPackageImpl extends EPackageImpl implements TypesPackage {
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getTModule_ModuleSpecifier() {
+	public EAttribute getTModule_AstMD5() {
 		return (EAttribute)tModuleEClass.getEStructuralFeatures().get(13);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public EAttribute getTModule_ModuleSpecifier() {
+		return (EAttribute)tModuleEClass.getEStructuralFeatures().get(14);
 	}
 
 	/**
@@ -2996,6 +3005,7 @@ public class TypesPackageImpl extends EPackageImpl implements TypesPackage {
 		createEReference(tModuleEClass, TMODULE__VARIABLES);
 		createEReference(tModuleEClass, TMODULE__INTERNAL_TYPES);
 		createEReference(tModuleEClass, TMODULE__EXPOSED_INTERNAL_TYPES);
+		createEAttribute(tModuleEClass, TMODULE__AST_MD5);
 		createEAttribute(tModuleEClass, TMODULE__MODULE_SPECIFIER);
 
 		typableElementEClass = createEClass(TYPABLE_ELEMENT);
@@ -3445,6 +3455,7 @@ public class TypesPackageImpl extends EPackageImpl implements TypesPackage {
 		initEReference(getTModule_Variables(), this.getTVariable(), null, "variables", null, 0, -1, TModule.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getTModule_InternalTypes(), this.getType(), null, "internalTypes", null, 0, -1, TModule.class, IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getTModule_ExposedInternalTypes(), this.getType(), null, "exposedInternalTypes", null, 0, -1, TModule.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
+		initEAttribute(getTModule_AstMD5(), theEcorePackage.getEString(), "astMD5", null, 0, 1, TModule.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getTModule_ModuleSpecifier(), theEcorePackage.getEString(), "moduleSpecifier", null, 0, 1, TModule.class, IS_TRANSIENT, IS_VOLATILE, !IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, IS_DERIVED, IS_ORDERED);
 
 		initEClass(typableElementEClass, TypableElement.class, "TypableElement", IS_ABSTRACT, IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);

--- a/plugins/org.eclipse.n4js.ts.model/model/Types.xcore
+++ b/plugins/org.eclipse.n4js.ts.model/model/Types.xcore
@@ -90,7 +90,7 @@ class TModule extends SyntaxRelatedTElement, TAnnotableElement {
 	 * Used in scoping to adjust shadowing rules for the project imports (see org.eclipse.n4js.scoping.utils.ProjectImportEnablingScope).
 	 */
 	boolean mainModule
-
+	
 	/**
 	 * True iff this TModule was created during pre-linking phase.
 	 */
@@ -137,6 +137,21 @@ class TModule extends SyntaxRelatedTElement, TAnnotableElement {
 	 * imports 'A'. To access those, the referring {@link #variables variable} has to be used.
 	 */
 	contains Type[] exposedInternalTypes
+	
+	/**
+	 * MD5 hash (hex) of the AST from which this type model was created. This can be used to quickly
+	 * compare two type models created from -- maybe -- different versions of the same AST.
+	 * <p>
+	 * The MD5 is used since this is the fastest and easiest solution to compare the AST. More elegant
+	 * methods may would use the AST (in order to ignore comments and whitespaces), however this
+	 * is rather complicated to implement: No proxies must be resolved and the hash must be stable between
+	 * different runs (and between different machines to enable stable tests). This is rather hard to
+	 * achieve with traversing the AST.
+	 * 
+	 * @see org.eclipse.n4js.typesbuilder.N4JSTypesBuilder.md5Hex(String)
+	 */
+	String astMD5
+	
 	/**
 	 * Returns the qualified module name as a file path, using '/' as a segment delimiter. No file extension is added,
 	 * though.

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/typesbuilder/N4JSTypesBuilder.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/typesbuilder/N4JSTypesBuilder.xtend
@@ -11,6 +11,8 @@
 package org.eclipse.n4js.typesbuilder
 
 import com.google.inject.Inject
+import java.math.BigInteger
+import java.security.MessageDigest
 import org.eclipse.n4js.n4JS.ExportableElement
 import org.eclipse.n4js.n4JS.ExportedVariableStatement
 import org.eclipse.n4js.n4JS.FunctionDeclaration
@@ -62,6 +64,14 @@ import static extension org.eclipse.n4js.utils.N4JSLanguageUtils.*
  * will later be resolved either on demand or by calling {@link N4JSResource#flattenModule()}.
  */
 public class N4JSTypesBuilder {
+	
+	public static def md5Hex(String s) {
+		try {
+			return new BigInteger(1, MessageDigest.getInstance("MD5").digest(s.getBytes("UTF-8"))).toString(16);
+		} catch (Exception exc) {
+			throw new RuntimeException("Error creating MD5 for content: " + exc.message, exc);
+		};
+	}
 
 	@Inject(optional=true) TypesFactory typesFactory = TypesFactory.eINSTANCE
 	@Inject extension N4JSTypesBuilderHelper
@@ -101,6 +111,7 @@ public class N4JSTypesBuilder {
 			val script = parseResult.rootASTElement as Script;
 
 			val TModule result = typesFactory.createTModule;
+			result.astMD5 = md5Hex(parseResult.rootNode.text);
 			var qualifiedModuleName = resource.qualifiedModuleName;
 			result.qualifiedName = qualifiedNameConverter.toString(qualifiedModuleName);
 			result.preLinkingPhase = preLinkingPhase;

--- a/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/scoping/N4JSScopingTest.xtend
+++ b/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/scoping/N4JSScopingTest.xtend
@@ -387,7 +387,7 @@ class N4JSScopingTest {
 		assertEquals("Stored user data",
 			'''
 				<?xml version="1.0" encoding="ASCII"?>
-				<types:TModule xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:typeRefs="http://www.eclipse.org/n4js/ts/TypeRefs" xmlns:types="http://www.eclipse.org/n4js/ts/Types" qualifiedName="org/eclipse/n4js/tests/scoping/Supplier">
+				<types:TModule xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:typeRefs="http://www.eclipse.org/n4js/ts/TypeRefs" xmlns:types="http://www.eclipse.org/n4js/ts/Types" qualifiedName="org/eclipse/n4js/tests/scoping/Supplier" astMD5="7db65ac965ae43f2b3673735d7296d9b">
 				  <astElement href="#/0"/>
 				  <topLevelTypes xsi:type="types:TClass" name="Supplier" exportedName="Supplier">
 				    <ownedMembers xsi:type="types:TMethod" name="foo" hasNoBody="true" declaredMemberAccessModifier="public">

--- a/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/scoping/N4JSScopingTestWithIndexTest.xtend
+++ b/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/scoping/N4JSScopingTestWithIndexTest.xtend
@@ -62,7 +62,7 @@ class N4JSScopingTestWithIndexTest {
 			"src/org/eclipse/n4js/tests/scoping/Client.n4js",
 			'''
 				<?xml version="1.0" encoding="ASCII"?>
-				<types:TModule xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:typeRefs="http://www.eclipse.org/n4js/ts/TypeRefs" xmlns:types="http://www.eclipse.org/n4js/ts/Types" qualifiedName="org/eclipse/n4js/tests/scoping/Supplier" projectId="org.eclipse.n4js.lang.tests" vendorID="org.eclipse.n4js" moduleLoader="N4JS">
+				<types:TModule xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:typeRefs="http://www.eclipse.org/n4js/ts/TypeRefs" xmlns:types="http://www.eclipse.org/n4js/ts/Types" qualifiedName="org/eclipse/n4js/tests/scoping/Supplier" projectId="org.eclipse.n4js.lang.tests" vendorID="org.eclipse.n4js" moduleLoader="N4JS" astMD5="7db65ac965ae43f2b3673735d7296d9b">
 				  <astElement href="#/0"/>
 				  <topLevelTypes xsi:type="types:TClass" name="Supplier" exportedName="Supplier">
 				    <ownedMembers xsi:type="types:TMethod" name="foo" hasNoBody="true" declaredMemberAccessModifier="public">
@@ -85,7 +85,7 @@ class N4JSScopingTestWithIndexTest {
 			"SupplierWithBuiltIn", "src/org/eclipse/n4js/tests/scoping/ClientWithBuiltIn.n4js",
 			'''
 				<?xml version="1.0" encoding="ASCII"?>
-				<types:TModule xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:typeRefs="http://www.eclipse.org/n4js/ts/TypeRefs" xmlns:types="http://www.eclipse.org/n4js/ts/Types" qualifiedName="org/eclipse/n4js/tests/scoping/SupplierWithBuiltIn" projectId="org.eclipse.n4js.lang.tests" vendorID="org.eclipse.n4js" moduleLoader="N4JS">
+				<types:TModule xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:typeRefs="http://www.eclipse.org/n4js/ts/TypeRefs" xmlns:types="http://www.eclipse.org/n4js/ts/Types" qualifiedName="org/eclipse/n4js/tests/scoping/SupplierWithBuiltIn" projectId="org.eclipse.n4js.lang.tests" vendorID="org.eclipse.n4js" moduleLoader="N4JS" astMD5="7a7bda036db41c8e954e99535f496cff">
 				  <astElement href="#/0"/>
 				  <topLevelTypes xsi:type="types:TClass" name="SupplierWithBuiltIn" exportedName="SupplierWithBuiltIn">
 				    <ownedMembers xsi:type="types:TField" name="s" declaredMemberAccessModifier="public">

--- a/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/typesbuilder/ClassWithSuperClassAndRolesTypesBuilderTest.xtend
+++ b/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/typesbuilder/ClassWithSuperClassAndRolesTypesBuilderTest.xtend
@@ -40,10 +40,10 @@ class ClassWithSuperClassAndRolesTypesBuilderTest extends AbstractTypesBuilderTe
 
 	override protected enableUserDataCompare() {
 		// to check the complete AST just change false to true
-		false
-		//true
+//		false
+		true
 	}
-
+	
 	@Test
 	def test() {
 		val textFileName = "ClassWithSuperClassAndRoles.n4js"
@@ -69,7 +69,41 @@ class ClassWithSuperClassAndRolesTypesBuilderTest extends AbstractTypesBuilderTe
 
 	override getExpectedTypesSerialization() '''
 		TModule {
-
+		    ref EObject astElement ref: Script@(unresolved proxy src/org/eclipse/n4js/tests/typesbuilder/ClassWithSuperClassAndRoles.n4js#/0)
+		    attr EString astMD5 '752c8770faa7f94d96cd74123d08cb8b'
+		    attr EString moduleSpecifier 'org/eclipse/n4js/tests/typesbuilder/ClassWithSuperClassAndRoles'
+		    attr EString qualifiedName 'org/eclipse/n4js/tests/typesbuilder/ClassWithSuperClassAndRoles'
+		    cref Type topLevelTypes [
+		        0: TClass {
+		            ref EObject astElement ref: N4ClassDeclaration@(unresolved proxy src/org/eclipse/n4js/tests/typesbuilder/ClassWithSuperClassAndRoles.n4js#/0/@scriptElements.0)
+		            attr EString name 'MyClass'
+		        }
+		        1: TInterface {
+		            ref EObject astElement ref: N4InterfaceDeclaration@(unresolved proxy src/org/eclipse/n4js/tests/typesbuilder/ClassWithSuperClassAndRoles.n4js#/0/@scriptElements.1)
+		            attr EString name 'Persistable'
+		        }
+		        2: TInterface {
+		            ref EObject astElement ref: N4InterfaceDeclaration@(unresolved proxy src/org/eclipse/n4js/tests/typesbuilder/ClassWithSuperClassAndRoles.n4js#/0/@scriptElements.2)
+		            attr EString name 'Comparable'
+		        }
+		        3: TClass {
+		            ref EObject astElement ref: N4ClassDeclaration@(unresolved proxy src/org/eclipse/n4js/tests/typesbuilder/ClassWithSuperClassAndRoles.n4js#/0/@scriptElements.3/@exportedElement)
+		            attr TypeAccessModifier declaredTypeAccessModifier 'publicInternal'
+		            attr EString exportedName 'MySubClass'
+		            cref ParameterizedTypeRef implementedInterfaceRefs [
+		                0: ParameterizedTypeRef {
+		                    ref Type declaredType ref: TInterface@(resource null)
+		                }
+		                1: ParameterizedTypeRef {
+		                    ref Type declaredType ref: TInterface@(resource null)
+		                }
+		            ]
+		            attr EString name 'MySubClass'
+		            cref ParameterizedTypeRef superClassRef ParameterizedTypeRef {
+		                ref Type declaredType ref: TClass@(resource null)
+		            }
+		        }
+		    ]
 		}'''
 
 	override assertExampleTypeStructure(String phase, Resource newN4jsResource) {

--- a/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/typesbuilder/TypesBuilderMD5HexTest.java
+++ b/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/typesbuilder/TypesBuilderMD5HexTest.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2017 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+package org.eclipse.n4js.tests.typesbuilder;
+
+import static org.junit.Assert.assertEquals;
+
+import org.eclipse.n4js.typesbuilder.N4JSTypesBuilder;
+import org.junit.Test;
+
+/**
+ * Test for static function
+ */
+public class TypesBuilderMD5HexTest {
+
+	@SuppressWarnings("javadoc")
+	@Test
+	public void testMD5Hex() {
+		assertEquals("b10a8db164e0754105b7a99be72e3fe5", N4JSTypesBuilder.md5Hex("Hello World"));
+	}
+}

--- a/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/typesbuilder/extensions/N4JSResourceExtensions.xtend
+++ b/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/typesbuilder/extensions/N4JSResourceExtensions.xtend
@@ -29,29 +29,29 @@ class N4JSResourceExtensions {
 
 	@Inject Provider<XtextResourceSet> resourceSetProvider
 
-	def reloadResourceFromDescription(Resource testResource, IResourceDescription updatedResourceDescription) {
+	def N4JSResource reloadResourceFromDescription(Resource testResource, IResourceDescription updatedResourceDescription) {
 		var rs2 = resourceSetProvider.get()
 		val newN4jsResource = rs2.createResource(testResource.URI) as N4JSResource
 		newN4jsResource.loadFromDescription(updatedResourceDescription);
-		newN4jsResource
+		return newN4jsResource
 	}
 
-	def getResourceDescription(Resource testResource) {
+	def IResourceDescription getResourceDescription(Resource testResource) {
 		val uri = testResource.URI
 		val resourceSet = testResource.resourceSet
 		val updatedResourceDescriptions = resourceDescriptionsProvider.getResourceDescriptions(resourceSet);
 		val updatedResourceDescription = updatedResourceDescriptions.getResourceDescription(uri)
 		updatedResourceDescription.getExportedObjectsByType(TypesPackage.eINSTANCE.TModule).forEach[EObjectURI]  // trigger user data computation (see N4JSResourceDescriptionStrategy#internalCreateEObjectDescriptionForRoot(TModule, IAcceptor<IEObjectDescription>))
-		updatedResourceDescription
+		return updatedResourceDescription
 	}
 
-	def unloadResource(Resource testResource) {
+	def boolean unloadResource(Resource testResource) {
 		val resourceSet = testResource.resourceSet
 		testResource.unload
-		resourceSet.resources.remove(testResource)
+		return resourceSet.resources.remove(testResource)
 	}
 
-	def resolve(Resource testResource) {
+	def void resolve(Resource testResource) {
 		if(testResource instanceof N4JSResource)
 			testResource.resolveLazyCrossReferences(CancelIndicator.NullImpl)
 		else

--- a/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/typesbuilder/extensions/ResourceAssertionsExtensions.xtend
+++ b/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/typesbuilder/extensions/ResourceAssertionsExtensions.xtend
@@ -22,20 +22,21 @@ import static org.junit.Assert.*
  */
 class ResourceAssertionsExtensions {
 
-	def assertASTResolved(String phase, N4JSResource newN4jsResource) {
+	def void assertASTResolved(String phase, N4JSResource newN4jsResource) {
 		val astElement = (newN4jsResource.contents.get(1) as SyntaxRelatedTElement).astElement
 		assertFalse(phase + ": AST element no proxy when fetched from type", astElement.eIsProxy)
 	}
 
-	def resolveAST(String phase, N4JSResource newN4jsResource) {
-		assertFalse(phase + ": AST no proxy after first access", newN4jsResource.contents.get(0).eIsProxy)
+	def void resolveAST(String phase, N4JSResource newN4jsResource) {
+		val ast = newN4jsResource.contents.get(0); // this resolves the AST if is was not resolved before
+		assertFalse(phase + ": AST no proxy after first access", ast.eIsProxy)
 	}
 
-	def assertASTIsProxifed(String phase, N4JSResource newN4jsResource) {
+	def void assertASTIsProxifed(String phase, N4JSResource newN4jsResource) {
 		assertTrue(phase + ": AST is proxy", (newN4jsResource.contents as BasicEList<? extends EObject>).basicGet(0).eIsProxy)
 	}
 
-	def assertResourceHasNoErrors(String phase, Resource testResource) {
+	def void assertResourceHasNoErrors(String phase, Resource testResource) {
 		assertTrue(phase + ": " + testResource.URI.trimFileExtension.lastSegment + " should have no errors but: " + testResource.errors.toString, testResource.errors.empty)
 	}
 }

--- a/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/typesbuilder/extensions/UserdataAssertionsExtension.xtend
+++ b/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/typesbuilder/extensions/UserdataAssertionsExtension.xtend
@@ -21,7 +21,7 @@ import static org.junit.Assert.*
 /**
  */
 class UserdataAssertionsExtension {
-
+	
 	def assertSerializedUserdata(Iterable<IEObjectDescription> eoDescs, CharSequence expectedTypesSerialization, boolean enableUserDataCompare, N4JSResource resource) {
 		val syntaxEoDesc = eoDescs.head;
 

--- a/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/typesbuilder/utils/AbstractTypesBuilderTest.xtend
+++ b/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/typesbuilder/utils/AbstractTypesBuilderTest.xtend
@@ -76,11 +76,11 @@ abstract class AbstractTypesBuilderTest {
 			int expectedTypesCount, int expectedTypesOnIndexCount) {
 
 		val updatedResourceDescription = assertFullyLoadedResource(index, testResource, expectedTypesCount, expectedExportedTypeToNamePairs)
-
-		val newN4jsResource = assertUnloadedResource(index, testResource, updatedResourceDescription)
-
-		assertASTResolved(index, newN4jsResource)
-
+		
+		val newN4jsResource = unloadResourceAndReloadFromDescription(index, testResource, updatedResourceDescription)
+		
+		resolveASTandAssert(index, newN4jsResource)
+		
 		rerunUnloadLoadProcess(index, max, newN4jsResource, expectedExportedTypeToNamePairs, expectedTypesCount, expectedTypesOnIndexCount)
 	}
 
@@ -96,9 +96,10 @@ abstract class AbstractTypesBuilderTest {
 		resolve(testResource)
 
 		val resourceDescriptions = assertIndexHasBeenFilled(phase, testResource);
+		
 
 		val eoDescs = assertAllExportedElementAreOnIndex(phase, resourceDescriptions, expectedExportedTypeToNamePairs)
-
+		
 		assertExampleJSStructure(phase, testResource)
 
 		assertExampleTypeStructure(phase, testResource)
@@ -108,27 +109,28 @@ abstract class AbstractTypesBuilderTest {
 		return getResourceDescription(testResource)
 	}
 
-	def private assertUnloadedResource(int index, Resource testResource, IResourceDescription updatedResourceDescription) {
-
-		unloadResource(testResource)
-
-		val newN4jsResource = reloadResourceFromDescription(testResource, updatedResourceDescription)
-
+	/**
+	 * Unloads given resource and returns newly from description loaded resource.
+	 */
+	def private N4JSResource unloadResourceAndReloadFromDescription(int index, Resource testResource, IResourceDescription updatedResourceDescription) {
 		val phase = 2 + (3 * index) + ". step: load from resource description"
-
+		assertUserDataCreated(phase + ", before unload, by resource", testResource)
+		unloadResource(testResource)
+		assertUserDataCreated(phase + ", after unload, by descriptions", updatedResourceDescription)
+		val newN4jsResource = reloadResourceFromDescription(testResource, updatedResourceDescription)
+		
 		assertExampleTypeStructure(phase, newN4jsResource)
-
 		assertASTIsProxifed(phase, newN4jsResource)
-
 		return newN4jsResource;
 	}
 
-	def private assertASTResolved(int index, N4JSResource newN4jsResource) {
+	def private resolveASTandAssert(int index, N4JSResource newN4jsResource) {
 
 		val phase = 3 + (3 * index) + ". step: resolve AST of proxified resource"
 
 		resolveAST(phase, newN4jsResource)
-
+		assertUserDataCreated(phase + ", after resolving AST", newN4jsResource)
+		
 		assertASTResolved(phase, newN4jsResource)
 	}
 


### PR DESCRIPTION
Issue #126

When loading an AST from a TModule (usually retreived from the index) by calling SyntaxRelatedTElement.astElement,  this caused a new TModule to be created again from the AST. That lead to an inconsistent state: Two different TModules which both link to the same AST, and the original TModule not contained in any resource anymore (because it was removed from the resource and replaced with the newly loaded one). Since the original one is detached from a resource, it cannot resolve proxies anymore. This lead to a lot of weird scenarios which are extremely hard to debug because the both TModule instances look similar.

This bugfix adds a new rewire step after the AST has been loaded and a new TModule has been created. It first compares the original TModule with the new one. If both are similar (except for references or derived/transient data), all links from the AST pointing to the new TModule are rewired to point to the old TModule (and also all astElements are set to the new AST).

- [ ] build