### PR TITLE
#146 fix resolving references to the structural types

### DIFF
--- a/plugins/org.eclipse.n4js.smith.graph/src/org/eclipse/n4js/smith/graph/EMFGraphProvider.java
+++ b/plugins/org.eclipse.n4js.smith.graph/src/org/eclipse/n4js/smith/graph/EMFGraphProvider.java
@@ -166,8 +166,7 @@ public class EMFGraphProvider implements GraphProvider {
 									targetNodesExternal.add(EcoreUtil.getURI((EObject) currTarget).toString());
 							}
 							if (!targetNodes.isEmpty() || !targetNodesExternal.isEmpty())
-								result.add(new Edge(currRef.getName(),
-										(!currRef.isContainment() && !currRef.isContainer()), node, targetNodes,
+								result.add(new Edge(currRef.getName(), !currRef.isContainment(), node, targetNodes,
 										targetNodesExternal));
 						}
 					} else {
@@ -182,7 +181,7 @@ public class EMFGraphProvider implements GraphProvider {
 							if (targetNode != null || targetNodeExternal != null) {
 								result.add(new Edge(
 										currRef.getName(),
-										(!currRef.isContainment() && !currRef.isContainer()),
+										!currRef.isContainment(),
 										node,
 										asCollection(targetNode),
 										asCollection(targetNodeExternal)));

--- a/plugins/org.eclipse.n4js.smith.graph/src/org/eclipse/n4js/smith/graph/EMFGraphProvider.java
+++ b/plugins/org.eclipse.n4js.smith.graph/src/org/eclipse/n4js/smith/graph/EMFGraphProvider.java
@@ -27,6 +27,10 @@ import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.emf.ecore.util.InternalEList;
+import org.eclipse.n4js.smith.graph.graph.Edge;
+import org.eclipse.n4js.smith.graph.graph.Graph.GraphProvider;
+import org.eclipse.n4js.smith.graph.graph.GraphUtils;
+import org.eclipse.n4js.smith.graph.graph.Node;
 import org.eclipse.xtext.TerminalRule;
 import org.eclipse.xtext.nodemodel.ICompositeNode;
 import org.eclipse.xtext.nodemodel.ILeafNode;
@@ -34,11 +38,6 @@ import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Iterators;
-
-import org.eclipse.n4js.smith.graph.graph.Edge;
-import org.eclipse.n4js.smith.graph.graph.Graph.GraphProvider;
-import org.eclipse.n4js.smith.graph.graph.GraphUtils;
-import org.eclipse.n4js.smith.graph.graph.Node;
 
 /**
  * Creates nodes and edges from an EMF {@link ResourceSet} as input.
@@ -167,7 +166,8 @@ public class EMFGraphProvider implements GraphProvider {
 									targetNodesExternal.add(EcoreUtil.getURI((EObject) currTarget).toString());
 							}
 							if (!targetNodes.isEmpty() || !targetNodesExternal.isEmpty())
-								result.add(new Edge(currRef.getName(), !currRef.isContainment(), node, targetNodes,
+								result.add(new Edge(currRef.getName(),
+										(!currRef.isContainment() && !currRef.isContainer()), node, targetNodes,
 										targetNodesExternal));
 						}
 					} else {
@@ -182,7 +182,7 @@ public class EMFGraphProvider implements GraphProvider {
 							if (targetNode != null || targetNodeExternal != null) {
 								result.add(new Edge(
 										currRef.getName(),
-										!currRef.isContainment(),
+										(!currRef.isContainment() && !currRef.isContainer()),
 										node,
 										asCollection(targetNode),
 										asCollection(targetNodeExternal)));

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/organize/imports/DocumentImportsOrganizer.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/organize/imports/DocumentImportsOrganizer.java
@@ -24,17 +24,6 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.util.EcoreUtil;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IRegion;
-import org.eclipse.ui.part.FileEditorInput;
-import org.eclipse.xtext.nodemodel.ILeafNode;
-import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
-import org.eclipse.xtext.resource.XtextResource;
-import org.eclipse.xtext.ui.editor.model.IXtextDocument;
-import org.eclipse.xtext.ui.editor.model.XtextDocumentProvider;
-import org.eclipse.xtext.util.concurrent.IUnitOfWork;
-
-import com.google.common.collect.Lists;
-import com.google.inject.Inject;
-
 import org.eclipse.n4js.documentation.N4JSDocumentationProvider;
 import org.eclipse.n4js.parser.InternalSemicolonInjectingParser;
 import org.eclipse.n4js.resource.N4JSResource;
@@ -46,6 +35,16 @@ import org.eclipse.n4js.ui.changes.IChange;
 import org.eclipse.n4js.ui.changes.Replacement;
 import org.eclipse.n4js.ui.organize.imports.BreakException.UserCanceledBreakException;
 import org.eclipse.n4js.utils.UtilN4;
+import org.eclipse.ui.part.FileEditorInput;
+import org.eclipse.xtext.nodemodel.ILeafNode;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.resource.XtextResource;
+import org.eclipse.xtext.ui.editor.model.IXtextDocument;
+import org.eclipse.xtext.ui.editor.model.XtextDocumentProvider;
+import org.eclipse.xtext.util.concurrent.IUnitOfWork;
+
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
 
 /**
  * This helper will analyze imports section of the provided document, and rewrite it with new computed state.

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/ASTProcessor.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/ASTProcessor.xtend
@@ -503,8 +503,8 @@ public class ASTProcessor extends AbstractProcessor {
 	}
 
 	def private void resolveAndProcessReferencesInNode(EObject astNode, ASTMetaInfoCache cache) {
-		for(eRef : astNode.eClass.EReferences) {
-			if(!eRef.isContainment) { // only cross-references have proxies (in our case)
+		for(eRef : astNode.eClass.EAllReferences) {
+			if(!eRef.isContainment && !eRef.isContainer) { // only cross-references have proxies (in our case)
 				val node = astNode.eGet(eRef, true);
 
 				if (node instanceof EObject) {

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSPostProcessor.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSPostProcessor.java
@@ -18,10 +18,6 @@ import org.eclipse.emf.common.util.TreeIterator;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emf.ecore.EReference;
 import org.eclipse.emf.ecore.util.EcoreUtil;
-import org.eclipse.xtext.util.CancelIndicator;
-
-import com.google.inject.Inject;
-
 import org.eclipse.n4js.postprocessing.ASTProcessor;
 import org.eclipse.n4js.resource.PostProcessingAwareResource.PostProcessor;
 import org.eclipse.n4js.ts.types.TModule;
@@ -30,6 +26,9 @@ import org.eclipse.n4js.ts.types.TypesPackage;
 import org.eclipse.n4js.typesbuilder.N4JSTypesBuilder;
 import org.eclipse.n4js.utils.EcoreUtilN4;
 import org.eclipse.n4js.utils.UtilN4;
+import org.eclipse.xtext.util.CancelIndicator;
+
+import com.google.inject.Inject;
 
 /**
  * Performs post-processing of N4JS resources. Main responsibilities are proxy resolution, types model creation, and
@@ -113,7 +112,7 @@ public class N4JSPostProcessor implements PostProcessor {
 		while (i.hasNext()) {
 			final EObject object = i.next();
 			for (EReference currRef : object.eClass().getEAllReferences()) {
-				if (!currRef.isContainment()) {
+				if (!currRef.isContainment() && !currRef.isContainer()) {
 					final Object currTarget = object.eGet(currRef);
 					if (currTarget instanceof Collection<?>) {
 						for (Object currObj : (Collection<?>) currTarget) {

--- a/testhelpers/org.eclipse.n4js.tests.helper/src/org/eclipse/n4js/N4JSValidationTestHelper.java
+++ b/testhelpers/org.eclipse.n4js.tests.helper/src/org/eclipse/n4js/N4JSValidationTestHelper.java
@@ -66,7 +66,7 @@ public class N4JSValidationTestHelper extends ValidationTestHelper {
 			final EObject currObj = iter.next();
 			if (currObj != null && !currObj.eIsProxy()) {
 				for (EReference currRef : currObj.eClass().getEAllReferences()) {
-					if (!currRef.isContainment() && currRef.getEOpposite() == null) {
+					if (!currRef.isContainment() && !currRef.isContainer() && currRef.getEOpposite() == null) {
 						if (currRef.isMany()) {
 							@SuppressWarnings("unchecked")
 							final EList<? extends EObject> targets = (EList<? extends EObject>) currObj.eGet(currRef,

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_01.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_01.n4js.xt
@@ -17,6 +17,7 @@
 END_SETUP
  */
 
+// XPECT nowarnings --> "The import of A is unused."
 import {A} from "postProcessing/references/ReferencedClassA"
 
 let x;

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_01.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_01.n4js.xt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.xpect.tests.N4JSXpectTest
+   ResourceSet {
+   	ThisFile {}
+   	Resource "ReferencedClassA.n4js" {}
+   }
+END_SETUP
+ */
+
+import {A} from "postProcessing/references/ReferencedClassA"
+
+let x;
+
+//XPECT noerrors --> "reference to A is resolved"
+x as {function(~A):any}

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_02.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_02.n4js.xt
@@ -17,6 +17,7 @@
 END_SETUP
  */
 
+// XPECT nowarnings --> "The import of A is unused."
 import {A} from "postProcessing/references/ReferencedClassA"
 
 let x;

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_02.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_02.n4js.xt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.xpect.tests.N4JSXpectTest
+   ResourceSet {
+   	ThisFile {}
+   	Resource "ReferencedClassA.n4js" {}
+   }
+END_SETUP
+ */
+
+import {A} from "postProcessing/references/ReferencedClassA"
+
+let x;
+
+//XPECT noerrors --> "reference to A is resolved"
+x as {function(~~A):any}

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_03.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_03.n4js.xt
@@ -17,6 +17,7 @@
 END_SETUP
  */
 
+// XPECT nowarnings --> "The import of A is unused."
 import {A} from "postProcessing/references/ReferencedClassA"
 
 let x;

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_03.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_03.n4js.xt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.xpect.tests.N4JSXpectTest
+   ResourceSet {
+   	ThisFile {}
+   	Resource "ReferencedClassA.n4js" {}
+   }
+END_SETUP
+ */
+
+import {A} from "postProcessing/references/ReferencedClassA"
+
+let x;
+
+//XPECT noerrors --> "reference to A is resolved"
+x as {function(~r~A):any}

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_04.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_04.n4js.xt
@@ -17,6 +17,7 @@
 END_SETUP
  */
 
+// XPECT nowarnings --> "The import of A is unused."
 import {A} from "postProcessing/references/ReferencedClassA"
 
 let x;

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_04.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_04.n4js.xt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.xpect.tests.N4JSXpectTest
+   ResourceSet {
+   	ThisFile {}
+   	Resource "ReferencedClassA.n4js" {}
+   }
+END_SETUP
+ */
+
+import {A} from "postProcessing/references/ReferencedClassA"
+
+let x;
+
+//XPECT noerrors --> "reference to A is resolved"
+x as {function(~i~A):any}

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_05.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_05.n4js.xt
@@ -17,6 +17,7 @@
 END_SETUP
  */
 
+// XPECT nowarnings --> "The import of A is unused."
 import {A} from "postProcessing/references/ReferencedClassA"
 
 let x;

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_05.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralParam_05.n4js.xt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.xpect.tests.N4JSXpectTest
+   ResourceSet {
+   	ThisFile {}
+   	Resource "ReferencedClassA.n4js" {}
+   }
+END_SETUP
+ */
+
+import {A} from "postProcessing/references/ReferencedClassA"
+
+let x;
+
+//XPECT noerrors --> "reference to A is resolved"
+x as {function(~w~A):any}

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_01.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_01.n4js.xt
@@ -17,6 +17,7 @@
 END_SETUP
  */
 
+// XPECT nowarnings --> "The import of A is unused."
 import {A} from "postProcessing/references/ReferencedClassA"
 
 let x;

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_01.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_01.n4js.xt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.xpect.tests.N4JSXpectTest
+   ResourceSet {
+   	ThisFile {}
+   	Resource "ReferencedClassA.n4js" {}
+   }
+END_SETUP
+ */
+
+import {A} from "postProcessing/references/ReferencedClassA"
+
+let x;
+
+//XPECT noerrors --> "reference to A is resolved"
+x as {function():~A}

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_02.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_02.n4js.xt
@@ -17,6 +17,7 @@
 END_SETUP
  */
 
+// XPECT nowarnings --> "The import of A is unused."
 import {A} from "postProcessing/references/ReferencedClassA"
 
 let x;

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_02.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_02.n4js.xt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.xpect.tests.N4JSXpectTest
+   ResourceSet {
+   	ThisFile {}
+   	Resource "ReferencedClassA.n4js" {}
+   }
+END_SETUP
+ */
+
+import {A} from "postProcessing/references/ReferencedClassA"
+
+let x;
+
+//XPECT noerrors --> "reference to A is resolved"
+x as {function():~~A}

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_03.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_03.n4js.xt
@@ -17,6 +17,7 @@
 END_SETUP
  */
 
+// XPECT nowarnings --> "The import of A is unused."
 import {A} from "postProcessing/references/ReferencedClassA"
 
 let x;

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_03.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_03.n4js.xt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.xpect.tests.N4JSXpectTest
+   ResourceSet {
+   	ThisFile {}
+   	Resource "ReferencedClassA.n4js" {}
+   }
+END_SETUP
+ */
+
+import {A} from "postProcessing/references/ReferencedClassA"
+
+let x;
+
+//XPECT noerrors --> "reference to A is resolved"
+x as {function():~r~A}

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_04.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_04.n4js.xt
@@ -17,6 +17,7 @@
 END_SETUP
  */
 
+// XPECT nowarnings --> "The import of A is unused."
 import {A} from "postProcessing/references/ReferencedClassA"
 
 let x;

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_04.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_04.n4js.xt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.xpect.tests.N4JSXpectTest
+   ResourceSet {
+   	ThisFile {}
+   	Resource "ReferencedClassA.n4js" {}
+   }
+END_SETUP
+ */
+
+import {A} from "postProcessing/references/ReferencedClassA"
+
+let x;
+
+//XPECT noerrors --> "reference to A is resolved"
+x as {function():~i~A}

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_05.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_05.n4js.xt
@@ -17,6 +17,7 @@
 END_SETUP
  */
 
+// XPECT nowarnings --> "The import of A is unused."
 import {A} from "postProcessing/references/ReferencedClassA"
 
 let x;

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_05.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/CastToFunctionWithStructuralReturn_05.n4js.xt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.xpect.tests.N4JSXpectTest
+   ResourceSet {
+   	ThisFile {}
+   	Resource "ReferencedClassA.n4js" {}
+   }
+END_SETUP
+ */
+
+import {A} from "postProcessing/references/ReferencedClassA"
+
+let x;
+
+//XPECT noerrors --> "reference to A is resolved"
+x as {function():~w~A}

--- a/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/ReferencedClassA.n4js
+++ b/tests/org.eclipse.n4js.xpect.tests/model/postProcessing/references/ReferencedClassA.n4js
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+export public class A{
+	
+}


### PR DESCRIPTION
fix #146 
 * tests for the issue
 * make `ASTProcessor` traverse inherited references
 * in general small adjustment when traversing references to avoid going to the parent
 * some imports cleaned up
