### PR TITLE
GH-171:  Use URL-encoding for FQNs in mangelhaft IDE reporter URLs

### DIFF
--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft.reporter.ide/src/n4js/org/eclipse/n4js/mangelhaft/reporter/ide/IDEReporter.n4js
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft.reporter.ide/src/n4js/org/eclipse/n4js/mangelhaft/reporter/ide/IDEReporter.n4js
@@ -166,6 +166,6 @@ export public class IDEReporter implements ITestReporter {
      * by the IDE. 
      */
     private static escapeGroupName(groupName: string) : string {
-	    	return groupName.replace(/\//g, "$");
+	    	return groupName.replace(/\//g, "%2F");
     }
 }

--- a/plugins/org.eclipse.n4js.external.libraries/shipped-code/mangelhaft/org.eclipse.n4js.mangelhaft.reporter.ide/src-gen/es/org.eclipse.n4js.mangelhaft.reporter.ide/org/eclipse/n4js/mangelhaft/reporter/ide/IDEReporter.js
+++ b/plugins/org.eclipse.n4js.external.libraries/shipped-code/mangelhaft/org.eclipse.n4js.mangelhaft.reporter.ide/src-gen/es/org.eclipse.n4js.mangelhaft.reporter.ide/org/eclipse/n4js/mangelhaft/reporter/ide/IDEReporter.js
@@ -183,7 +183,7 @@
 				}, {
 					escapeGroupName: {
 						value: function escapeGroupName___n4(groupName) {
-							return groupName.replace(/\//g, "$");
+							return groupName.replace(/\//g, "%2F");
 						}
 					}
 				}, function(instanceProto, staticProto) {

--- a/plugins/org.eclipse.n4js.external.libraries/shipped-code/mangelhaft/org.eclipse.n4js.mangelhaft.reporter.ide/src/n4js/org/eclipse/n4js/mangelhaft/reporter/ide/IDEReporter.n4js
+++ b/plugins/org.eclipse.n4js.external.libraries/shipped-code/mangelhaft/org.eclipse.n4js.mangelhaft.reporter.ide/src/n4js/org/eclipse/n4js/mangelhaft/reporter/ide/IDEReporter.n4js
@@ -166,6 +166,6 @@ export public class IDEReporter implements ITestReporter {
      * by the IDE. 
      */
     private static escapeGroupName(groupName: string) : string {
-	    	return groupName.replace(/\//g, "$");
+	    	return groupName.replace(/\//g, "%2F");
     }
 }

--- a/plugins/org.eclipse.n4js.tester/src/org/eclipse/n4js/tester/server/resources/BaseResource.java
+++ b/plugins/org.eclipse.n4js.tester/src/org/eclipse/n4js/tester/server/resources/BaseResource.java
@@ -46,8 +46,8 @@ public abstract class BaseResource {
 	 *            the HTTP servlet request.
 	 * @param resp
 	 *            the HTTP servlet response.
-	 * @param pathInfo
-	 *            TODO
+	 * @param escapedPathInfo
+	 *            the escaped path info of the requested resource
 	 * @throws IOException
 	 *             if processing the HTTP request fails.
 	 * @throws ServletException

--- a/plugins/org.eclipse.n4js.tester/src/org/eclipse/n4js/tester/server/resources/BaseResource.java
+++ b/plugins/org.eclipse.n4js.tester/src/org/eclipse/n4js/tester/server/resources/BaseResource.java
@@ -23,7 +23,6 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.log4j.Logger;
-import org.eclipse.n4js.tester.UrlDecoderService;
 import org.eclipse.n4js.tester.fsm.TestFsmRegistry;
 
 import com.google.inject.Inject;
@@ -39,9 +38,6 @@ public abstract class BaseResource {
 	@Inject
 	private TestFsmRegistry fsmRegistry;
 
-	@Inject
-	private UrlDecoderService urlDecoder;
-
 	/**
 	 * Handles the HTTP method. In case of supported request media type it reads the request body and delegates to
 	 * {@link #doHandle(String, String)} method. sets the response status code and the response body.
@@ -50,16 +46,16 @@ public abstract class BaseResource {
 	 *            the HTTP servlet request.
 	 * @param resp
 	 *            the HTTP servlet response.
+	 * @param pathInfo
+	 *            TODO
 	 * @throws IOException
 	 *             if processing the HTTP request fails.
 	 * @throws ServletException
 	 *             if processing the HTTP request fails.
 	 */
-	public void doHandle(final HttpServletRequest req, final HttpServletResponse resp)
+	public void doHandle(final HttpServletRequest req, final HttpServletResponse resp, String pathInfo)
 			throws IOException, ServletException {
-
 		final String body = getRequestBody(req);
-		final String pathInfo = urlDecoder.decode(req.getPathInfo());
 		resp.setStatus(doHandle(body, pathInfo));
 	}
 
@@ -126,10 +122,12 @@ public abstract class BaseResource {
 	 *            the HTTP request.
 	 * @param resp
 	 *            the HTTP servlet.
+	 * @param escapedPathInfo
+	 *            the escaped path info of the requested resource
 	 * @throws ServletException
 	 *             if the request-response post processing fails.
 	 */
-	protected void handleStatusOk(final HttpServletRequest req, final HttpServletResponse resp)
+	protected void handleStatusOk(final HttpServletRequest req, final HttpServletResponse resp, String escapedPathInfo)
 			throws ServletException {
 		// Does nothing by default.
 	}

--- a/plugins/org.eclipse.n4js.tester/src/org/eclipse/n4js/tester/server/resources/ResourceRouterServlet.java
+++ b/plugins/org.eclipse.n4js.tester/src/org/eclipse/n4js/tester/server/resources/ResourceRouterServlet.java
@@ -129,7 +129,6 @@ public class ResourceRouterServlet extends HttpServlet {
 			if (SC_OK == resp.getStatus()) {
 				resource.handleStatusOk(req, resp, pathInfo);
 			}
-			System.out.println("Handled " + req.getRequestURL() + " without any disturbances.");
 		} catch (final ClientResourceException e) {
 			resp.reset();
 			resp.setStatus(e.getStatusCode());

--- a/plugins/org.eclipse.n4js.tester/src/org/eclipse/n4js/tester/server/resources/service/TestCatalogAssemblerResource.java
+++ b/plugins/org.eclipse.n4js.tester/src/org/eclipse/n4js/tester/server/resources/service/TestCatalogAssemblerResource.java
@@ -46,7 +46,7 @@ public class TestCatalogAssemblerResource extends BaseResource {
 	}
 
 	@Override
-	protected void handleStatusOk(final HttpServletRequest req, final HttpServletResponse resp)
+	protected void handleStatusOk(final HttpServletRequest req, final HttpServletResponse resp, String escapdPathInfo)
 			throws ServletException {
 
 		try {

--- a/plugins/org.eclipse.n4js.tester/src/org/eclipse/n4js/tester/server/resources/tests/TestResource.java
+++ b/plugins/org.eclipse.n4js.tester/src/org/eclipse/n4js/tester/server/resources/tests/TestResource.java
@@ -21,6 +21,7 @@ import javax.servlet.ServletException;
 
 import org.eclipse.n4js.naming.N4JSQualifiedNameConverter;
 import org.eclipse.n4js.tester.TesterEventBus;
+import org.eclipse.n4js.tester.UrlDecoderService;
 import org.eclipse.n4js.tester.events.TestEvent;
 import org.eclipse.n4js.tester.server.resources.BaseResource;
 import org.eclipse.n4js.tester.server.resources.ClientResourceException;
@@ -33,39 +34,32 @@ import com.google.inject.Inject;
  */
 /* default */abstract class TestResource extends BaseResource {
 
-	/** Reserved character to be used as delimiter for the test id */
-	private static final String TEST_ID_DELIMITER = "$";
-
 	@Inject
 	private TesterEventBus bus;
 
+	@Inject
+	private UrlDecoderService urlDecoder;
+
 	@Override
 	protected int doHandle(final String body, final String pathInfo) throws ServletException {
+		TestResourceParameters parameters = this.getParametersFromPathInfo(pathInfo);
 
-		final List<String> pathValues = newArrayList(on("/").omitEmptyStrings().split(pathInfo));
-		if (4 != pathValues.size()) { // sessionID, tests, testId, ${operation}
-			throw new ClientResourceException(SC_NOT_FOUND);
-		}
-
-		final String sessionId = pathValues.get(0);
-		final String escapeTestId = unescapeTestId(pathValues.get(2));
-
-		if (sessionExists(sessionId)) {
+		if (null != parameters && sessionExists(parameters.sessionId)) {
 			try {
-				bus.post(createEvent(sessionId, escapeTestId, body));
+				bus.post(createEvent(parameters.sessionId, parameters.testId, body));
 			} catch (final Exception e) {
 				final Throwable rootCause = Throwables.getRootCause(e);
 				if (rootCause instanceof ClientResourceException) {
 					throw (ClientResourceException) rootCause;
 				}
-				LOGGER.error("Error while creating event for test session. [Session ID: " + sessionId + "]", e);
+				LOGGER.error("Error while creating event for test session. [Session ID: " + parameters.sessionId + "]",
+						e);
 				throw new ServletException(e);
 			}
 			return SC_OK;
 		}
 
 		return SC_NOT_FOUND;
-
 	}
 
 	/**
@@ -92,8 +86,46 @@ import com.google.inject.Inject;
 	 * This makes sure, that the underlying module specifier is restored to use the correct delimiter according to
 	 * {@link N4JSQualifiedNameConverter#DELIMITER}.
 	 */
-	private static String unescapeTestId(String testId) {
-		return testId.replace(TEST_ID_DELIMITER, N4JSQualifiedNameConverter.DELIMITER);
+	private String unescapeTestId(String testId) {
+		return urlDecoder.decode(testId);
 	}
 
+	/**
+	 * Parses the test resource parameters from the given escaped path info string.
+	 *
+	 * If the parsing fails, <code>null</code> is returned.
+	 * <p>
+	 * Note that this method assumes that the pathInfo string can be segmented in exactly 4 segments and is of following
+	 * structure ${sessionID}, "tests", ${testId}, ${operation}.
+	 * </p>
+	 */
+	protected final TestResourceParameters getParametersFromPathInfo(String pathInfo) {
+		final List<String> pathValues = newArrayList(on("/").omitEmptyStrings().split(pathInfo));
+		if (4 != pathValues.size()) { // sessionID, tests, testId, ${operation}
+			return null;
+		}
+
+		final String sessionId = pathValues.get(0);
+		final String unescapedTestId = unescapeTestId(pathValues.get(2));
+
+		return new TestResourceParameters(sessionId, unescapedTestId);
+	}
+
+	/**
+	 * Data type that holds the parameters for a test resource.
+	 */
+	protected static final class TestResourceParameters {
+		/** The session ID of the test resource */
+		public final String sessionId;
+		/** The unescaped ID of the test resource */
+		public final String testId;
+
+		/**
+		 * Instantiate a new {@link TestResourceParameters} instance.
+		 */
+		private TestResourceParameters(String sessionID, String testID) {
+			this.sessionId = sessionID;
+			this.testId = testID;
+		}
+	}
 }

--- a/tests/org.eclipse.n4js.hlc.tests/probands/testers/DemoTest/test/subfolder/SubFolderModule.n4js
+++ b/tests/org.eclipse.n4js.hlc.tests/probands/testers/DemoTest/test/subfolder/SubFolderModule.n4js
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+export public class SubFolderTest {
+    
+    @Test
+    public testPass() : void {
+		// dummy test
+    }
+
+}

--- a/tests/org.eclipse.n4js.hlc.tests/src/org/eclipse/n4js/hlc/tests/N4jscTestersTest.java
+++ b/tests/org.eclipse.n4js.hlc.tests/src/org/eclipse/n4js/hlc/tests/N4jscTestersTest.java
@@ -139,7 +139,7 @@ public class N4jscTestersTest extends AbstractN4jscTest {
 		file.deleteOnExit();
 		final String actual = new String(
 				java.nio.file.Files.readAllBytes(Paths.get(file.toURI())));
-		final String expected = "[{\"origin\":\"DemoTest\",\"fqn\":\"BarTest/OsInspectorTest2\",\"testMethods\":[\"testFail\"]},{\"origin\":\"DemoTest\",\"fqn\":\"FooTest/OsInspectorTest\",\"testMethods\":[\"testPass\"]},{\"origin\":\"SysProjectA\",\"fqn\":\"T/T\",\"testMethods\":[\"t\"]},{\"origin\":\"TestProjectA\",\"fqn\":\"A/A\",\"testMethods\":[\"a\"]},{\"origin\":\"TestProjectA\",\"fqn\":\"B/B\",\"testMethods\":[\"b1\",\"b2\"]},{\"origin\":\"TestProjectB\",\"fqn\":\"CSub1/CSub1\",\"testMethods\":[\"c1\",\"c2\"]},{\"origin\":\"TestProjectB\",\"fqn\":\"CSub2/CSub2\",\"testMethods\":[\"c1\",\"c2\",\"c3\"]}]";
+		final String expected = "[{\"origin\":\"DemoTest\",\"fqn\":\"BarTest/OsInspectorTest2\",\"testMethods\":[\"testFail\"]},{\"origin\":\"DemoTest\",\"fqn\":\"FooTest/OsInspectorTest\",\"testMethods\":[\"testPass\"]},{\"origin\":\"DemoTest\",\"fqn\":\"subfolder/SubFolderModule/SubFolderTest\",\"testMethods\":[\"testPass\"]},{\"origin\":\"SysProjectA\",\"fqn\":\"T/T\",\"testMethods\":[\"t\"]},{\"origin\":\"TestProjectA\",\"fqn\":\"A/A\",\"testMethods\":[\"a\"]},{\"origin\":\"TestProjectA\",\"fqn\":\"B/B\",\"testMethods\":[\"b1\",\"b2\"]},{\"origin\":\"TestProjectB\",\"fqn\":\"CSub1/CSub1\",\"testMethods\":[\"c1\",\"c2\"]},{\"origin\":\"TestProjectB\",\"fqn\":\"CSub2/CSub2\",\"testMethods\":[\"c1\",\"c2\",\"c3\"]}]";
 		assertEquals(expected, actual);
 	}
 
@@ -161,7 +161,7 @@ public class N4jscTestersTest extends AbstractN4jscTest {
 		file.deleteOnExit();
 		final String actual = new String(
 				java.nio.file.Files.readAllBytes(Paths.get(file.toURI())));
-		final String expected = "[{\"origin\":\"DemoTest\",\"fqn\":\"BarTest/OsInspectorTest2\",\"testMethods\":[\"testFail\"]},{\"origin\":\"DemoTest\",\"fqn\":\"FooTest/OsInspectorTest\",\"testMethods\":[\"testPass\"]},{\"origin\":\"SysProjectA\",\"fqn\":\"T/T\",\"testMethods\":[\"t\"]},{\"origin\":\"TestProjectA\",\"fqn\":\"A/A\",\"testMethods\":[\"a\"]},{\"origin\":\"TestProjectA\",\"fqn\":\"B/B\",\"testMethods\":[\"b1\",\"b2\"]},{\"origin\":\"TestProjectB\",\"fqn\":\"CSub1/CSub1\",\"testMethods\":[\"c1\",\"c2\"]},{\"origin\":\"TestProjectB\",\"fqn\":\"CSub2/CSub2\",\"testMethods\":[\"c1\",\"c2\",\"c3\"]}]";
+		final String expected = "[{\"origin\":\"DemoTest\",\"fqn\":\"BarTest/OsInspectorTest2\",\"testMethods\":[\"testFail\"]},{\"origin\":\"DemoTest\",\"fqn\":\"FooTest/OsInspectorTest\",\"testMethods\":[\"testPass\"]},{\"origin\":\"DemoTest\",\"fqn\":\"subfolder/SubFolderModule/SubFolderTest\",\"testMethods\":[\"testPass\"]},{\"origin\":\"SysProjectA\",\"fqn\":\"T/T\",\"testMethods\":[\"t\"]},{\"origin\":\"TestProjectA\",\"fqn\":\"A/A\",\"testMethods\":[\"a\"]},{\"origin\":\"TestProjectA\",\"fqn\":\"B/B\",\"testMethods\":[\"b1\",\"b2\"]},{\"origin\":\"TestProjectB\",\"fqn\":\"CSub1/CSub1\",\"testMethods\":[\"c1\",\"c2\"]},{\"origin\":\"TestProjectB\",\"fqn\":\"CSub2/CSub2\",\"testMethods\":[\"c1\",\"c2\",\"c3\"]}]";
 		assertEquals(expected, actual);
 	}
 
@@ -188,7 +188,7 @@ public class N4jscTestersTest extends AbstractN4jscTest {
 		file.deleteOnExit();
 		final String actual = new String(
 				java.nio.file.Files.readAllBytes(Paths.get(file.toURI())));
-		final String expected = "[{\"origin\":\"DemoTest\",\"fqn\":\"BarTest/OsInspectorTest2\",\"testMethods\":[\"testFail\"]},{\"origin\":\"DemoTest\",\"fqn\":\"FooTest/OsInspectorTest\",\"testMethods\":[\"testPass\"]},{\"origin\":\"SysProjectA\",\"fqn\":\"T/T\",\"testMethods\":[\"t\"]},{\"origin\":\"TestProjectA\",\"fqn\":\"A/A\",\"testMethods\":[\"a\"]},{\"origin\":\"TestProjectA\",\"fqn\":\"B/B\",\"testMethods\":[\"b1\",\"b2\"]},{\"origin\":\"TestProjectB\",\"fqn\":\"CSub1/CSub1\",\"testMethods\":[\"c1\",\"c2\"]},{\"origin\":\"TestProjectB\",\"fqn\":\"CSub2/CSub2\",\"testMethods\":[\"c1\",\"c2\",\"c3\"]}]";
+		final String expected = "[{\"origin\":\"DemoTest\",\"fqn\":\"BarTest/OsInspectorTest2\",\"testMethods\":[\"testFail\"]},{\"origin\":\"DemoTest\",\"fqn\":\"FooTest/OsInspectorTest\",\"testMethods\":[\"testPass\"]},{\"origin\":\"DemoTest\",\"fqn\":\"subfolder/SubFolderModule/SubFolderTest\",\"testMethods\":[\"testPass\"]},{\"origin\":\"SysProjectA\",\"fqn\":\"T/T\",\"testMethods\":[\"t\"]},{\"origin\":\"TestProjectA\",\"fqn\":\"A/A\",\"testMethods\":[\"a\"]},{\"origin\":\"TestProjectA\",\"fqn\":\"B/B\",\"testMethods\":[\"b1\",\"b2\"]},{\"origin\":\"TestProjectB\",\"fqn\":\"CSub1/CSub1\",\"testMethods\":[\"c1\",\"c2\"]},{\"origin\":\"TestProjectB\",\"fqn\":\"CSub2/CSub2\",\"testMethods\":[\"c1\",\"c2\",\"c3\"]}]";
 		assertEquals(expected, actual);
 	}
 

--- a/tests/org.eclipse.n4js.tester.tests/src/org/eclipse/n4js/tester/tests/LoggingMockResourceTesterModule.java
+++ b/tests/org.eclipse.n4js.tester.tests/src/org/eclipse/n4js/tester/tests/LoggingMockResourceTesterModule.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+package org.eclipse.n4js.tester.tests;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.n4js.tester.TesterEventBus;
+import org.eclipse.n4js.tester.events.TestEvent;
+import org.eclipse.n4js.tester.fsm.TestFsm;
+import org.eclipse.n4js.tester.fsm.TestFsmRegistry;
+import org.eclipse.n4js.tester.fsm.TestFsmRegistryImpl;
+import org.eclipse.n4js.tester.internal.InternalTestTreeRegistry;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+/**
+ * Customized module in respect of the {@link TestFsmRegistry} implementation.
+ *
+ * This module can be used to get information about the test events that are created in consequence of server requests.
+ */
+public class LoggingMockResourceTesterModule extends MockTesterModule {
+
+	@Override
+	protected void configure() {
+		bind(TestFsmRegistry.class).to(LoggingFsmRegistry.class);
+	}
+
+	/**
+	 * A mock-implementation of {@link TestFsmRegistryImpl} that keeps track of all processed test events.
+	 */
+	@Singleton
+	public static final class LoggingFsmRegistry extends TestFsmRegistryImpl {
+
+		private final List<TestEvent> events = new ArrayList<>();
+
+		/**
+		 * Initializes a new {@link LoggingFsmRegistry}.
+		 */
+		@Inject
+		public LoggingFsmRegistry(final TesterEventBus bus, final InternalTestTreeRegistry registry) {
+			super(bus, registry);
+		}
+
+		@Override
+		public boolean isSessionExist(final String sessionId) {
+			return true;
+		}
+
+		@Override
+		public TestFsm registerFsm(final String sessionId) {
+			return null;
+		}
+
+		@Override
+		public void receivedTestEvent(final TestEvent event) {
+			this.events.add(event);
+		}
+
+		/**
+		 * Returns a list of logged test events. New events are added to the end of the list.
+		 */
+		public List<TestEvent> getEvents() {
+			return events;
+		}
+
+	}
+
+}

--- a/tests/org.eclipse.n4js.tester.tests/src/org/eclipse/n4js/tester/tests/resource/TestIdParsingTest.xtend
+++ b/tests/org.eclipse.n4js.tester.tests/src/org/eclipse/n4js/tester/tests/resource/TestIdParsingTest.xtend
@@ -1,0 +1,135 @@
+/**
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+package org.eclipse.n4js.tester.tests.resource;
+
+import com.google.inject.Inject
+import java.io.UnsupportedEncodingException
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import org.eclipse.n4js.tester.TesterModule
+import org.eclipse.n4js.tester.events.TestEndedEvent
+import org.eclipse.n4js.tester.events.TestEvent
+import org.eclipse.n4js.tester.events.TestPingedEvent
+import org.eclipse.n4js.tester.events.TestStartedEvent
+import org.eclipse.n4js.tester.tests.InjectedModules
+import org.eclipse.n4js.tester.tests.JUnitGuiceClassRunner
+import org.eclipse.n4js.tester.tests.LoggingMockResourceTesterModule
+import org.eclipse.n4js.tester.tests.LoggingMockResourceTesterModule.LoggingFsmRegistry
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import static com.google.common.collect.ImmutableMap.*
+import static com.jayway.restassured.RestAssured.*
+import static java.util.Collections.*
+import static java.util.UUID.randomUUID
+import static javax.servlet.http.HttpServletResponse.*
+import static org.eclipse.n4js.tester.server.resources.ContentType.*
+
+/**
+ * Class for testing the session RESTful resources.
+ */
+@RunWith(JUnitGuiceClassRunner)
+@InjectedModules(baseModules =#[TesterModule], overrides = #[LoggingMockResourceTesterModule])
+public class TestIdParsingTest extends BaseResourcesTest {
+	
+	@Inject
+	LoggingFsmRegistry registry;
+	
+	/**
+	 * Tests that the encoded test and session ID is correctly parsed
+	 * from the test start request URL.
+	 */
+	@Test
+	def void testPostStartExpectTestId() {
+		val testId = encodeTestId("A/B/C/D#method");
+		val sessionId = randomUUID.toString;
+		
+		given
+			.contentType(START_TEST)
+			.body(builder.put('timeout', 1000L).put('properties', singletonMap('someProperty', 'someValue')).build)
+		.when
+			.post('''«URL»«sessionId»/tests/«testId»/start''')
+		.then
+			.expectStatusCode(SC_OK);
+			
+		assertEvent("Created test start event has correct test ID.", registry.events.last, TestStartedEvent, sessionId, testId);
+	}
+	
+	/**
+	 * Tests that the encoded test and session ID is correctly parsed
+	 * from the test end request URL.
+	 */
+	@Test
+	def void testPostTestEndExpectTestId() {
+		val testId = encodeTestId("A/B/C/D#method")
+		val sessionId = randomUUID.toString;
+		
+		given
+			.contentType(END_TEST)
+			.body(newTestResult)
+		.when
+			.post('''«URL»«sessionId»/tests/«testId»/end''')
+		.then
+			.expectStatusCode(SC_OK)
+			
+		assertEvent("Create test ended event has correct test ID.", registry.events.last, TestEndedEvent, sessionId, testId);
+	}
+	
+	/**
+	 * Tests that the encoded test and session ID is correctly parsed
+	 * from the test ping request URL.
+	 */
+	@Test
+	def void testPostTestPingExpectTestId() {
+		val testId = encodeTestId("A/B/C/D#method")
+		val sessionId = randomUUID.toString;
+		
+		given
+			.contentType(PING_TEST)
+			.body(singletonMap('timeout', 1000L))
+		.when
+			.post('''«URL»«sessionId»/tests/«testId»/ping''')
+		.then
+			.expectStatusCode(SC_OK)
+			
+		assertEvent("Created test ping event has correct test ID.", registry.events.last, TestPingedEvent, sessionId, testId);
+	}
+
+
+	/**
+	 * Asserts the given test event to match the given session ID and if applicable the test ID.
+	 */
+	private def void assertEvent(String message, TestEvent e, Class<? extends TestEvent> eventClass, String sessionId, String testId) {
+		Assert.assertTrue(message + " Event class doesn't match.", eventClass.isInstance(e));
+		Assert.assertEquals(message + " Session ID doesn't match.", e.sessionId, sessionId);
+		
+		if (e instanceof TestStartedEvent) {
+			Assert.assertEquals(message + " Test ID doesn't match.", e.testId, testId);
+		} else if (e instanceof TestPingedEvent) {
+			Assert.assertEquals(message + " Test ID doesn't match.", e.testId, testId);
+		} else if (e instanceof TestEndedEvent) {
+			Assert.assertEquals(message + " Test ID doesn't match.", e.testId, testId);
+		}
+	}
+	
+	/**
+	 * Returns the URL-encoded version of the given test id.
+	 */
+	private def String encodeTestId(String testId) {
+		try {
+			return URLEncoder.encode(testId, StandardCharsets.UTF_8.toString);
+		} catch (UnsupportedEncodingException e) {
+			Assert.fail("Failed to URL-encode test ID '" + testId + "'");
+			return ""; // this will never be execute
+		}
+	}
+}


### PR DESCRIPTION
As discussed I changed the escaping of FQNs in mangelhaft IDE reporter URLs to standard URL-escaping.