### PR TITLE
GH-177: Add icons for all editors in their plugin.xml files

### DIFF
--- a/plugins/org.eclipse.n4js.n4jsx.ui/plugin.xml
+++ b/plugins/org.eclipse.n4js.n4jsx.ui/plugin.xml
@@ -21,6 +21,7 @@ Contributors:
             default="true"
             extensions="n4jsx,jsx"
             id="org.eclipse.n4js.n4jsx.N4JSX"
+            icon="platform:/plugin/org.eclipse.ui/icons/full/obj16/file_obj.png"
             name="N4JSX Editor">
         </editor>
     </extension>

--- a/plugins/org.eclipse.n4js.n4mf.ui/plugin.xml
+++ b/plugins/org.eclipse.n4js.n4mf.ui/plugin.xml
@@ -21,6 +21,7 @@ Contributors:
             default="true"
             extensions="n4mf"
             id="org.eclipse.n4js.n4mf.N4MF"
+            icon="platform:/plugin/org.eclipse.ui/icons/full/obj16/file_obj.png"
             name="N4MF Editor">
         </editor>
     </extension>

--- a/plugins/org.eclipse.n4js.regex.ui/plugin.xml
+++ b/plugins/org.eclipse.n4js.regex.ui/plugin.xml
@@ -21,6 +21,7 @@ Contributors:
             default="true"
             extensions="regex"
             id="org.eclipse.n4js.regex.RegularExpression"
+            icon="platform:/plugin/org.eclipse.ui/icons/full/obj16/file_obj.png"
             name="RegularExpression Editor">
         </editor>
     </extension>

--- a/plugins/org.eclipse.n4js.ts.ui/plugin.xml
+++ b/plugins/org.eclipse.n4js.ts.ui/plugin.xml
@@ -22,6 +22,7 @@ Contributors:
             default="true"
             extensions="n4ts"
             id="org.eclipse.n4js.ts.Types"
+            icon="platform:/plugin/org.eclipse.ui/icons/full/obj16/file_obj.png"
             name="Types Editor">
         </editor>
     </extension>

--- a/plugins/org.eclipse.n4js.ui/plugin.xml
+++ b/plugins/org.eclipse.n4js.ui/plugin.xml
@@ -101,6 +101,7 @@ Contributors:
             default="true"
             extensions="n4js,js,n4jsd"
             id="org.eclipse.n4js.N4JS"
+            icon="platform:/plugin/org.eclipse.ui/icons/full/obj16/file_obj.png"
             name="N4JS Editor">
         </editor>
     </extension>


### PR DESCRIPTION
Issue: https://github.com/eclipse/n4js/issues/177

The Quick Access Search could cause NPEs since the actual editors are initialised lazily. If we don't provide an icon in the plugin.xml files, the Eclipse platform can't find an icon for inactive background editors. 
This is not handled in the QuickAccessEntry creation which can lead to NPEs.

In this PR I added icons to all our editors in their plugin.xml files. The icon I used is the one the default XtextEditor provides. To be found under platform:/plugin/org.eclipse.ui/icons/full/obj16/file_obj.png.

This change also means that on startup, all editor tabs will have a nice icon in their title even if they haven't been loaded yet.

Also please don't forget about the internal PR.

For builds see internal PR.