### PR TITLE
#225: added warning if object literal contains superfluous properties

### DIFF
--- a/builds/org.eclipse.n4js.product.build/N4JS__IDE.launch
+++ b/builds/org.eclipse.n4js.product.build/N4JS__IDE.launch
@@ -28,22 +28,6 @@
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="org.eclipse.n4js.product.product"/>
 <setAttribute key="selected_features">
-<setEntry value="org.eclipse.n4js.compiler.sdk:default"/>
-<setEntry value="org.eclipse.n4js.dependencies.sdk:default"/>
-<setEntry value="org.eclipse.n4js.dependencies.ui.sdk:default"/>
-<setEntry value="org.eclipse.n4js.jsdoc2spec.sdk:default"/>
-<setEntry value="org.eclipse.n4js.lang.sdk:default"/>
-<setEntry value="org.eclipse.n4js.n4mf.sdk:default"/>
-<setEntry value="org.eclipse.n4js.regex.sdk:default"/>
-<setEntry value="org.eclipse.n4js.runner.sdk:default"/>
-<setEntry value="org.eclipse.n4js.sdk:default"/>
-<setEntry value="org.eclipse.n4js.smith.sdk:default"/>
-<setEntry value="org.eclipse.n4js.tester.sdk:default"/>
-<setEntry value="org.eclipse.n4js.ts.sdk:default"/>
-<setEntry value="org.eclipse.n4js.unicode.sdk:default"/>
-<setEntry value="org.eclipse.n4js.xpect.sdk:default"/>
-<setEntry value="org.eclipse.n4js.n4jsx.sdk:default"/>
-<setEntry value="org.eclipse.n4js.n4jsx.xpect.sdk:default"/>
 <setEntry value="org.eclipse.e4.rcp:default"/>
 <setEntry value="org.eclipse.ecf.core.feature:default"/>
 <setEntry value="org.eclipse.ecf.core.ssl.feature:default"/>
@@ -60,6 +44,22 @@
 <setEntry value="org.eclipse.equinox.p2.user.ui:default"/>
 <setEntry value="org.eclipse.help:default"/>
 <setEntry value="org.eclipse.jgit:default"/>
+<setEntry value="org.eclipse.n4js.compiler.sdk:default"/>
+<setEntry value="org.eclipse.n4js.dependencies.sdk:default"/>
+<setEntry value="org.eclipse.n4js.dependencies.ui.sdk:default"/>
+<setEntry value="org.eclipse.n4js.jsdoc2spec.sdk:default"/>
+<setEntry value="org.eclipse.n4js.lang.sdk:default"/>
+<setEntry value="org.eclipse.n4js.n4jsx.sdk:default"/>
+<setEntry value="org.eclipse.n4js.n4jsx.xpect.sdk:default"/>
+<setEntry value="org.eclipse.n4js.n4mf.sdk:default"/>
+<setEntry value="org.eclipse.n4js.regex.sdk:default"/>
+<setEntry value="org.eclipse.n4js.runner.sdk:default"/>
+<setEntry value="org.eclipse.n4js.sdk:default"/>
+<setEntry value="org.eclipse.n4js.smith.sdk:default"/>
+<setEntry value="org.eclipse.n4js.tester.sdk:default"/>
+<setEntry value="org.eclipse.n4js.ts.sdk:default"/>
+<setEntry value="org.eclipse.n4js.unicode.sdk:default"/>
+<setEntry value="org.eclipse.n4js.xpect.sdk:default"/>
 <setEntry value="org.eclipse.platform:default"/>
 <setEntry value="org.eclipse.rcp:default"/>
 <setEntry value="org.eclipse.wst.common_core.feature:default"/>

--- a/docs/org.eclipse.n4js.spec/chapters/08_expressions/expressions.adoc
+++ b/docs/org.eclipse.n4js.spec/chapters/08_expressions/expressions.adoc
@@ -818,6 +818,15 @@ $\spc \mu(pa.name)=\type{N4JSIdentifier}$
 
 --
 
+.Superfluous properties of an object literal
+[req,id=IDE-22501,version=1]
+--
+Let $E$ be the expected type of an object literal $O$ as defined by the context in which $O$ is used.
+If $E$ is not type `Object` and not dynamic, then the compiler creates a warning $O$ contains properties not found in $E$.
+
+This is true in particular for object literals passed in as arguments of a spec-constructor.
+--
+
 
 ==== Scoping and linking
 

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/messages.properties
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/messages.properties
@@ -316,8 +316,8 @@ CLF_SPEC_WRONG_TYPE=error;;;Annotation @Spec may only be used with formal parame
 CLF_SPEC_WRONG_ADD_MEMBERTYPE=error;;;Type of structural member {0} of spec parameter must be a subtype of {1}: {2}.
 # no parameters required
 CLF_SPEC_MULTIPLE=error;;;Only a single formal parameter in each constructor may be annotated with @Spec.
-# 0: name of the superfluous property
-CLF_SPEC_SUPERFLUOUS_PROPERTIES=warning;;;{0} is not used in constructor.
+# 0: name of the superfluous property, 1: the type not defining the property
+CLF_SPEC_SUPERFLUOUS_PROPERTIES=warning;;;{0} is not defined in {1}.
 # 0: name of the property, {1} built-in/provided by runtime interface
 CLF_SPEC_BUILT_IN_OR_PROVIDED_BY_RUNTIME_OR_EXTENAL_WITHOUT_N4JS_ANNOTATION=warning;;;{0} is a property of built-in / provided by runtime / external without @N4JS annotation interface {1} and can not be initialized in Spec constructor.
 # 0:the cycle

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSClassValidator.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSClassValidator.xtend
@@ -175,24 +175,11 @@ class N4JSClassValidator extends AbstractN4JSDeclarativeValidator {
 			publicWritableFieldsAndSetters.put(it.name, it);
 		];
 
-		checkSuperfluousPropertiesForSpecConstructor(publicWritableFieldsAndSetters, objectLiteral);
+		// superfluous properties in initializer are checked in org.eclipse.n4js.validation.validators.N4JSTypeValidator.internalCheckSuperfluousPropertiesInObjectLiteral(..)
 		checkFieldInitializationOfImplementedInterface(publicWritableFieldsAndSetters, objectLiteral);
 	}
 
-	/**
-	 * Method for checking if an object literal in {@code @Spec} constructor provides any superfluous properties.
-	 * If so, validation warning will be raised for each violating properties.
-	 * IDE-1014.
-	 */
-	def private void checkSuperfluousPropertiesForSpecConstructor(Map<String, TMember> publicWritableFieldsMap, ObjectLiteral objectLiteral) {
-		val inputMembers = (objectLiteral.definedType as ContainerType<?>).ownedMembers;
-		inputMembers.forEach [
-			if (!publicWritableFieldsMap.containsKey(name)) {
-				val message = getMessageForCLF_SPEC_SUPERFLUOUS_PROPERTIES(name);
-				addIssue(message, astElement, PROPERTY_NAME_OWNER__DECLARED_NAME, CLF_SPEC_SUPERFLUOUS_PROPERTIES);
-			}
-		];
-	}
+
 
 	/**
 	 * Check if an object literal in {@code @Spec} constructor provide a property that comes from a built-in/provided by runtime interface.

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSTypeValidator.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSTypeValidator.xtend
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */
@@ -33,7 +33,9 @@ import org.eclipse.n4js.n4JS.N4JSASTUtils
 import org.eclipse.n4js.n4JS.N4JSPackage
 import org.eclipse.n4js.n4JS.N4MemberDeclaration
 import org.eclipse.n4js.n4JS.N4MethodDeclaration
+import org.eclipse.n4js.n4JS.ObjectLiteral
 import org.eclipse.n4js.n4JS.ParameterizedPropertyAccessExpression
+import org.eclipse.n4js.n4JS.PropertyNameValuePair
 import org.eclipse.n4js.n4JS.Script
 import org.eclipse.n4js.n4JS.ThisLiteral
 import org.eclipse.n4js.n4JS.TypedElement
@@ -70,11 +72,14 @@ import org.eclipse.n4js.ts.types.TMember
 import org.eclipse.n4js.ts.types.TSetter
 import org.eclipse.n4js.ts.types.Type
 import org.eclipse.n4js.ts.types.TypesPackage
+import org.eclipse.n4js.ts.types.TypingStrategy
 import org.eclipse.n4js.ts.types.VoidType
 import org.eclipse.n4js.ts.types.util.Variance
 import org.eclipse.n4js.ts.utils.TypeUtils
 import org.eclipse.n4js.typesystem.N4JSTypeSystem
+import org.eclipse.n4js.typesystem.RuleEnvironmentExtensions
 import org.eclipse.n4js.typesystem.TypeSystemHelper
+import org.eclipse.n4js.typesystem.TypingStrategyFilter
 import org.eclipse.n4js.utils.ContainerTypesHelper
 import org.eclipse.n4js.utils.N4JSLanguageUtils
 import org.eclipse.n4js.validation.AbstractN4JSDeclarativeValidator
@@ -90,7 +95,6 @@ import static org.eclipse.n4js.ts.typeRefs.TypeRefsPackage.Literals.PARAMETERIZE
 import static org.eclipse.n4js.validation.IssueCodes.*
 
 import static extension org.eclipse.n4js.typesystem.RuleEnvironmentExtensions.*
-import org.eclipse.n4js.ts.types.TypingStrategy
 
 /**
  * Class for validating the N4JS types.
@@ -109,15 +113,14 @@ class N4JSTypeValidator extends AbstractN4JSDeclarativeValidator {
 	private N4JSScopeProvider n4jsScopeProvider;
 
 	@Inject
-	private ContainerTypesHelper containerTypesHelper;
-
+	protected extension ContainerTypesHelper containerTypesHelper;
+	
 	@Inject
 	private JavaScriptVariantHelper jsVariantHelper;
 
-
 	/**
-	 * NEEEDED
-	 *
+	 * NEEDED
+	 * 
 	 * when removed check methods will be called twice once by N4JSValidator, and once by
 	 * AbstractDeclarativeN4JSValidator
 	 */
@@ -125,24 +128,23 @@ class N4JSTypeValidator extends AbstractN4JSDeclarativeValidator {
 		// nop
 	}
 
-
 	/**
 	 * Validates all generic type variable declarations.
 	 * Raises validation error for each type variable if any of their declared upper bound is a primitive type.
 	 * <p>
 	 * IDEBUG-185
-	 *
+	 * 
 	 * @param declaration the generic declaration to check the upper bound declarations of its type variables.
 	 */
 	@Check
 	def checkGenericDeclarationType(GenericDeclaration declaration) {
 		val functionType = newRuleEnvironment(declaration).functionType
-		declaration.typeVars.filterNull.forEach [typeVar|
+		declaration.typeVars.filterNull.forEach [ typeVar |
 			val ub = typeVar.declaredUpperBound;
-			if(ub!==null) {
+			if (ub !== null) {
 				val declType = ub.declaredType;
 				if (declType instanceof ContainerType<?> && declType.final) {
-					if(declType === functionType) {
+					if (declType === functionType) {
 						// important exception (until function type expressions are supported as bounds):
 						// class C<T extends Function> {} makes sense even though Function is final
 						return;
@@ -156,14 +158,13 @@ class N4JSTypeValidator extends AbstractN4JSDeclarativeValidator {
 
 	@Check
 	def checkTModuleCreated(Script script) {
-		if(script.module === null) {
+		if (script.module === null) {
 			val rootNode = NodeModelUtils.getNode(script)
-			if(rootNode !== null) {
+			if (rootNode !== null) {
 				addIssue(IssueCodes.getMessageForTYS_MISSING, script, rootNode.offset, rootNode.length, TYS_MISSING);
 			}
 		}
 	}
-
 
 	@Check
 	def checkParameterizedTypeRef(ParameterizedTypeRef paramTypeRef) {
@@ -187,14 +188,14 @@ class N4JSTypeValidator extends AbstractN4JSDeclarativeValidator {
 		if (isInTypeTypeRef) {
 			internalCheckValidTypeInTypeTypeRef(paramTypeRef);
 		} else {
-			internalCheckTypeArguments(declaredType.typeVars, paramTypeRef.typeArgs, false,
-				declaredType, paramTypeRef, TypeRefsPackage.eINSTANCE.parameterizedTypeRef_DeclaredType);
+			internalCheckTypeArguments(declaredType.typeVars, paramTypeRef.typeArgs, false, declaredType, paramTypeRef,
+				TypeRefsPackage.eINSTANCE.parameterizedTypeRef_DeclaredType);
 		}
 		internalCheckDynamic(paramTypeRef);
-		
+
 		internalCheckStructuralPrimitiveTypeRef(paramTypeRef);
 	}
-	
+
 	/**
 	 * Add an issue if explicit use of structural type operator with a primitive type is detected.
 	 */
@@ -210,21 +211,20 @@ class N4JSTypeValidator extends AbstractN4JSDeclarativeValidator {
 	def private void internalCheckValidLocationForVoid(ParameterizedTypeRef typeRef) {
 		if (typeRef.declaredType instanceof VoidType) {
 			val isValidLocationForVoid = (
-					typeRef.eContainer instanceof FunctionDefinition
-					&& typeRef.eContainmentFeature===N4JSPackage.eINSTANCE.functionDefinition_ReturnTypeRef
+					typeRef.eContainer instanceof FunctionDefinition &&
+				typeRef.eContainmentFeature === N4JSPackage.eINSTANCE.functionDefinition_ReturnTypeRef
 				) || (
-					typeRef.eContainer instanceof FunctionTypeExpression
-					&& typeRef.eContainmentFeature===TypeRefsPackage.eINSTANCE.functionTypeExpression_ReturnTypeRef
+					typeRef.eContainer instanceof FunctionTypeExpression &&
+				typeRef.eContainmentFeature === TypeRefsPackage.eINSTANCE.functionTypeExpression_ReturnTypeRef
 				) || (
-					typeRef.eContainer instanceof TFunction
-					&& typeRef.eContainmentFeature===TypesPackage.eINSTANCE.TFunction_ReturnTypeRef
+					typeRef.eContainer instanceof TFunction && typeRef.eContainmentFeature === TypesPackage.eINSTANCE.TFunction_ReturnTypeRef
 				) || (
 					// void is not truly allowed as the return type of a getter, but there's a separate validation for
 					// that; so treat this case as legal here:
-					typeRef.eContainer instanceof GetterDeclaration
-					&& typeRef.eContainmentFeature===N4JSPackage.eINSTANCE.typedElement_DeclaredTypeRef
+					typeRef.eContainer instanceof GetterDeclaration &&
+				typeRef.eContainmentFeature === N4JSPackage.eINSTANCE.typedElement_DeclaredTypeRef
 				);
-			if(!isValidLocationForVoid) {
+			if (!isValidLocationForVoid) {
 				addIssue(IssueCodes.getMessageForTYS_VOID_AT_WRONG_LOCATION, typeRef, TYS_VOID_AT_WRONG_LOCATION);
 			}
 		}
@@ -233,12 +233,15 @@ class N4JSTypeValidator extends AbstractN4JSDeclarativeValidator {
 	def private void internalCheckValidTypeInTypeTypeRef(ParameterizedTypeRef paramTypeRef) {
 		// IDE-785 uses ParamterizedTypeRefs in ClassifierTypeRefs. Currently Type Arguments are not supported in ClassifierTypeRefs, so
 		// we actively forbid them here. Will be loosened for IDE-1310
-		if( ! paramTypeRef.typeArgs.isEmpty ) {
-			addIssue(IssueCodes.getMessageForAST_NO_TYPE_ARGS_IN_CLASSIFIERTYPEREF, paramTypeRef, AST_NO_TYPE_ARGS_IN_CLASSIFIERTYPEREF)
-		} else if ( paramTypeRef instanceof FunctionTypeRef ) {
-			addIssue(IssueCodes.getMessageForAST_NO_FUNCTIONTYPEREFS_IN_CLASSIFIERTYPEREF, paramTypeRef, AST_NO_FUNCTIONTYPEREFS_IN_CLASSIFIERTYPEREF)
-		} else if ( paramTypeRef.declaredType instanceof TFunction ) {
-			addIssue(IssueCodes.getMessageForAST_NO_FUNCTIONTYPEREFS_IN_CLASSIFIERTYPEREF, paramTypeRef, AST_NO_FUNCTIONTYPEREFS_IN_CLASSIFIERTYPEREF)
+		if (! paramTypeRef.typeArgs.isEmpty) {
+			addIssue(IssueCodes.getMessageForAST_NO_TYPE_ARGS_IN_CLASSIFIERTYPEREF, paramTypeRef,
+				AST_NO_TYPE_ARGS_IN_CLASSIFIERTYPEREF)
+		} else if (paramTypeRef instanceof FunctionTypeRef) {
+			addIssue(IssueCodes.getMessageForAST_NO_FUNCTIONTYPEREFS_IN_CLASSIFIERTYPEREF, paramTypeRef,
+				AST_NO_FUNCTIONTYPEREFS_IN_CLASSIFIERTYPEREF)
+		} else if (paramTypeRef.declaredType instanceof TFunction) {
+			addIssue(IssueCodes.getMessageForAST_NO_FUNCTIONTYPEREFS_IN_CLASSIFIERTYPEREF, paramTypeRef,
+				AST_NO_FUNCTIONTYPEREFS_IN_CLASSIFIERTYPEREF)
 		}
 	}
 
@@ -250,279 +253,341 @@ class N4JSTypeValidator extends AbstractN4JSDeclarativeValidator {
 			// is not the job of this validation)
 			return;
 		}
-		if (!(thisTypeRef.isUsedStructurallyAsFormalParametersInTheConstructor
-			|| thisTypeRef.isUsedAtCovariantPositionInClassifierDeclaration
-			|| thisTypeRef.isUsedInVariableWithSyntaxError)) {
+		if (!(thisTypeRef.isUsedStructurallyAsFormalParametersInTheConstructor ||
+			thisTypeRef.isUsedAtCovariantPositionInClassifierDeclaration ||
+			thisTypeRef.isUsedInVariableWithSyntaxError)) {
 
-			addIssue(IssueCodes.getMessageForAST_THIS_WRONG_PLACE, thisTypeRef, IssueCodes.AST_THIS_WRONG_PLACE);
+				addIssue(IssueCodes.getMessageForAST_THIS_WRONG_PLACE, thisTypeRef, IssueCodes.AST_THIS_WRONG_PLACE);
+			}
 		}
-	}
 
-	def private boolean isUsedStructurallyAsFormalParametersInTheConstructor(ThisTypeRef thisTypeRef) {
-		if (thisTypeRef.useSiteStructuralTyping) {
-			val methodOrConstructor = thisTypeRef?.eContainer?.eContainer;
-			if (methodOrConstructor instanceof N4MethodDeclaration) {
-				if (methodOrConstructor !== null && methodOrConstructor.isConstructor) {
-					return true
+		def private boolean isUsedStructurallyAsFormalParametersInTheConstructor(ThisTypeRef thisTypeRef) {
+			if (thisTypeRef.useSiteStructuralTyping) {
+				val methodOrConstructor = thisTypeRef?.eContainer?.eContainer;
+				if (methodOrConstructor instanceof N4MethodDeclaration) {
+					if (methodOrConstructor !== null && methodOrConstructor.isConstructor) {
+						return true
+					}
+				}
+			}
+			return false
+		}
+
+		def private boolean isUsedAtCovariantPositionInClassifierDeclaration(ThisTypeRef thisTypeRef) {
+			val classifierDecl = EcoreUtil2.getContainerOfType(thisTypeRef, N4ClassifierDeclaration);
+			if (classifierDecl !== null) {
+				// exception: disallow for static members of interfaces
+				if (classifierDecl instanceof N4InterfaceDeclaration) {
+					val memberDecl = EcoreUtil2.getContainerOfType(thisTypeRef, N4MemberDeclaration);
+					if (memberDecl !== null && memberDecl.static) {
+						return false;
+					}
+				}
+				val varianceOfPos = N4JSLanguageUtils.getVarianceOfPosition(thisTypeRef);
+				if (varianceOfPos !== null) {
+					return varianceOfPos === Variance.CO;
+				}
+			}
+			return false;
+		}
+
+		private def boolean isUsedInVariableWithSyntaxError(ThisTypeRef ref) {
+			val container = ref.eContainer
+			if (container instanceof VariableDeclaration) {
+				return container.name === null
+			}
+			return false
+		}
+
+		@Check
+		def checkSymbolReference(TypeRef typeRef) {
+			var bits = BuiltInTypeScope.get(typeRef?.eResource.resourceSet);
+			if (typeRef.declaredType === bits.symbolObjectType) {
+				// we have a type reference to 'Symbol'
+				// -> the only allowed case is as target/receiver of a property access (i.e.: Symbol.iterator)
+				val parent = typeRef.eContainer;
+				if (!(parent instanceof ParameterizedPropertyAccessExpression) ||
+					(parent as ParameterizedPropertyAccessExpression).target !== typeRef) {
+					addIssue(IssueCodes.getMessageForBIT_SYMBOL_INVALID_USE, typeRef, BIT_SYMBOL_INVALID_USE);
 				}
 			}
 		}
-		return false
-	}
 
-	def private boolean isUsedAtCovariantPositionInClassifierDeclaration(ThisTypeRef thisTypeRef) {
-		val classifierDecl = EcoreUtil2.getContainerOfType(thisTypeRef, N4ClassifierDeclaration);
-		if(classifierDecl!==null) {
-			// exception: disallow for static members of interfaces
-			if(classifierDecl instanceof N4InterfaceDeclaration) {
-				val memberDecl = EcoreUtil2.getContainerOfType(thisTypeRef, N4MemberDeclaration);
-				if(memberDecl!==null && memberDecl.static) {
-					return false;
+		/*
+		 * Constraints 08: primitive types except any must not be declared dynamic
+		 */
+		def internalCheckDynamic(ParameterizedTypeRef ref) {
+			if (ref.dynamic) {
+				val Type t = ref.declaredType;
+				if (t instanceof PrimitiveType && ! (t instanceof AnyType)) {
+					addIssue(IssueCodes.getMessageForTYS_PRIMITIVE_TYPE_DYNAMIC(t.name), ref,
+						TYS_PRIMITIVE_TYPE_DYNAMIC);
 				}
 			}
-			val varianceOfPos = N4JSLanguageUtils.getVarianceOfPosition(thisTypeRef);
-			if(varianceOfPos!==null) {
-				return varianceOfPos===Variance.CO;
-			}
 		}
-		return false;
-	}
 
-	private def boolean isUsedInVariableWithSyntaxError(ThisTypeRef ref) {
-		val container = ref.eContainer
-		if (container instanceof VariableDeclaration) {
-			return container.name === null
-		}
-		return false
-	}
+		@Check
+		def checkTypeHiddenByTypeVariable(GenericDeclaration genDecl) {
 
-	@Check
-	def checkSymbolReference(TypeRef typeRef) {
-		var bits = BuiltInTypeScope.get(typeRef?.eResource.resourceSet);
-		if(typeRef.declaredType === bits.symbolObjectType) {
-			// we have a type reference to 'Symbol'
-			// -> the only allowed case is as target/receiver of a property access (i.e.: Symbol.iterator)
-			val parent = typeRef.eContainer;
-			if(!(parent instanceof ParameterizedPropertyAccessExpression) ||
-				(parent as ParameterizedPropertyAccessExpression).target!==typeRef) {
-				addIssue(IssueCodes.getMessageForBIT_SYMBOL_INVALID_USE, typeRef, BIT_SYMBOL_INVALID_USE);
-			}
-		}
-	}
-
-
-	/*
-	 * Constraints 08: primitive types except any must not be declared dynamic
-	 */
-	def internalCheckDynamic(ParameterizedTypeRef ref) {
-		if (ref.dynamic) {
-			val Type t = ref.declaredType;
-			if (t instanceof PrimitiveType && ! (t instanceof AnyType)) {
-				addIssue(IssueCodes.getMessageForTYS_PRIMITIVE_TYPE_DYNAMIC(t.name), ref, TYS_PRIMITIVE_TYPE_DYNAMIC);
-			}
-		}
-	}
-
-	@Check
-	def checkTypeHiddenByTypeVariable(GenericDeclaration genDecl) {
-
-		// TODO reconsider this warning or its implementation; re-generating the scope can become quite expensive
-		// (but note that moving this to the scoping code is not trivial, because warning has to be generated also
-		//  if not references to the type parameter are made!)
-		if (!genDecl.typeVars.empty) {
-			val staticAccess = genDecl instanceof N4MemberDeclaration && (genDecl as N4MemberDeclaration).static;
-			val scope = n4jsScopeProvider.getTypeScope( // note: calling #getTypeScope() here, NOT #getScope()!
+			// TODO reconsider this warning or its implementation; re-generating the scope can become quite expensive
+			// (but note that moving this to the scoping code is not trivial, because warning has to be generated also
+			// if not references to the type parameter are made!)
+			if (!genDecl.typeVars.empty) {
+				val staticAccess = genDecl instanceof N4MemberDeclaration && (genDecl as N4MemberDeclaration).static;
+				val scope = n4jsScopeProvider.getTypeScope( // note: calling #getTypeScope() here, NOT #getScope()!
 				genDecl.eContainer, // use container, because we do not want to see type variables we are currently validating
 				TypeRefsPackage.eINSTANCE.parameterizedTypeRef_DeclaredType, // provide any reference that expects instances of Type as target objects
 				staticAccess);
-			genDecl.typeVars.forEach [
-				if (!it.name.nullOrEmpty) {
-					val hiddenTypeDscr = scope.getSingleElement(QualifiedName.create(it.name));
-					val hiddenType = hiddenTypeDscr?.getEObjectOrProxy;
-					if (hiddenType instanceof Type && !(AbstractDescriptionWithError.isErrorDescription_XTEND_MVN_BUG_HACK(hiddenTypeDscr))) {
-						val message = getMessageForVIS_TYPE_PARAMETER_HIDES_TYPE(name, hiddenType.keyword);
-						addIssue(message, it, VIS_TYPE_PARAMETER_HIDES_TYPE);
+				genDecl.typeVars.forEach [
+					if (!it.name.nullOrEmpty) {
+						val hiddenTypeDscr = scope.getSingleElement(QualifiedName.create(it.name));
+						val hiddenType = hiddenTypeDscr?.getEObjectOrProxy;
+						if (hiddenType instanceof Type &&
+							!(AbstractDescriptionWithError.isErrorDescription_XTEND_MVN_BUG_HACK(hiddenTypeDscr))) {
+							val message = getMessageForVIS_TYPE_PARAMETER_HIDES_TYPE(name, hiddenType.keyword);
+							addIssue(message, it, VIS_TYPE_PARAMETER_HIDES_TYPE);
+						}
 					}
-				}
-			]
+				]
+			}
 		}
-	}
 
-	/**
-	 * This handles a special case that is not checked by method {@link #checkTypeMatchesExpectedType(Expression)}.
-	 * In a compound assignment like += or *=, the left-hand side is both read from and written to. So we have
-	 * to check 1) that the type for write access is correct and 2) the type of read access is correct. Usually
-	 * these two types are the same, but in case of a getter/setter pair they can be different and need to be
-	 * checked individually. Case 1) is taken care of by method {@link #checkTypeMatchesExpectedType(Expression)}.
-	 * Case 2) is checked here in this method.
-	 */
-	@Check
-	def void checkCompoundAssignmentGetterSetterClashOnLhs(AssignmentExpression assExpr) {
-		if (assExpr.op === null || assExpr.op === AssignmentOperator.ASSIGN)
-			return; // following code is only required for compound assignments, i.e. +=, *=, etc.; not for =
+		/**
+		 * This handles a special case that is not checked by method {@link #checkTypeMatchesExpectedType(Expression)}.
+		 * In a compound assignment like += or *=, the left-hand side is both read from and written to. So we have
+		 * to check 1) that the type for write access is correct and 2) the type of read access is correct. Usually
+		 * these two types are the same, but in case of a getter/setter pair they can be different and need to be
+		 * checked individually. Case 1) is taken care of by method {@link #checkTypeMatchesExpectedType(Expression)}.
+		 * Case 2) is checked here in this method.
+		 */
+		@Check
+		def void checkCompoundAssignmentGetterSetterClashOnLhs(AssignmentExpression assExpr) {
+			if (assExpr.op === null || assExpr.op === AssignmentOperator.ASSIGN)
+				return; // following code is only required for compound assignments, i.e. +=, *=, etc.; not for =
+			val Expression lhs = assExpr.lhs;
+			if (lhs instanceof ParameterizedPropertyAccessExpression) {
+				val prop = lhs.property;
 
-		val Expression lhs = assExpr.lhs;
-		if (lhs instanceof ParameterizedPropertyAccessExpression) {
-			val prop = lhs.property;
+				// in case of a getter/setter pair, scoping will here always give us the setter as property,
+				// because we are on the left-hand side of an assignment (i.e. write access)
+				if (prop instanceof TSetter) {
 
-			// in case of a getter/setter pair, scoping will here always give us the setter as property,
-			// because we are on the left-hand side of an assignment (i.e. write access)
-			if (prop instanceof TSetter) {
+					// ok, we have the situation we are interested in (setter on LHS of compound assignment)
+					// --> now check if there is a matching getter of correct type
+					val TSetter setter = prop;
+					val Type targetType = ts.tau(lhs.target)?.declaredType;
+					if (targetType instanceof ContainerType<?>) {
+						val TMember m = containerTypesHelper.fromContext(assExpr).findMember(targetType, setter.name,
+							false, setter.static);
+						if (m === null) {
 
-				// ok, we have the situation we are interested in (setter on LHS of compound assignment)
-				// --> now check if there is a matching getter of correct type
-				val TSetter setter = prop;
-				val Type targetType = ts.tau(lhs.target)?.declaredType;
-				if (targetType instanceof ContainerType<?>) {
-					val TMember m = containerTypesHelper.fromContext(assExpr).findMember(targetType, setter.name, false, setter.static);
-					if (m === null) {
+							// no getter at all
+							val message = messageForTYS_COMPOUND_MISSING_GETTER
+							addIssue(message, assExpr.lhs, TYS_COMPOUND_MISSING_GETTER);
+						} else if (m instanceof TGetter) {
+							val TGetter getter = m;
+							var G = assExpr.newRuleEnvironment;
 
-						// no getter at all
-						val message = messageForTYS_COMPOUND_MISSING_GETTER
-						addIssue(message, assExpr.lhs, TYS_COMPOUND_MISSING_GETTER);
-					} else if (m instanceof TGetter) {
-						val TGetter getter = m;
-						var G = assExpr.newRuleEnvironment;
-
-						// must use .rhs in next line, because .lhs would give us the expected type for write access
-						// (which is already checked by the generic method #checkTypeMatchesExpectedType()
-						val expectedType = ts.expectedTypeIn(G, assExpr, assExpr.rhs).value;
-						val TypeRef typeOfGetterRAW = TypeUtils.getMemberTypeRef(getter);
-						if (expectedType !== null && typeOfGetterRAW !== null) {
-							val TypeRef typeOfGetter = ts.substTypeVariablesInTypeRef(G, typeOfGetterRAW);
-							if (typeOfGetter !== null) {
-								val result = ts.subtype(G, typeOfGetter, expectedType);
-								createError(result, assExpr.lhs);
+							// must use .rhs in next line, because .lhs would give us the expected type for write access
+							// (which is already checked by the generic method #checkTypeMatchesExpectedType()
+							val expectedType = ts.expectedTypeIn(G, assExpr, assExpr.rhs).value;
+							val TypeRef typeOfGetterRAW = TypeUtils.getMemberTypeRef(getter);
+							if (expectedType !== null && typeOfGetterRAW !== null) {
+								val TypeRef typeOfGetter = ts.substTypeVariablesInTypeRef(G, typeOfGetterRAW);
+								if (typeOfGetter !== null) {
+									val result = ts.subtype(G, typeOfGetter, expectedType);
+									createError(result, assExpr.lhs);
+								}
 							}
 						}
 					}
 				}
 			}
 		}
-	}
 
-	@Check
-	def void checkInconsistentInterfaceImplementationOrExtension(N4ClassifierDeclaration classifierDecl) {
-		val tClassifier = classifierDecl.definedType as TClassifier;
-		if(tClassifier===null)
-			return; // broken AST
-		val G = newRuleEnvironment(classifierDecl);
-		G.recordInconsistentSubstitutions;
-		tClassifier.superClassifierRefs.forEach[tsh.addSubstitutions(G, it)];
-		for(tv : G.getTypeMappingKeys()) {
-			if(!tv.declaredCovariant && !tv.declaredContravariant) {
-				val subst = ts.substTypeVariables(G, TypeUtils.createTypeRef(tv)).value;
-				if(subst instanceof UnknownTypeRef) {
-					val badSubst = G.getInconsistentSubstitutions(tv);
-					if(!badSubst.empty) {
-						if(!tsh.allEqualType(G, badSubst)) {
-							val mode = if(tClassifier instanceof TClass) "implement" else "extend";
-							val ifcName = (tv.eContainer as TInterface).name;
-							val tvName = "invariant " + tv.name;
-							val typeRefsStr = badSubst.map[typeRefAsString].join(", ");
-							val message = getMessageForCLF_IMPLEMENT_EXTEND_SAME_INTERFACE_INCONSISTENTLY(mode, ifcName, tvName, typeRefsStr);
-							addIssue(message, classifierDecl, N4JSPackage.eINSTANCE.n4TypeDeclaration_Name,
-								CLF_IMPLEMENT_EXTEND_SAME_INTERFACE_INCONSISTENTLY);
+		@Check
+		def void checkInconsistentInterfaceImplementationOrExtension(N4ClassifierDeclaration classifierDecl) {
+			val tClassifier = classifierDecl.definedType as TClassifier;
+			if (tClassifier === null)
+				return; // broken AST
+			val G = newRuleEnvironment(classifierDecl);
+			G.recordInconsistentSubstitutions;
+			tClassifier.superClassifierRefs.forEach[tsh.addSubstitutions(G, it)];
+			for (tv : G.getTypeMappingKeys()) {
+				if (!tv.declaredCovariant && !tv.declaredContravariant) {
+					val subst = ts.substTypeVariables(G, TypeUtils.createTypeRef(tv)).value;
+					if (subst instanceof UnknownTypeRef) {
+						val badSubst = G.getInconsistentSubstitutions(tv);
+						if (!badSubst.empty) {
+							if (!tsh.allEqualType(G, badSubst)) {
+								val mode = if (tClassifier instanceof TClass) "implement" else "extend";
+								val ifcName = (tv.eContainer as TInterface).name;
+								val tvName = "invariant " + tv.name;
+								val typeRefsStr = badSubst.map[typeRefAsString].join(", ");
+								val message = getMessageForCLF_IMPLEMENT_EXTEND_SAME_INTERFACE_INCONSISTENTLY(mode,
+									ifcName, tvName, typeRefsStr);
+								addIssue(message, classifierDecl, N4JSPackage.eINSTANCE.n4TypeDeclaration_Name,
+									CLF_IMPLEMENT_EXTEND_SAME_INTERFACE_INCONSISTENTLY);
+							}
 						}
 					}
 				}
 			}
 		}
-	}
 
-	/**
-	 * This tests ALL expressions, including expressions used on right hand side of assignments or property definitions. That is,
-	 * there is no need to test field declarations or property declarations separately, as this will lead to duplicate error
-	 * messages.
-	 */
-	@Check
-	def void checkTypeMatchesExpectedType(Expression expression) {
+		/**
+		 * This tests ALL expressions, including expressions used on right hand side of assignments or property definitions. That is,
+		 * there is no need to test field declarations or property declarations separately, as this will lead to duplicate error
+		 * messages.
+		 */
+		@Check
+		def void checkTypeMatchesExpectedType(Expression expression) {
 
-		if(!jsVariantHelper.requireCheckTypeMatchesExpectedType(expression)) {
-			return;
-		}
+			if (!jsVariantHelper.requireCheckTypeMatchesExpectedType(expression)) {
+				return;
+			}
 
-		// expressionAnnotationList occur on function- and class-expressions.
-		// checking of the content is done in N4JSAnnotationValidation
-		if (expression instanceof ExpressionAnnotationList) {
-			return
-		}
+			// expressionAnnotationList occur on function- and class-expressions.
+			// checking of the content is done in N4JSAnnotationValidation
+			if (expression instanceof ExpressionAnnotationList) {
+				return
+			}
 
-		var G = expression.newRuleEnvironment;
-		val inferredType = ts.type(G, expression);
-		if (createError(inferredType, expression)) {
-			return;
-		}
+			var G = expression.newRuleEnvironment;
+			val inferredType = ts.type(G, expression);
+			if (createError(inferredType, expression)) {
+				return;
+			}
 
-		// use a fresh environment for expectations
-		G = newRuleEnvironment(expression);
+			// use a fresh environment for expectations
+			G = newRuleEnvironment(expression);
 
-		val expectedType = ts.expectedTypeIn(G, expression.eContainer, expression);
-		if (expectedType.value !== null) {
+			val expectedType = ts.expectedTypeIn(G, expression.eContainer, expression);
+			if (expectedType.value !== null) {
 
-			// for certain problems in single-expression arrow functions, we want a special error message
-			val singleExprArrowFunction = N4JSASTUtils.getContainingSingleExpressionArrowFunction(expression);
-			if (singleExprArrowFunction!==null && TypeUtils.isVoid(inferredType.value)) {
-				if (TypeUtils.isVoid(expectedType.value) || singleExprArrowFunction.isReturnValueOptional) {
-					return; // all good
-				}
-				if(singleExprArrowFunction.returnTypeRef===null) { // show specialized error message only if return type of arrow function was inferred (i.e. not declared explicitly)
-					val message = IssueCodes.getMessageForFUN_SINGLE_EXP_LAMBDA_IMPLICIT_RETURN_ALLOWED_UNLESS_VOID();
-					addIssue(message, expression,
+				val expectedTyeRef = expectedType.value;
+
+				// for certain problems in single-expression arrow functions, we want a special error message
+				val singleExprArrowFunction = N4JSASTUtils.getContainingSingleExpressionArrowFunction(expression);
+				if (singleExprArrowFunction !== null && TypeUtils.isVoid(inferredType.value)) {
+					if (TypeUtils.isVoid(expectedTyeRef) || singleExprArrowFunction.isReturnValueOptional) {
+						return; // all good
+					}
+					if (singleExprArrowFunction.returnTypeRef === null) { // show specialized error message only if return type of arrow function was inferred (i.e. not declared explicitly)
+						val message = IssueCodes.
+							getMessageForFUN_SINGLE_EXP_LAMBDA_IMPLICIT_RETURN_ALLOWED_UNLESS_VOID();
+						addIssue(message, expression,
 							IssueCodes.FUN_SINGLE_EXP_LAMBDA_IMPLICIT_RETURN_ALLOWED_UNLESS_VOID);
-					return;
+						return;
+					}
 				}
-			}
 
-			internalCheckUseOfUndefinedExpression(G, expression, expectedType.value, inferredType.value);
+				internalCheckUseOfUndefinedExpression(G, expression, expectedTyeRef, inferredType.value);
 
-			val boolean writeAccess = ExpressionExtensions.isLeftHandSide(expression);
-			if (writeAccess) {
+				val boolean writeAccess = ExpressionExtensions.isLeftHandSide(expression);
+				if (writeAccess) {
 
-				// special case: write access
-				val result = ts.subtype(G, expectedType.value, inferredType.value);
+					// special case: write access
+					val result = ts.subtype(G, expectedTyeRef, inferredType.value);
 
-				if (result.failed) {
-					// use custom error message, because otherwise it will be completely confusing
-					val message = getMessageForTYS_NO_SUPERTYPE_WRITE_ACCESS(expectedType.value.typeRefAsString,
-						inferredType.value.typeRefAsString);
-					addIssue(message, expression, TYS_NO_SUPERTYPE_WRITE_ACCESS)
-				}
-			} else {
+					if (result.failed) {
+						// use custom error message, because otherwise it will be completely confusing
+						val message = getMessageForTYS_NO_SUPERTYPE_WRITE_ACCESS(expectedTyeRef.typeRefAsString,
+							inferredType.value.typeRefAsString);
+						addIssue(message, expression, TYS_NO_SUPERTYPE_WRITE_ACCESS)
+					}
+				} else {
 
-				// standard case: read access
-				val result = ts.subtype(G, inferredType.value, expectedType.value)
-				// not working, as primitive types are not part of currently validated resource:
-				// errorGenerator.generateErrors(this, result, expression)
-				// so we create error here differently:
-				createError(result, expression)
-			}
-		}
-	}
+					// standard case: read access
+					val result = ts.subtype(G, inferredType.value, expectedTyeRef)
+					// not working, as primitive types are not part of currently validated resource:
+					// errorGenerator.generateErrors(this, result, expression)
+					// so we create error here differently:
+					val errorCreated = createError(result, expression)
 
-	def private void internalCheckUseOfUndefinedExpression(RuleEnvironment G, Expression expression, TypeRef expectedTypeRef, TypeRef actualTypeRef) {
-		if(TypeUtils.isUndefined(actualTypeRef) && !TypeUtils.isUndefined(expectedTypeRef)) {
-			val parent = expression.eContainer;
-			if(!(parent instanceof ExpressionStatement)
-				&& !(parent instanceof UnaryExpression && (parent as UnaryExpression).op===UnaryOperator.VOID)
-				&& !(expression instanceof UnaryExpression && (expression as UnaryExpression).op===UnaryOperator.VOID)
-				&& !(expression instanceof ThisLiteral)) {
-
-				val undefinedField = G.globalObjectType.findOwnedMember("undefined", false, false) as TField;
-				val isUndefinedLiteral = if(expression instanceof IdentifierRef) expression.id===undefinedField;
-				if(!isUndefinedLiteral) {
-					addIssue(getMessageForEXP_USE_OF_UNDEF_EXPR, expression, EXP_USE_OF_UNDEF_EXPR);
+					if (! errorCreated && expression instanceof ObjectLiteral) {
+						internalCheckSuperfluousPropertiesInObjectLiteral(expectedTyeRef, expression as ObjectLiteral);
+					}
 				}
 			}
 		}
-	}
+		
+	 /**
+	 * #225: always check for superfluous properties in object literal
+	 * req-id IDE-22501
+	 */
+	def void internalCheckSuperfluousPropertiesInObjectLiteral(TypeRef typeRef, ObjectLiteral objectLiteral) {
+		val typingStrategy = typeRef.typingStrategy;
+		if (typingStrategy != TypingStrategy.NOMINAL && typingStrategy != TypingStrategy.DEFAULT) {
+			if (typeRef.isDynamic) {
+				return;
+			}
 
-	@Check
-	def void checkBogusTypeReference(TypedElement te) {
-		if(te.bogusTypeRef !== null) {
-			addIssue(IssueCodes.getMessageForTYS_INVALID_TYPE_SYNTAX, te.bogusTypeRef, TYS_INVALID_TYPE_SYNTAX);
+			var type = typeRef.declaredType;
+			if (type===null && typeRef instanceof BoundThisTypeRef) {
+				type = (typeRef as BoundThisTypeRef).actualThisTypeRef?.declaredType;
+			}
+			if (! (type instanceof ContainerType<?>)) {
+				return;
+			}
+
+			val G = RuleEnvironmentExtensions.newRuleEnvironment(objectLiteral);
+			val structuralMembers = typeRef.structuralMembers;
+			if (structuralMembers.isEmpty && type == RuleEnvironmentExtensions.objectType(G)) {
+				return;
+			}
+
+			val strategyFilter = new TypingStrategyFilter(typingStrategy);
+			val expectedMembers = containerTypesHelper.fromContext(objectLiteral).allMembers(
+				type as ContainerType<?>).filter[member|strategyFilter.apply(member)].map[member|member.name].
+				toSet();
+
+			// These are available via the 'with' keyword add them to the accepted ones
+			typeRef.structuralMembers.forEach[member|expectedMembers.add(member.name)];
+
+			val inputMembers = (objectLiteral.definedType as ContainerType<?>).ownedMembers;
+			for (property : inputMembers) {
+				if (!expectedMembers.contains(property.name)) {
+					var astElement = property.astElement;
+					if (astElement instanceof PropertyNameValuePair) {
+						astElement = astElement.declaredName;
+					}
+					val message = getMessageForCLF_SPEC_SUPERFLUOUS_PROPERTIES(property.name,
+						typeRef.typeRefAsString);
+					addIssue(message, astElement, CLF_SPEC_SUPERFLUOUS_PROPERTIES);
+				}
+			};
 		}
 	}
+		
+
+
+		def private void internalCheckUseOfUndefinedExpression(RuleEnvironment G, Expression expression,
+			TypeRef expectedTypeRef, TypeRef actualTypeRef) {
+			if (TypeUtils.isUndefined(actualTypeRef) && !TypeUtils.isUndefined(expectedTypeRef)) {
+				val parent = expression.eContainer;
+				if (!(parent instanceof ExpressionStatement) &&
+					!(parent instanceof UnaryExpression && (parent as UnaryExpression).op === UnaryOperator.VOID) &&
+					!(expression instanceof UnaryExpression &&
+						(expression as UnaryExpression).op === UnaryOperator.VOID) &&
+					!(expression instanceof ThisLiteral)) {
+
+						val undefinedField = G.globalObjectType.findOwnedMember("undefined", false, false) as TField;
+						val isUndefinedLiteral = if (expression instanceof IdentifierRef)
+								expression.id === undefinedField;
+						if (!isUndefinedLiteral) {
+							addIssue(getMessageForEXP_USE_OF_UNDEF_EXPR, expression, EXP_USE_OF_UNDEF_EXPR);
+						}
+					}
+				}
+			}
+
+			@Check
+			def void checkBogusTypeReference(TypedElement te) {
+				if (te.bogusTypeRef !== null) {
+					addIssue(IssueCodes.getMessageForTYS_INVALID_TYPE_SYNTAX, te.bogusTypeRef, TYS_INVALID_TYPE_SYNTAX);
+				}
+			}
 
 //  TODO IDE-1010 Code-snippet with partial solution
 //	@Check
@@ -576,137 +641,132 @@ class N4JSTypeValidator extends AbstractN4JSDeclarativeValidator {
 //		}
 //
 //	}
+			def boolean createError(Result<?> result, EObject source) {
+				if (result.failed) {
+					errorGenerator.generateErrors(getMessageAcceptor(), result, source);
+					return true;
+				}
+				false;
+			}
 
+			/**
+			 * This validates a warning in chapter 4.10.1:<br/>
+			 * <i>The use of the any type in a union type produces a warning.</i>
+			 */
+			@Check
+			def void checkUnionTypeContainsNoAny(UnionTypeExpression ute) {
+				checkComposedTypeRefContainsNoAny(ute, messageForUNI_ANY_USED, UNI_ANY_USED, true);
+			}
 
-	def boolean createError(Result<?> result, EObject source) {
-		if (result.failed) {
-			errorGenerator.generateErrors(getMessageAcceptor(), result, source);
-			return true;
-		}
-		false;
-	}
+			/**
+			 * This validates a warning in chapter 4.10.2:<br/>
+			 * <i>The use of the any type in an intersection type produces a warning.</i>
+			 */
+			@Check
+			def void checkIntersectionTypeContainsNoAny(IntersectionTypeExpression ite) {
+				checkComposedTypeRefContainsNoAny(ite, messageForINTER_ANY_USED, INTER_ANY_USED, false);
+			}
 
+			def private void checkComposedTypeRefContainsNoAny(ComposedTypeRef ctr, String msg, String issueCode,
+				boolean soleVoidAllowesAny) {
+				val G = ctr.newRuleEnvironment;
+				val anyType = G.anyType;
+				val voidType = G.voidType;
+				val EList<TypeRef> typeRefs = ctr.getTypeRefs();
+				val Iterable<TypeRef> anyTypeRefs = typeRefs.filter[it.getDeclaredType() === anyType]; // identity check on typeRefs is OK here
+				var boolean dontShowWarning = false;
+				if (soleVoidAllowesAny) {
+					val boolean containsVoid = typeRefs.exists[it.getDeclaredType() === voidType]; // identity check on typeRefs is OK here
+					dontShowWarning = containsVoid && anyTypeRefs.size() == 1;
+				}
 
-	/**
-	 * This validates a warning in chapter 4.10.1:<br/>
-	 * <i>The use of the any type in a union type produces a warning.</i>
-	 */
-	@Check
-	def void checkUnionTypeContainsNoAny(UnionTypeExpression ute) {
-		checkComposedTypeRefContainsNoAny(ute, messageForUNI_ANY_USED, UNI_ANY_USED, true);
-	}
+				if (!dontShowWarning) {
+					for (TypeRef anyTR : anyTypeRefs) {
+						addIssue(msg, anyTR, issueCode);
+					}
+				}
+			}
 
+			/**
+			 * This validates a warning in chapter 4.10.1:<br/>
+			 * <i>The use of unnecessary subtypes in union types produces a warning.</i>
+			 */
+			@Check
+			def void checkUnionHasUnnecessarySubtype(UnionTypeExpression ute) {
+				val List<TypeRef> tRefs = extractNonStructTypeRefs(ute);
+				val G = ute.newRuleEnvironment;
+				val anyType = G.anyType;
+				tRefs.removeIf[it.getDeclaredType === anyType]; // identity check on typeRefs is OK here
+				if (tRefs.size() > 1) {
+					val List<TypeRef> intersectionTR = tsh.getSuperTypesOnly(G, tRefs);
+					tRefs.removeAll(intersectionTR);
 
-	/**
-	 * This validates a warning in chapter 4.10.2:<br/>
-	 * <i>The use of the any type in an intersection type produces a warning.</i>
-	 */
-	@Check
-	def void checkIntersectionTypeContainsNoAny(IntersectionTypeExpression ite) {
-		checkComposedTypeRefContainsNoAny(ite, messageForINTER_ANY_USED, INTER_ANY_USED, false);
-	}
+					for (TypeRef tClassR : tRefs) {
+						val message = messageForUNI_REDUNDANT_SUBTYPE;
+						addIssue(message, tClassR, UNI_REDUNDANT_SUBTYPE);
+					}
+				}
+			}
 
-	def private void checkComposedTypeRefContainsNoAny(ComposedTypeRef ctr, String msg, String issueCode, boolean soleVoidAllowesAny) {
-		val G = ctr.newRuleEnvironment;
-		val anyType = G.anyType;
-		val voidType = G.voidType;
-		val EList<TypeRef> typeRefs = ctr.getTypeRefs();
-		val Iterable<TypeRef> anyTypeRefs = typeRefs.filter[it.getDeclaredType()===anyType]; // identity check on typeRefs is OK here
+			/**
+			 * Entry method for validating the containing types of an intersection type.
+			 */
+			@Check
+			def void checkIntersectionType(IntersectionTypeExpression ite) {
+				val List<TypeRef> tClassRefs = extractNonStructTypeRefs(ite);
 
-		var boolean dontShowWarning = false;
-		if (soleVoidAllowesAny) {
-			val boolean containsVoid = typeRefs.exists[it.getDeclaredType()===voidType]; // identity check on typeRefs is OK here
-			dontShowWarning = containsVoid && anyTypeRefs.size() == 1;
-		}
+				if (tClassRefs.size() > 1) {
+					val G = ite.newRuleEnvironment;
+					val List<TypeRef> intersectionTR = tsh.getSubtypesOnly(G, tClassRefs);
 
-		if (!dontShowWarning) {
-			for (TypeRef anyTR : anyTypeRefs) {
-				addIssue(msg, anyTR, issueCode);
+					checkIntersectionTypeContainsMaxOneClass(ite, G, tClassRefs, intersectionTR);
+					checkIntersectionHasUnnecessarySupertype(ite, G, tClassRefs, intersectionTR);
+				}
+			}
+
+			/**
+			 * This validates constraint 25.2 ("Intersection Type") in chapter 4.10.2:<br/>
+			 * <i>Only one class must be contained in the intersection type.</i><br/><br/>
+			 * Currently, only a warning is displayed.
+			 */
+			def private void checkIntersectionTypeContainsMaxOneClass(IntersectionTypeExpression ite, RuleEnvironment G,
+				List<TypeRef> tClassRefs, List<TypeRef> intersectionTR) {
+				if (intersectionTR.size() > 1) {
+					for (TypeRef tClassR : intersectionTR) {
+						val message = messageForINTER_ONLY_ONE_CLASS_ALLOWED;
+						addIssue(message, tClassR, INTER_ONLY_ONE_CLASS_ALLOWED);
+					}
+				}
+			}
+
+			/**
+			 * This validates a warning in chapter 4.10.2:<br/>
+			 * <i>The use of unnecessary supertypes in intersection types produces a warning.</i>
+			 */
+			def private void checkIntersectionHasUnnecessarySupertype(IntersectionTypeExpression ite, RuleEnvironment G,
+				List<TypeRef> tClassRefs, List<TypeRef> intersectionTR) {
+				tClassRefs.removeAll(intersectionTR);
+
+				for (TypeRef tClassR : tClassRefs) {
+					val message = messageForINTER_REDUNDANT_SUPERTYPE;
+					addIssue(message, tClassR, INTER_REDUNDANT_SUPERTYPE);
+				}
+			}
+
+			def private List<TypeRef> extractNonStructTypeRefs(ComposedTypeRef ctr) {
+				val List<TypeRef> tClassRefs = new LinkedList();
+				val G = ctr.newRuleEnvironment;
+				val List<TypeRef> tRefs = tsh.getSimplifiedTypeRefs(G, ctr);
+
+				for (TypeRef tR : tRefs) {
+					val Type type = tR.getDeclaredType();
+					if (type instanceof TClass) {
+						var isStructural = tR.isDefSiteStructuralTyping() || tR.isUseSiteStructuralTyping();
+						if (!isStructural)
+							tClassRefs.add(tR);
+					}
+				}
+				return tClassRefs;
 			}
 		}
-	}
-
-
-	/**
-	 * This validates a warning in chapter 4.10.1:<br/>
-	 * <i>The use of unnecessary subtypes in union types produces a warning.</i>
-	 */
-	@Check
-	def void checkUnionHasUnnecessarySubtype(UnionTypeExpression ute) {
-		val List<TypeRef> tRefs = extractNonStructTypeRefs(ute);
-		val G = ute.newRuleEnvironment;
-		val anyType = G.anyType;
-		tRefs.removeIf[it.getDeclaredType === anyType]; // identity check on typeRefs is OK here
-
-		if (tRefs.size() > 1) {
-			val List<TypeRef> intersectionTR = tsh.getSuperTypesOnly(G, tRefs);
-			tRefs.removeAll(intersectionTR);
-
-			for (TypeRef tClassR : tRefs) {
-				val message = messageForUNI_REDUNDANT_SUBTYPE;
-				addIssue(message, tClassR, UNI_REDUNDANT_SUBTYPE);
-			}
-		}
-	}
-
-
-	/**
-	 * Entry method for validating the containing types of an intersection type.
-	 */
-	@Check
-	def void checkIntersectionType(IntersectionTypeExpression ite) {
-		val List<TypeRef> tClassRefs = extractNonStructTypeRefs(ite);
-
-		if (tClassRefs.size() > 1) {
-			val G = ite.newRuleEnvironment;
-			val List<TypeRef> intersectionTR = tsh.getSubtypesOnly(G, tClassRefs);
-
-			checkIntersectionTypeContainsMaxOneClass(ite, G, tClassRefs, intersectionTR);
-			checkIntersectionHasUnnecessarySupertype(ite, G, tClassRefs, intersectionTR);
-		}
-	}
-
-	/**
-	 * This validates constraint 25.2 ("Intersection Type") in chapter 4.10.2:<br/>
-	 * <i>Only one class must be contained in the intersection type.</i><br/><br/>
-	 * Currently, only a warning is displayed.
-	 */
-	def private void checkIntersectionTypeContainsMaxOneClass(IntersectionTypeExpression ite, RuleEnvironment G, List<TypeRef> tClassRefs, List<TypeRef> intersectionTR) {
-		if (intersectionTR.size() > 1) {
-			for (TypeRef tClassR : intersectionTR) {
-				val message = messageForINTER_ONLY_ONE_CLASS_ALLOWED;
-				addIssue(message, tClassR, INTER_ONLY_ONE_CLASS_ALLOWED);
-			}
-		}
-	}
-
-	/**
-	 * This validates a warning in chapter 4.10.2:<br/>
-	 * <i>The use of unnecessary supertypes in intersection types produces a warning.</i>
-	 */
-	def private void checkIntersectionHasUnnecessarySupertype(IntersectionTypeExpression ite, RuleEnvironment G, List<TypeRef> tClassRefs, List<TypeRef> intersectionTR) {
-		tClassRefs.removeAll(intersectionTR);
-
-		for (TypeRef tClassR : tClassRefs) {
-			val message = messageForINTER_REDUNDANT_SUPERTYPE;
-			addIssue(message, tClassR, INTER_REDUNDANT_SUPERTYPE);
-		}
-	}
-
-
-	def private List<TypeRef> extractNonStructTypeRefs(ComposedTypeRef ctr) {
-		val List<TypeRef> tClassRefs = new LinkedList();
-		val G = ctr.newRuleEnvironment;
-		val List<TypeRef> tRefs = tsh.getSimplifiedTypeRefs(G, ctr);
-
-		for (TypeRef tR : tRefs) {
-			val Type type = tR.getDeclaredType();
-			if (type instanceof TClass) {
-				var isStructural = tR.isDefSiteStructuralTyping() || tR.isUseSiteStructuralTyping();
-				if (!isStructural)
-					tClassRefs.add(tR);
-			}
-		}
-		return tClassRefs;
-	}
-}
+		

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSTypeValidator.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSTypeValidator.xtend
@@ -133,7 +133,7 @@ class N4JSTypeValidator extends AbstractN4JSDeclarativeValidator {
 	 * Raises validation error for each type variable if any of their declared upper bound is a primitive type.
 	 * <p>
 	 * IDEBUG-185
-	 * 
+	 *
 	 * @param declaration the generic declaration to check the upper bound declarations of its type variables.
 	 */
 	@Check
@@ -253,265 +253,264 @@ class N4JSTypeValidator extends AbstractN4JSDeclarativeValidator {
 			// is not the job of this validation)
 			return;
 		}
-		if (!(thisTypeRef.isUsedStructurallyAsFormalParametersInTheConstructor ||
-			thisTypeRef.isUsedAtCovariantPositionInClassifierDeclaration ||
-			thisTypeRef.isUsedInVariableWithSyntaxError)) {
+		if (!(thisTypeRef.isUsedStructurallyAsFormalParametersInTheConstructor 
+			|| thisTypeRef.isUsedAtCovariantPositionInClassifierDeclaration 
+			|| thisTypeRef.isUsedInVariableWithSyntaxError)) {
+			addIssue(IssueCodes.getMessageForAST_THIS_WRONG_PLACE, thisTypeRef, IssueCodes.AST_THIS_WRONG_PLACE);
+		}
+	}
 
-				addIssue(IssueCodes.getMessageForAST_THIS_WRONG_PLACE, thisTypeRef, IssueCodes.AST_THIS_WRONG_PLACE);
+	def private boolean isUsedStructurallyAsFormalParametersInTheConstructor(ThisTypeRef thisTypeRef) {
+		if (thisTypeRef.useSiteStructuralTyping) {
+			val methodOrConstructor = thisTypeRef?.eContainer?.eContainer;
+			if (methodOrConstructor instanceof N4MethodDeclaration) {
+				if (methodOrConstructor !== null && methodOrConstructor.isConstructor) {
+					return true
+				}
 			}
 		}
+		return false
+	}
 
-		def private boolean isUsedStructurallyAsFormalParametersInTheConstructor(ThisTypeRef thisTypeRef) {
-			if (thisTypeRef.useSiteStructuralTyping) {
-				val methodOrConstructor = thisTypeRef?.eContainer?.eContainer;
-				if (methodOrConstructor instanceof N4MethodDeclaration) {
-					if (methodOrConstructor !== null && methodOrConstructor.isConstructor) {
-						return true
+	def private boolean isUsedAtCovariantPositionInClassifierDeclaration(ThisTypeRef thisTypeRef) {
+		val classifierDecl = EcoreUtil2.getContainerOfType(thisTypeRef, N4ClassifierDeclaration);
+		if (classifierDecl !== null) {
+			// exception: disallow for static members of interfaces
+			if (classifierDecl instanceof N4InterfaceDeclaration) {
+				val memberDecl = EcoreUtil2.getContainerOfType(thisTypeRef, N4MemberDeclaration);
+				if (memberDecl !== null && memberDecl.static) {
+					return false;
+				}
+			}
+			val varianceOfPos = N4JSLanguageUtils.getVarianceOfPosition(thisTypeRef);
+			if (varianceOfPos !== null) {
+				return varianceOfPos === Variance.CO;
+			}
+		}
+		return false;
+	}
+
+	private def boolean isUsedInVariableWithSyntaxError(ThisTypeRef ref) {
+		val container = ref.eContainer
+		if (container instanceof VariableDeclaration) {
+			return container.name === null
+		}
+		return false
+	}
+
+	@Check
+	def checkSymbolReference(TypeRef typeRef) {
+		var bits = BuiltInTypeScope.get(typeRef?.eResource.resourceSet);
+		if (typeRef.declaredType === bits.symbolObjectType) {
+			// we have a type reference to 'Symbol'
+			// -> the only allowed case is as target/receiver of a property access (i.e.: Symbol.iterator)
+			val parent = typeRef.eContainer;
+			if (!(parent instanceof ParameterizedPropertyAccessExpression) ||
+				(parent as ParameterizedPropertyAccessExpression).target !== typeRef) {
+				addIssue(IssueCodes.getMessageForBIT_SYMBOL_INVALID_USE, typeRef, BIT_SYMBOL_INVALID_USE);
+			}
+		}
+	}
+
+	/*
+	 * Constraints 08: primitive types except any must not be declared dynamic
+	 */
+	def internalCheckDynamic(ParameterizedTypeRef ref) {
+		if (ref.dynamic) {
+			val Type t = ref.declaredType;
+			if (t instanceof PrimitiveType && ! (t instanceof AnyType)) {
+				addIssue(IssueCodes.getMessageForTYS_PRIMITIVE_TYPE_DYNAMIC(t.name), ref,
+					TYS_PRIMITIVE_TYPE_DYNAMIC);
+			}
+		}
+	}
+
+	@Check
+	def checkTypeHiddenByTypeVariable(GenericDeclaration genDecl) {
+
+		// TODO reconsider this warning or its implementation; re-generating the scope can become quite expensive
+		// (but note that moving this to the scoping code is not trivial, because warning has to be generated also
+		// if not references to the type parameter are made!)
+		if (!genDecl.typeVars.empty) {
+			val staticAccess = genDecl instanceof N4MemberDeclaration && (genDecl as N4MemberDeclaration).static;
+			val scope = n4jsScopeProvider.getTypeScope( // note: calling #getTypeScope() here, NOT #getScope()!
+			genDecl.eContainer, // use container, because we do not want to see type variables we are currently validating
+			TypeRefsPackage.eINSTANCE.parameterizedTypeRef_DeclaredType, // provide any reference that expects instances of Type as target objects
+			staticAccess);
+			genDecl.typeVars.forEach [
+				if (!it.name.nullOrEmpty) {
+					val hiddenTypeDscr = scope.getSingleElement(QualifiedName.create(it.name));
+					val hiddenType = hiddenTypeDscr?.getEObjectOrProxy;
+					if (hiddenType instanceof Type &&
+						!(AbstractDescriptionWithError.isErrorDescription_XTEND_MVN_BUG_HACK(hiddenTypeDscr))) {
+						val message = getMessageForVIS_TYPE_PARAMETER_HIDES_TYPE(name, hiddenType.keyword);
+						addIssue(message, it, VIS_TYPE_PARAMETER_HIDES_TYPE);
 					}
 				}
-			}
-			return false
+			]
 		}
+	}
 
-		def private boolean isUsedAtCovariantPositionInClassifierDeclaration(ThisTypeRef thisTypeRef) {
-			val classifierDecl = EcoreUtil2.getContainerOfType(thisTypeRef, N4ClassifierDeclaration);
-			if (classifierDecl !== null) {
-				// exception: disallow for static members of interfaces
-				if (classifierDecl instanceof N4InterfaceDeclaration) {
-					val memberDecl = EcoreUtil2.getContainerOfType(thisTypeRef, N4MemberDeclaration);
-					if (memberDecl !== null && memberDecl.static) {
-						return false;
-					}
-				}
-				val varianceOfPos = N4JSLanguageUtils.getVarianceOfPosition(thisTypeRef);
-				if (varianceOfPos !== null) {
-					return varianceOfPos === Variance.CO;
-				}
-			}
-			return false;
-		}
+	/**
+	 * This handles a special case that is not checked by method {@link #checkTypeMatchesExpectedType(Expression)}.
+	 * In a compound assignment like += or *=, the left-hand side is both read from and written to. So we have
+	 * to check 1) that the type for write access is correct and 2) the type of read access is correct. Usually
+	 * these two types are the same, but in case of a getter/setter pair they can be different and need to be
+	 * checked individually. Case 1) is taken care of by method {@link #checkTypeMatchesExpectedType(Expression)}.
+	 * Case 2) is checked here in this method.
+	 */
+	@Check
+	def void checkCompoundAssignmentGetterSetterClashOnLhs(AssignmentExpression assExpr) {
+		if (assExpr.op === null || assExpr.op === AssignmentOperator.ASSIGN)
+			return; // following code is only required for compound assignments, i.e. +=, *=, etc.; not for =
+		val Expression lhs = assExpr.lhs;
+		if (lhs instanceof ParameterizedPropertyAccessExpression) {
+			val prop = lhs.property;
 
-		private def boolean isUsedInVariableWithSyntaxError(ThisTypeRef ref) {
-			val container = ref.eContainer
-			if (container instanceof VariableDeclaration) {
-				return container.name === null
-			}
-			return false
-		}
+			// in case of a getter/setter pair, scoping will here always give us the setter as property,
+			// because we are on the left-hand side of an assignment (i.e. write access)
+			if (prop instanceof TSetter) {
 
-		@Check
-		def checkSymbolReference(TypeRef typeRef) {
-			var bits = BuiltInTypeScope.get(typeRef?.eResource.resourceSet);
-			if (typeRef.declaredType === bits.symbolObjectType) {
-				// we have a type reference to 'Symbol'
-				// -> the only allowed case is as target/receiver of a property access (i.e.: Symbol.iterator)
-				val parent = typeRef.eContainer;
-				if (!(parent instanceof ParameterizedPropertyAccessExpression) ||
-					(parent as ParameterizedPropertyAccessExpression).target !== typeRef) {
-					addIssue(IssueCodes.getMessageForBIT_SYMBOL_INVALID_USE, typeRef, BIT_SYMBOL_INVALID_USE);
-				}
-			}
-		}
+				// ok, we have the situation we are interested in (setter on LHS of compound assignment)
+				// --> now check if there is a matching getter of correct type
+				val TSetter setter = prop;
+				val Type targetType = ts.tau(lhs.target)?.declaredType;
+				if (targetType instanceof ContainerType<?>) {
+					val TMember m = containerTypesHelper.fromContext(assExpr).findMember(targetType, setter.name,
+						false, setter.static);
+					if (m === null) {
 
-		/*
-		 * Constraints 08: primitive types except any must not be declared dynamic
-		 */
-		def internalCheckDynamic(ParameterizedTypeRef ref) {
-			if (ref.dynamic) {
-				val Type t = ref.declaredType;
-				if (t instanceof PrimitiveType && ! (t instanceof AnyType)) {
-					addIssue(IssueCodes.getMessageForTYS_PRIMITIVE_TYPE_DYNAMIC(t.name), ref,
-						TYS_PRIMITIVE_TYPE_DYNAMIC);
-				}
-			}
-		}
+						// no getter at all
+						val message = messageForTYS_COMPOUND_MISSING_GETTER
+						addIssue(message, assExpr.lhs, TYS_COMPOUND_MISSING_GETTER);
+					} else if (m instanceof TGetter) {
+						val TGetter getter = m;
+						var G = assExpr.newRuleEnvironment;
 
-		@Check
-		def checkTypeHiddenByTypeVariable(GenericDeclaration genDecl) {
-
-			// TODO reconsider this warning or its implementation; re-generating the scope can become quite expensive
-			// (but note that moving this to the scoping code is not trivial, because warning has to be generated also
-			// if not references to the type parameter are made!)
-			if (!genDecl.typeVars.empty) {
-				val staticAccess = genDecl instanceof N4MemberDeclaration && (genDecl as N4MemberDeclaration).static;
-				val scope = n4jsScopeProvider.getTypeScope( // note: calling #getTypeScope() here, NOT #getScope()!
-				genDecl.eContainer, // use container, because we do not want to see type variables we are currently validating
-				TypeRefsPackage.eINSTANCE.parameterizedTypeRef_DeclaredType, // provide any reference that expects instances of Type as target objects
-				staticAccess);
-				genDecl.typeVars.forEach [
-					if (!it.name.nullOrEmpty) {
-						val hiddenTypeDscr = scope.getSingleElement(QualifiedName.create(it.name));
-						val hiddenType = hiddenTypeDscr?.getEObjectOrProxy;
-						if (hiddenType instanceof Type &&
-							!(AbstractDescriptionWithError.isErrorDescription_XTEND_MVN_BUG_HACK(hiddenTypeDscr))) {
-							val message = getMessageForVIS_TYPE_PARAMETER_HIDES_TYPE(name, hiddenType.keyword);
-							addIssue(message, it, VIS_TYPE_PARAMETER_HIDES_TYPE);
-						}
-					}
-				]
-			}
-		}
-
-		/**
-		 * This handles a special case that is not checked by method {@link #checkTypeMatchesExpectedType(Expression)}.
-		 * In a compound assignment like += or *=, the left-hand side is both read from and written to. So we have
-		 * to check 1) that the type for write access is correct and 2) the type of read access is correct. Usually
-		 * these two types are the same, but in case of a getter/setter pair they can be different and need to be
-		 * checked individually. Case 1) is taken care of by method {@link #checkTypeMatchesExpectedType(Expression)}.
-		 * Case 2) is checked here in this method.
-		 */
-		@Check
-		def void checkCompoundAssignmentGetterSetterClashOnLhs(AssignmentExpression assExpr) {
-			if (assExpr.op === null || assExpr.op === AssignmentOperator.ASSIGN)
-				return; // following code is only required for compound assignments, i.e. +=, *=, etc.; not for =
-			val Expression lhs = assExpr.lhs;
-			if (lhs instanceof ParameterizedPropertyAccessExpression) {
-				val prop = lhs.property;
-
-				// in case of a getter/setter pair, scoping will here always give us the setter as property,
-				// because we are on the left-hand side of an assignment (i.e. write access)
-				if (prop instanceof TSetter) {
-
-					// ok, we have the situation we are interested in (setter on LHS of compound assignment)
-					// --> now check if there is a matching getter of correct type
-					val TSetter setter = prop;
-					val Type targetType = ts.tau(lhs.target)?.declaredType;
-					if (targetType instanceof ContainerType<?>) {
-						val TMember m = containerTypesHelper.fromContext(assExpr).findMember(targetType, setter.name,
-							false, setter.static);
-						if (m === null) {
-
-							// no getter at all
-							val message = messageForTYS_COMPOUND_MISSING_GETTER
-							addIssue(message, assExpr.lhs, TYS_COMPOUND_MISSING_GETTER);
-						} else if (m instanceof TGetter) {
-							val TGetter getter = m;
-							var G = assExpr.newRuleEnvironment;
-
-							// must use .rhs in next line, because .lhs would give us the expected type for write access
-							// (which is already checked by the generic method #checkTypeMatchesExpectedType()
-							val expectedType = ts.expectedTypeIn(G, assExpr, assExpr.rhs).value;
-							val TypeRef typeOfGetterRAW = TypeUtils.getMemberTypeRef(getter);
-							if (expectedType !== null && typeOfGetterRAW !== null) {
-								val TypeRef typeOfGetter = ts.substTypeVariablesInTypeRef(G, typeOfGetterRAW);
-								if (typeOfGetter !== null) {
-									val result = ts.subtype(G, typeOfGetter, expectedType);
-									createError(result, assExpr.lhs);
-								}
+						// must use .rhs in next line, because .lhs would give us the expected type for write access
+						// (which is already checked by the generic method #checkTypeMatchesExpectedType()
+						val expectedType = ts.expectedTypeIn(G, assExpr, assExpr.rhs).value;
+						val TypeRef typeOfGetterRAW = TypeUtils.getMemberTypeRef(getter);
+						if (expectedType !== null && typeOfGetterRAW !== null) {
+							val TypeRef typeOfGetter = ts.substTypeVariablesInTypeRef(G, typeOfGetterRAW);
+							if (typeOfGetter !== null) {
+								val result = ts.subtype(G, typeOfGetter, expectedType);
+								createError(result, assExpr.lhs);
 							}
 						}
 					}
 				}
 			}
 		}
+	}
 
-		@Check
-		def void checkInconsistentInterfaceImplementationOrExtension(N4ClassifierDeclaration classifierDecl) {
-			val tClassifier = classifierDecl.definedType as TClassifier;
-			if (tClassifier === null)
-				return; // broken AST
-			val G = newRuleEnvironment(classifierDecl);
-			G.recordInconsistentSubstitutions;
-			tClassifier.superClassifierRefs.forEach[tsh.addSubstitutions(G, it)];
-			for (tv : G.getTypeMappingKeys()) {
-				if (!tv.declaredCovariant && !tv.declaredContravariant) {
-					val subst = ts.substTypeVariables(G, TypeUtils.createTypeRef(tv)).value;
-					if (subst instanceof UnknownTypeRef) {
-						val badSubst = G.getInconsistentSubstitutions(tv);
-						if (!badSubst.empty) {
-							if (!tsh.allEqualType(G, badSubst)) {
-								val mode = if (tClassifier instanceof TClass) "implement" else "extend";
-								val ifcName = (tv.eContainer as TInterface).name;
-								val tvName = "invariant " + tv.name;
-								val typeRefsStr = badSubst.map[typeRefAsString].join(", ");
-								val message = getMessageForCLF_IMPLEMENT_EXTEND_SAME_INTERFACE_INCONSISTENTLY(mode,
-									ifcName, tvName, typeRefsStr);
-								addIssue(message, classifierDecl, N4JSPackage.eINSTANCE.n4TypeDeclaration_Name,
-									CLF_IMPLEMENT_EXTEND_SAME_INTERFACE_INCONSISTENTLY);
-							}
+	@Check
+	def void checkInconsistentInterfaceImplementationOrExtension(N4ClassifierDeclaration classifierDecl) {
+		val tClassifier = classifierDecl.definedType as TClassifier;
+		if (tClassifier === null)
+			return; // broken AST
+		val G = newRuleEnvironment(classifierDecl);
+		G.recordInconsistentSubstitutions;
+		tClassifier.superClassifierRefs.forEach[tsh.addSubstitutions(G, it)];
+		for (tv : G.getTypeMappingKeys()) {
+			if (!tv.declaredCovariant && !tv.declaredContravariant) {
+				val subst = ts.substTypeVariables(G, TypeUtils.createTypeRef(tv)).value;
+				if (subst instanceof UnknownTypeRef) {
+					val badSubst = G.getInconsistentSubstitutions(tv);
+					if (!badSubst.empty) {
+						if (!tsh.allEqualType(G, badSubst)) {
+							val mode = if (tClassifier instanceof TClass) "implement" else "extend";
+							val ifcName = (tv.eContainer as TInterface).name;
+							val tvName = "invariant " + tv.name;
+							val typeRefsStr = badSubst.map[typeRefAsString].join(", ");
+							val message = getMessageForCLF_IMPLEMENT_EXTEND_SAME_INTERFACE_INCONSISTENTLY(mode,
+								ifcName, tvName, typeRefsStr);
+							addIssue(message, classifierDecl, N4JSPackage.eINSTANCE.n4TypeDeclaration_Name,
+								CLF_IMPLEMENT_EXTEND_SAME_INTERFACE_INCONSISTENTLY);
 						}
 					}
 				}
 			}
 		}
+	}
 
-		/**
-		 * This tests ALL expressions, including expressions used on right hand side of assignments or property definitions. That is,
-		 * there is no need to test field declarations or property declarations separately, as this will lead to duplicate error
-		 * messages.
-		 */
-		@Check
-		def void checkTypeMatchesExpectedType(Expression expression) {
+	/**
+	 * This tests ALL expressions, including expressions used on right hand side of assignments or property definitions. That is,
+	 * there is no need to test field declarations or property declarations separately, as this will lead to duplicate error
+	 * messages.
+	 */
+	@Check
+	def void checkTypeMatchesExpectedType(Expression expression) {
 
-			if (!jsVariantHelper.requireCheckTypeMatchesExpectedType(expression)) {
-				return;
-			}
+		if (!jsVariantHelper.requireCheckTypeMatchesExpectedType(expression)) {
+			return;
+		}
 
-			// expressionAnnotationList occur on function- and class-expressions.
-			// checking of the content is done in N4JSAnnotationValidation
-			if (expression instanceof ExpressionAnnotationList) {
-				return
-			}
+		// expressionAnnotationList occur on function- and class-expressions.
+		// checking of the content is done in N4JSAnnotationValidation
+		if (expression instanceof ExpressionAnnotationList) {
+			return
+		}
 
-			var G = expression.newRuleEnvironment;
-			val inferredType = ts.type(G, expression);
-			if (createError(inferredType, expression)) {
-				return;
-			}
+		var G = expression.newRuleEnvironment;
+		val inferredType = ts.type(G, expression);
+		if (createError(inferredType, expression)) {
+			return;
+		}
 
-			// use a fresh environment for expectations
-			G = newRuleEnvironment(expression);
+		// use a fresh environment for expectations
+		G = newRuleEnvironment(expression);
 
-			val expectedType = ts.expectedTypeIn(G, expression.eContainer, expression);
-			if (expectedType.value !== null) {
+		val expectedType = ts.expectedTypeIn(G, expression.eContainer, expression);
+		if (expectedType.value !== null) {
 
-				val expectedTyeRef = expectedType.value;
+			val expectedTyeRef = expectedType.value;
 
-				// for certain problems in single-expression arrow functions, we want a special error message
-				val singleExprArrowFunction = N4JSASTUtils.getContainingSingleExpressionArrowFunction(expression);
-				if (singleExprArrowFunction !== null && TypeUtils.isVoid(inferredType.value)) {
-					if (TypeUtils.isVoid(expectedTyeRef) || singleExprArrowFunction.isReturnValueOptional) {
-						return; // all good
-					}
-					if (singleExprArrowFunction.returnTypeRef === null) { // show specialized error message only if return type of arrow function was inferred (i.e. not declared explicitly)
-						val message = IssueCodes.
-							getMessageForFUN_SINGLE_EXP_LAMBDA_IMPLICIT_RETURN_ALLOWED_UNLESS_VOID();
-						addIssue(message, expression,
-							IssueCodes.FUN_SINGLE_EXP_LAMBDA_IMPLICIT_RETURN_ALLOWED_UNLESS_VOID);
-						return;
-					}
+			// for certain problems in single-expression arrow functions, we want a special error message
+			val singleExprArrowFunction = N4JSASTUtils.getContainingSingleExpressionArrowFunction(expression);
+			if (singleExprArrowFunction !== null && TypeUtils.isVoid(inferredType.value)) {
+				if (TypeUtils.isVoid(expectedTyeRef) || singleExprArrowFunction.isReturnValueOptional) {
+					return; // all good
 				}
+				if (singleExprArrowFunction.returnTypeRef === null) { // show specialized error message only if return type of arrow function was inferred (i.e. not declared explicitly)
+					val message = IssueCodes.
+						getMessageForFUN_SINGLE_EXP_LAMBDA_IMPLICIT_RETURN_ALLOWED_UNLESS_VOID();
+					addIssue(message, expression,
+						IssueCodes.FUN_SINGLE_EXP_LAMBDA_IMPLICIT_RETURN_ALLOWED_UNLESS_VOID);
+					return;
+				}
+			}
 
-				internalCheckUseOfUndefinedExpression(G, expression, expectedTyeRef, inferredType.value);
+			internalCheckUseOfUndefinedExpression(G, expression, expectedTyeRef, inferredType.value);
 
-				val boolean writeAccess = ExpressionExtensions.isLeftHandSide(expression);
-				if (writeAccess) {
+			val boolean writeAccess = ExpressionExtensions.isLeftHandSide(expression);
+			if (writeAccess) {
 
-					// special case: write access
-					val result = ts.subtype(G, expectedTyeRef, inferredType.value);
+				// special case: write access
+				val result = ts.subtype(G, expectedTyeRef, inferredType.value);
 
-					if (result.failed) {
-						// use custom error message, because otherwise it will be completely confusing
-						val message = getMessageForTYS_NO_SUPERTYPE_WRITE_ACCESS(expectedTyeRef.typeRefAsString,
-							inferredType.value.typeRefAsString);
-						addIssue(message, expression, TYS_NO_SUPERTYPE_WRITE_ACCESS)
-					}
-				} else {
+				if (result.failed) {
+					// use custom error message, because otherwise it will be completely confusing
+					val message = getMessageForTYS_NO_SUPERTYPE_WRITE_ACCESS(expectedTyeRef.typeRefAsString,
+						inferredType.value.typeRefAsString);
+					addIssue(message, expression, TYS_NO_SUPERTYPE_WRITE_ACCESS)
+				}
+			} else {
 
-					// standard case: read access
-					val result = ts.subtype(G, inferredType.value, expectedTyeRef)
-					// not working, as primitive types are not part of currently validated resource:
-					// errorGenerator.generateErrors(this, result, expression)
-					// so we create error here differently:
-					val errorCreated = createError(result, expression)
+				// standard case: read access
+				val result = ts.subtype(G, inferredType.value, expectedTyeRef)
+				// not working, as primitive types are not part of currently validated resource:
+				// errorGenerator.generateErrors(this, result, expression)
+				// so we create error here differently:
+				val errorCreated = createError(result, expression)
 
-					if (! errorCreated && expression instanceof ObjectLiteral) {
-						internalCheckSuperfluousPropertiesInObjectLiteral(expectedTyeRef, expression as ObjectLiteral);
-					}
+				if (! errorCreated && expression instanceof ObjectLiteral) {
+					internalCheckSuperfluousPropertiesInObjectLiteral(expectedTyeRef, expression as ObjectLiteral);
 				}
 			}
 		}
-		
+	}
+	
 	 /**
 	 * #225: always check for superfluous properties in object literal
 	 * req-id IDE-22501
@@ -522,7 +521,7 @@ class N4JSTypeValidator extends AbstractN4JSDeclarativeValidator {
 			if (typeRef.isDynamic) {
 				return;
 			}
-
+	
 			var type = typeRef.declaredType;
 			if (type===null && typeRef instanceof BoundThisTypeRef) {
 				type = (typeRef as BoundThisTypeRef).actualThisTypeRef?.declaredType;
@@ -530,21 +529,21 @@ class N4JSTypeValidator extends AbstractN4JSDeclarativeValidator {
 			if (! (type instanceof ContainerType<?>)) {
 				return;
 			}
-
+	
 			val G = RuleEnvironmentExtensions.newRuleEnvironment(objectLiteral);
 			val structuralMembers = typeRef.structuralMembers;
 			if (structuralMembers.isEmpty && type == RuleEnvironmentExtensions.objectType(G)) {
 				return;
 			}
-
+	
 			val strategyFilter = new TypingStrategyFilter(typingStrategy);
 			val expectedMembers = containerTypesHelper.fromContext(objectLiteral).allMembers(
 				type as ContainerType<?>).filter[member|strategyFilter.apply(member)].map[member|member.name].
 				toSet();
-
+	
 			// These are available via the 'with' keyword add them to the accepted ones
 			typeRef.structuralMembers.forEach[member|expectedMembers.add(member.name)];
-
+	
 			val inputMembers = (objectLiteral.definedType as ContainerType<?>).ownedMembers;
 			for (property : inputMembers) {
 				if (!expectedMembers.contains(property.name)) {
@@ -559,35 +558,35 @@ class N4JSTypeValidator extends AbstractN4JSDeclarativeValidator {
 			};
 		}
 	}
-		
+	
 
 
-		def private void internalCheckUseOfUndefinedExpression(RuleEnvironment G, Expression expression,
-			TypeRef expectedTypeRef, TypeRef actualTypeRef) {
-			if (TypeUtils.isUndefined(actualTypeRef) && !TypeUtils.isUndefined(expectedTypeRef)) {
-				val parent = expression.eContainer;
-				if (!(parent instanceof ExpressionStatement) &&
-					!(parent instanceof UnaryExpression && (parent as UnaryExpression).op === UnaryOperator.VOID) &&
-					!(expression instanceof UnaryExpression &&
-						(expression as UnaryExpression).op === UnaryOperator.VOID) &&
-					!(expression instanceof ThisLiteral)) {
+	def private void internalCheckUseOfUndefinedExpression(RuleEnvironment G, Expression expression,
+		TypeRef expectedTypeRef, TypeRef actualTypeRef) {
+		if (TypeUtils.isUndefined(actualTypeRef) && !TypeUtils.isUndefined(expectedTypeRef)) {
+			val parent = expression.eContainer;
+			if (!(parent instanceof ExpressionStatement) &&
+				!(parent instanceof UnaryExpression && (parent as UnaryExpression).op === UnaryOperator.VOID) &&
+				!(expression instanceof UnaryExpression &&
+					(expression as UnaryExpression).op === UnaryOperator.VOID) &&
+				!(expression instanceof ThisLiteral)) {
 
-						val undefinedField = G.globalObjectType.findOwnedMember("undefined", false, false) as TField;
-						val isUndefinedLiteral = if (expression instanceof IdentifierRef)
-								expression.id === undefinedField;
-						if (!isUndefinedLiteral) {
-							addIssue(getMessageForEXP_USE_OF_UNDEF_EXPR, expression, EXP_USE_OF_UNDEF_EXPR);
-						}
-					}
+				val undefinedField = G.globalObjectType.findOwnedMember("undefined", false, false) as TField;
+				val isUndefinedLiteral = if (expression instanceof IdentifierRef)
+						expression.id === undefinedField;
+				if (!isUndefinedLiteral) {
+					addIssue(getMessageForEXP_USE_OF_UNDEF_EXPR, expression, EXP_USE_OF_UNDEF_EXPR);
 				}
 			}
+		}
+	}
 
-			@Check
-			def void checkBogusTypeReference(TypedElement te) {
-				if (te.bogusTypeRef !== null) {
-					addIssue(IssueCodes.getMessageForTYS_INVALID_TYPE_SYNTAX, te.bogusTypeRef, TYS_INVALID_TYPE_SYNTAX);
-				}
-			}
+	@Check
+	def void checkBogusTypeReference(TypedElement te) {
+		if (te.bogusTypeRef !== null) {
+			addIssue(IssueCodes.getMessageForTYS_INVALID_TYPE_SYNTAX, te.bogusTypeRef, TYS_INVALID_TYPE_SYNTAX);
+		}
+	}
 
 //  TODO IDE-1010 Code-snippet with partial solution
 //	@Check
@@ -641,132 +640,132 @@ class N4JSTypeValidator extends AbstractN4JSDeclarativeValidator {
 //		}
 //
 //	}
-			def boolean createError(Result<?> result, EObject source) {
-				if (result.failed) {
-					errorGenerator.generateErrors(getMessageAcceptor(), result, source);
-					return true;
-				}
-				false;
-			}
+	def boolean createError(Result<?> result, EObject source) {
+		if (result.failed) {
+			errorGenerator.generateErrors(getMessageAcceptor(), result, source);
+			return true;
+		}
+		false;
+	}
 
-			/**
-			 * This validates a warning in chapter 4.10.1:<br/>
-			 * <i>The use of the any type in a union type produces a warning.</i>
-			 */
-			@Check
-			def void checkUnionTypeContainsNoAny(UnionTypeExpression ute) {
-				checkComposedTypeRefContainsNoAny(ute, messageForUNI_ANY_USED, UNI_ANY_USED, true);
-			}
+	/**
+	 * This validates a warning in chapter 4.10.1:<br/>
+	 * <i>The use of the any type in a union type produces a warning.</i>
+	 */
+	@Check
+	def void checkUnionTypeContainsNoAny(UnionTypeExpression ute) {
+		checkComposedTypeRefContainsNoAny(ute, messageForUNI_ANY_USED, UNI_ANY_USED, true);
+	}
 
-			/**
-			 * This validates a warning in chapter 4.10.2:<br/>
-			 * <i>The use of the any type in an intersection type produces a warning.</i>
-			 */
-			@Check
-			def void checkIntersectionTypeContainsNoAny(IntersectionTypeExpression ite) {
-				checkComposedTypeRefContainsNoAny(ite, messageForINTER_ANY_USED, INTER_ANY_USED, false);
-			}
+	/**
+	 * This validates a warning in chapter 4.10.2:<br/>
+	 * <i>The use of the any type in an intersection type produces a warning.</i>
+	 */
+	@Check
+	def void checkIntersectionTypeContainsNoAny(IntersectionTypeExpression ite) {
+		checkComposedTypeRefContainsNoAny(ite, messageForINTER_ANY_USED, INTER_ANY_USED, false);
+	}
 
-			def private void checkComposedTypeRefContainsNoAny(ComposedTypeRef ctr, String msg, String issueCode,
-				boolean soleVoidAllowesAny) {
-				val G = ctr.newRuleEnvironment;
-				val anyType = G.anyType;
-				val voidType = G.voidType;
-				val EList<TypeRef> typeRefs = ctr.getTypeRefs();
-				val Iterable<TypeRef> anyTypeRefs = typeRefs.filter[it.getDeclaredType() === anyType]; // identity check on typeRefs is OK here
-				var boolean dontShowWarning = false;
-				if (soleVoidAllowesAny) {
-					val boolean containsVoid = typeRefs.exists[it.getDeclaredType() === voidType]; // identity check on typeRefs is OK here
-					dontShowWarning = containsVoid && anyTypeRefs.size() == 1;
-				}
+	def private void checkComposedTypeRefContainsNoAny(ComposedTypeRef ctr, String msg, String issueCode,
+		boolean soleVoidAllowesAny) {
+		val G = ctr.newRuleEnvironment;
+		val anyType = G.anyType;
+		val voidType = G.voidType;
+		val EList<TypeRef> typeRefs = ctr.getTypeRefs();
+		val Iterable<TypeRef> anyTypeRefs = typeRefs.filter[it.getDeclaredType() === anyType]; // identity check on typeRefs is OK here
+		var boolean dontShowWarning = false;
+		if (soleVoidAllowesAny) {
+			val boolean containsVoid = typeRefs.exists[it.getDeclaredType() === voidType]; // identity check on typeRefs is OK here
+			dontShowWarning = containsVoid && anyTypeRefs.size() == 1;
+		}
 
-				if (!dontShowWarning) {
-					for (TypeRef anyTR : anyTypeRefs) {
-						addIssue(msg, anyTR, issueCode);
-					}
-				}
-			}
-
-			/**
-			 * This validates a warning in chapter 4.10.1:<br/>
-			 * <i>The use of unnecessary subtypes in union types produces a warning.</i>
-			 */
-			@Check
-			def void checkUnionHasUnnecessarySubtype(UnionTypeExpression ute) {
-				val List<TypeRef> tRefs = extractNonStructTypeRefs(ute);
-				val G = ute.newRuleEnvironment;
-				val anyType = G.anyType;
-				tRefs.removeIf[it.getDeclaredType === anyType]; // identity check on typeRefs is OK here
-				if (tRefs.size() > 1) {
-					val List<TypeRef> intersectionTR = tsh.getSuperTypesOnly(G, tRefs);
-					tRefs.removeAll(intersectionTR);
-
-					for (TypeRef tClassR : tRefs) {
-						val message = messageForUNI_REDUNDANT_SUBTYPE;
-						addIssue(message, tClassR, UNI_REDUNDANT_SUBTYPE);
-					}
-				}
-			}
-
-			/**
-			 * Entry method for validating the containing types of an intersection type.
-			 */
-			@Check
-			def void checkIntersectionType(IntersectionTypeExpression ite) {
-				val List<TypeRef> tClassRefs = extractNonStructTypeRefs(ite);
-
-				if (tClassRefs.size() > 1) {
-					val G = ite.newRuleEnvironment;
-					val List<TypeRef> intersectionTR = tsh.getSubtypesOnly(G, tClassRefs);
-
-					checkIntersectionTypeContainsMaxOneClass(ite, G, tClassRefs, intersectionTR);
-					checkIntersectionHasUnnecessarySupertype(ite, G, tClassRefs, intersectionTR);
-				}
-			}
-
-			/**
-			 * This validates constraint 25.2 ("Intersection Type") in chapter 4.10.2:<br/>
-			 * <i>Only one class must be contained in the intersection type.</i><br/><br/>
-			 * Currently, only a warning is displayed.
-			 */
-			def private void checkIntersectionTypeContainsMaxOneClass(IntersectionTypeExpression ite, RuleEnvironment G,
-				List<TypeRef> tClassRefs, List<TypeRef> intersectionTR) {
-				if (intersectionTR.size() > 1) {
-					for (TypeRef tClassR : intersectionTR) {
-						val message = messageForINTER_ONLY_ONE_CLASS_ALLOWED;
-						addIssue(message, tClassR, INTER_ONLY_ONE_CLASS_ALLOWED);
-					}
-				}
-			}
-
-			/**
-			 * This validates a warning in chapter 4.10.2:<br/>
-			 * <i>The use of unnecessary supertypes in intersection types produces a warning.</i>
-			 */
-			def private void checkIntersectionHasUnnecessarySupertype(IntersectionTypeExpression ite, RuleEnvironment G,
-				List<TypeRef> tClassRefs, List<TypeRef> intersectionTR) {
-				tClassRefs.removeAll(intersectionTR);
-
-				for (TypeRef tClassR : tClassRefs) {
-					val message = messageForINTER_REDUNDANT_SUPERTYPE;
-					addIssue(message, tClassR, INTER_REDUNDANT_SUPERTYPE);
-				}
-			}
-
-			def private List<TypeRef> extractNonStructTypeRefs(ComposedTypeRef ctr) {
-				val List<TypeRef> tClassRefs = new LinkedList();
-				val G = ctr.newRuleEnvironment;
-				val List<TypeRef> tRefs = tsh.getSimplifiedTypeRefs(G, ctr);
-
-				for (TypeRef tR : tRefs) {
-					val Type type = tR.getDeclaredType();
-					if (type instanceof TClass) {
-						var isStructural = tR.isDefSiteStructuralTyping() || tR.isUseSiteStructuralTyping();
-						if (!isStructural)
-							tClassRefs.add(tR);
-					}
-				}
-				return tClassRefs;
+		if (!dontShowWarning) {
+			for (TypeRef anyTR : anyTypeRefs) {
+				addIssue(msg, anyTR, issueCode);
 			}
 		}
-		
+	}
+
+	/**
+	 * This validates a warning in chapter 4.10.1:<br/>
+	 * <i>The use of unnecessary subtypes in union types produces a warning.</i>
+	 */
+	@Check
+	def void checkUnionHasUnnecessarySubtype(UnionTypeExpression ute) {
+		val List<TypeRef> tRefs = extractNonStructTypeRefs(ute);
+		val G = ute.newRuleEnvironment;
+		val anyType = G.anyType;
+		tRefs.removeIf[it.getDeclaredType === anyType]; // identity check on typeRefs is OK here
+		if (tRefs.size() > 1) {
+			val List<TypeRef> intersectionTR = tsh.getSuperTypesOnly(G, tRefs);
+			tRefs.removeAll(intersectionTR);
+
+			for (TypeRef tClassR : tRefs) {
+				val message = messageForUNI_REDUNDANT_SUBTYPE;
+				addIssue(message, tClassR, UNI_REDUNDANT_SUBTYPE);
+			}
+		}
+	}
+
+	/**
+	 * Entry method for validating the containing types of an intersection type.
+	 */
+	@Check
+	def void checkIntersectionType(IntersectionTypeExpression ite) {
+		val List<TypeRef> tClassRefs = extractNonStructTypeRefs(ite);
+
+		if (tClassRefs.size() > 1) {
+			val G = ite.newRuleEnvironment;
+			val List<TypeRef> intersectionTR = tsh.getSubtypesOnly(G, tClassRefs);
+
+			checkIntersectionTypeContainsMaxOneClass(ite, G, tClassRefs, intersectionTR);
+			checkIntersectionHasUnnecessarySupertype(ite, G, tClassRefs, intersectionTR);
+		}
+	}
+
+	/**
+	 * This validates constraint 25.2 ("Intersection Type") in chapter 4.10.2:<br/>
+	 * <i>Only one class must be contained in the intersection type.</i><br/><br/>
+	 * Currently, only a warning is displayed.
+	 */
+	def private void checkIntersectionTypeContainsMaxOneClass(IntersectionTypeExpression ite, RuleEnvironment G,
+		List<TypeRef> tClassRefs, List<TypeRef> intersectionTR) {
+		if (intersectionTR.size() > 1) {
+			for (TypeRef tClassR : intersectionTR) {
+				val message = messageForINTER_ONLY_ONE_CLASS_ALLOWED;
+				addIssue(message, tClassR, INTER_ONLY_ONE_CLASS_ALLOWED);
+			}
+		}
+	}
+
+	/**
+	 * This validates a warning in chapter 4.10.2:<br/>
+	 * <i>The use of unnecessary supertypes in intersection types produces a warning.</i>
+	 */
+	def private void checkIntersectionHasUnnecessarySupertype(IntersectionTypeExpression ite, RuleEnvironment G,
+		List<TypeRef> tClassRefs, List<TypeRef> intersectionTR) {
+		tClassRefs.removeAll(intersectionTR);
+
+		for (TypeRef tClassR : tClassRefs) {
+			val message = messageForINTER_REDUNDANT_SUPERTYPE;
+			addIssue(message, tClassR, INTER_REDUNDANT_SUPERTYPE);
+		}
+	}
+
+	def private List<TypeRef> extractNonStructTypeRefs(ComposedTypeRef ctr) {
+		val List<TypeRef> tClassRefs = new LinkedList();
+		val G = ctr.newRuleEnvironment;
+		val List<TypeRef> tRefs = tsh.getSimplifiedTypeRefs(G, ctr);
+
+		for (TypeRef tR : tRefs) {
+			val Type type = tR.getDeclaredType();
+			if (type instanceof TClass) {
+				var isStructural = tR.isDefSiteStructuralTyping() || tR.isUseSiteStructuralTyping();
+				if (!isStructural)
+					tClassRefs.add(tR);
+			}
+		}
+		return tClassRefs;
+	}
+}
+	

--- a/tests/org.eclipse.n4js.bugreports.tests/bugreports-tests/GHOLD_0214_SpecCtorsWithPublicInternalInconsistency.n4js.xt
+++ b/tests/org.eclipse.n4js.bugreports.tests/bugreports-tests/GHOLD_0214_SpecCtorsWithPublicInternalInconsistency.n4js.xt
@@ -17,7 +17,7 @@ class A {
     @Internal public a: int;
 }
 
-// XPECT warnings --> "a is not used in constructor." at "a"
+// XPECT warnings --> "a is not defined in ~i~this[A]." at "a"
 let x = new A({ a: 5 }); // value has to be initialized
 
 /* XPECT output ---

--- a/tests/org.eclipse.n4js.bugreports.tests/bugreports-tests/IDEBUG_0113_OptionalFieldsWithCtorExecTest.n4js.xt
+++ b/tests/org.eclipse.n4js.bugreports.tests/bugreports-tests/IDEBUG_0113_OptionalFieldsWithCtorExecTest.n4js.xt
@@ -47,6 +47,7 @@ var cb = new C({s:"Hello"});
 console.log(cb.s)
 console.log(cb.n)
 
+// XPECT warnings --> "superfluous is not defined in ~~this[C]." at "superfluous"
 var cc = new C({s:"Hello", superfluous: "nobody needs that", n: 42});
 console.log(cc.s)
 console.log(cc.n)

--- a/tests/org.eclipse.n4js.expectmatrix.tests/xpect-pending/matrix/Class_x_ST_US/01_instantiation.n4js.xt
+++ b/tests/org.eclipse.n4js.expectmatrix.tests/xpect-pending/matrix/Class_x_ST_US/01_instantiation.n4js.xt
@@ -42,37 +42,37 @@ var a2 : ~A2 = { a: 2, f: function () { console.log( this.a) ; this.f();} };
 var a3 : ~~A2 = { a: 2 };
 
 // Spec says structural (field) type cannot be on right-hand-side of instanceof but strange error occurs
-// GHOLD-9 (IDEBUG-163) instanceof  XPECT FIXME errors  --> "Cannot use structural type with instanceof." at "A2"
+// GHOLD-9 (IDEBUG-163) instanceof XPECT FIXME errors --> "Cannot use structural type with instanceof." at "A2"
 a2 instanceof ~A2;
 
-// GHOLD-9 (IDEBUG-163) instanceof  XPECT FIXME errors  --> "Cannot use structural field type with instanceof." at "A2"
+// GHOLD-9 (IDEBUG-163) instanceof XPECT FIXME errors --> "Cannot use structural field type with instanceof." at "A2"
 a3 instanceof ~~A2;
 
 // missing members  XPECT errors  --> "~Object with { a: number } is not a structural subtype of ~A2: missing method f." at "{a: 2}"
 var a4 : ~A2 = {a: 2};
 
-/* superfluous members in field type, noerrors but  XPECT warnings  ---
+/* superfluous members in field type, noerrors but XPECT warnings ---
    "b is not defined in ~~A2." at "b"
    "f is not defined in ~~A2." at "f"
    --- */
 var a5 : ~~A2 = {a: 2, b: 3, f: function () {} };
 
-// primitive parameter  XPECT noerrors  -->
+// primitive parameter XPECT noerrors -->
 var b1a : ~B1<string> = { a: 2, s: "s" };
 
-// structural parameter  XPECT noerrors  -->
+// structural parameter XPECT noerrors -->
 var b1b : ~B1<~A1> = { a: 2, s: a1 };
 
-// structural parameter defined inside the definition  XPECT noerrors  -->
+// structural parameter defined inside the definition XPECT noerrors -->
 var b1c : ~B1<~A1> = { a: 2, s: {a: 2} };
 
-// str. field: primitive parameter  XPECT noerrors  -->
+// str. field: primitive parameter XPECT noerrors  -->
 var b2a : ~~B2<string> = { a: 2, s: "s" };
 
-// str. field: non-structural parameter  XPECT noerrors  -->
+// str. field: non-structural parameter XPECT noerrors  -->
 var b2b : ~~B2<A1> = { a: 2, s: new A1() };
 
-// str. field: structural parameter  XPECT noerrors  -->
+// str. field: structural parameter XPECT noerrors  -->
 var b2b2 : ~~B2<~~A2> = { a: 2, s: a3 };
 
 // str. field: structural parameter defined inside the definition XPECT noerrors  -->

--- a/tests/org.eclipse.n4js.expectmatrix.tests/xpect-pending/matrix/Class_x_ST_US/01_instantiation.n4js.xt
+++ b/tests/org.eclipse.n4js.expectmatrix.tests/xpect-pending/matrix/Class_x_ST_US/01_instantiation.n4js.xt
@@ -9,7 +9,8 @@
  *   NumberFour AG - Initial API and implementation
  */
 
-/* XPECT_SETUP org.eclipse.n4js.expectmatrix.tests.N4JSExpectMatrixPendingTest END_SETUP  */
+/*  XPECT_SETUP org.eclipse.n4js.expectmatrix.tests.N4JSExpectMatrixPendingTest
+END_SETUP   */
 
 ///////////////////
 // Instantiation //
@@ -41,35 +42,38 @@ var a2 : ~A2 = { a: 2, f: function () { console.log( this.a) ; this.f();} };
 var a3 : ~~A2 = { a: 2 };
 
 // Spec says structural (field) type cannot be on right-hand-side of instanceof but strange error occurs
-// GHOLD-9 (IDEBUG-163) instanceof XPECT FIXME errors --> "Cannot use structural type with instanceof." at "A2"
+// GHOLD-9 (IDEBUG-163) instanceof  XPECT FIXME errors  --> "Cannot use structural type with instanceof." at "A2"
 a2 instanceof ~A2;
 
-// GHOLD-9 (IDEBUG-163) instanceof XPECT FIXME errors --> "Cannot use structural field type with instanceof." at "A2"
+// GHOLD-9 (IDEBUG-163) instanceof  XPECT FIXME errors  --> "Cannot use structural field type with instanceof." at "A2"
 a3 instanceof ~~A2;
 
-// missing members XPECT errors --> "~Object with { a: number } is not a structural subtype of ~A2: missing method f." at "{a: 2}"
+// missing members  XPECT errors  --> "~Object with { a: number } is not a structural subtype of ~A2: missing method f." at "{a: 2}"
 var a4 : ~A2 = {a: 2};
 
-// superfluous members in field type XPECT noerrors -->
+/* superfluous members in field type, noerrors but  XPECT warnings  ---
+   "b is not defined in ~~A2." at "b"
+   "f is not defined in ~~A2." at "f"
+   --- */
 var a5 : ~~A2 = {a: 2, b: 3, f: function () {} };
 
-// primitive parameter XPECT noerrors -->
+// primitive parameter  XPECT noerrors  -->
 var b1a : ~B1<string> = { a: 2, s: "s" };
 
-// structural parameter XPECT noerrors -->
+// structural parameter  XPECT noerrors  -->
 var b1b : ~B1<~A1> = { a: 2, s: a1 };
 
-// structural parameter defined inside the definition XPECT noerrors -->
+// structural parameter defined inside the definition  XPECT noerrors  -->
 var b1c : ~B1<~A1> = { a: 2, s: {a: 2} };
 
-// str. field: primitive parameter XPECT noerrors -->
+// str. field: primitive parameter  XPECT noerrors  -->
 var b2a : ~~B2<string> = { a: 2, s: "s" };
 
-// str. field: non-structural parameter XPECT noerrors -->
+// str. field: non-structural parameter  XPECT noerrors  -->
 var b2b : ~~B2<A1> = { a: 2, s: new A1() };
 
-// str. field: structural parameter XPECT noerrors -->
+// str. field: structural parameter  XPECT noerrors  -->
 var b2b2 : ~~B2<~~A2> = { a: 2, s: a3 };
 
-// str. field: structural parameter defined inside the definition XPECT noerrors -->
+// str. field: structural parameter defined inside the definition XPECT noerrors  -->
 var b2c : ~~B2<~~A2> = { a: 2, s: {a: 2} };

--- a/tests/org.eclipse.n4js.expectmatrix.tests/xpect-pending/matrix/Ctor_x_AnnoReadonly/03_anon_interface.n4js.xt
+++ b/tests/org.eclipse.n4js.expectmatrix.tests/xpect-pending/matrix/Ctor_x_AnnoReadonly/03_anon_interface.n4js.xt
@@ -45,7 +45,7 @@ var b1 = new B({s: "S", t: "T", n: new C()});
 // n missing but required by anonymous interface XPECT errors --> "~Object with { s: string; t: string } is not a structural subtype of ~~B with { n: C }: missing structural field n." at "{s: "S", t: "T"}"
 var b2 = new B({s: "S", t: "T"});
 
-// passing additional non-existent parameter (cf. IDEBUG-99) XPECT noerrors -->
+// passing additional non-existent parameter (cf. IDEBUG-99), noerrors but XPECT warnings --> "m is not defined in ~~this[B]." at "m"
 var b3 = new B({s: "S", t: "T", n: new C(), m: "M"});
 
 // n set to null XPECT noerrors -->

--- a/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Class_x_ST_DS/04_default_n_static.n4js.xt
+++ b/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Class_x_ST_DS/04_default_n_static.n4js.xt
@@ -28,7 +28,7 @@ class ~E2 {
 // static members are not required XPECT noerrors -->
 var e1 : E1 = {i: 3};
 
-// full instantiation XPECT noerrors -->
+// full instantiation, noerrors but XPECT warnings --> "j is not defined in E1." at "j"
 var e2 : E1 = {i: 3, j: 4};
 
 // defaulted members are required XPECT errors --> "~Object with { i: number } is not a structural subtype of E2: missing field j." at "{i: 3}"

--- a/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Class_x_ST_US/07_static_n_default.n4js.xt
+++ b/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Class_x_ST_US/07_static_n_default.n4js.xt
@@ -32,7 +32,7 @@ class E2 {
 // static members are not required XPECT noerrors -->
 var e1a : ~E1 = {i: 3};
 
-// full assignment XPECT noerrors -->
+// full assignment noerrors but XPECT warnings --> "j is not defined in ~E1." at "j"
 var e1b : ~E1 = {i: 3, j: 4};
 
 // initialized members are required as well XPECT errors --> "~Object with { i: number } is not a structural subtype of ~E2: missing field j." at "{i: 3}"

--- a/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Class_x_ST_US/09_nested_ST_members.n4js.xt
+++ b/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Class_x_ST_US/09_nested_ST_members.n4js.xt
@@ -35,7 +35,7 @@ class G {
 	}
 }
 
-// XPECT warnings --> "foo is not used in constructor." at "foo"
+// XPECT warnings --> "foo is not defined in ~i~this[C]." at "foo"
 var c_nom : C = new C({n: 3, foo: function (){} });
 var c_str : ~C = {n: 3, foo: function (){} };
 var c_fld : ~~C = {n: 3};
@@ -88,11 +88,13 @@ var f3aOK : ~C = g.f({n: 3, foo: function (){} });
 var f3b : C = g.f({n: 3});
 
 // type returned incompatible XPECT errors -->"Structural type ~~C is not a subtype of non-structural type C." at "g.ff({n: 3, foo: function (){} })"
+// XPECT warnings --> "foo is not defined in ~~C." at "foo"
 var f4a : C = g.ff({n: 3, foo: function (){} });
-// XPECT noerrors -->
+// noerrors but XPECT warnings --> "foo is not defined in ~~C." at "foo"
 var f4aOK : ~~C = g.ff({n: 3, foo: function (){} });
 
 // type returned incompatible XPECT errors -->"Structural type ~~C is not a subtype of non-structural type C." at "g.ff({n: 3, foo: function (){} })"
+// XPECT warnings --> "foo is not defined in ~~C." at "foo"
 var f4b : C = g.ff({n: 3, foo: function (){} });
-// XPECT noerrors -->
+// noerrors but XPECT warnings --> "foo is not defined in ~~C." at "foo"
 var f4bOK : ~~C = g.ff({n: 3, foo: function (){} });

--- a/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Ctor_x_AnnoSpec/02_spec_access.n4js.xt
+++ b/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Ctor_x_AnnoSpec/02_spec_access.n4js.xt
@@ -25,9 +25,9 @@ class A {
 }
 
 // XPECT warnings ---
-// "y is not used in constructor." at "y"
-// "z is not used in constructor." at "z"
-// "w is not used in constructor." at "w"
+// "w is not defined in ~i~this[A]." at "w"
+// "y is not defined in ~i~this[A]." at "y"
+// "z is not defined in ~i~this[A]." at "z"
 // ---
 var a : A = new A({x: 1, y: 2, z: 3, w: 4});
 

--- a/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Enum/ST.n4js.xt
+++ b/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Enum/ST.n4js.xt
@@ -39,7 +39,7 @@ var a2 : A<SBEnum> = { t: SBEnum.a, f: function (tt : SBEnum) : SBEnum {return t
 // structural type for variable XPECT noerrors -->
 var b1 : ~B<SBEnum> = { t: SBEnum.a, f: function (tt : SBEnum) : SBEnum {return tt;} };
 
-// structural field type for variable XPECT noerrors -->
+// structural field type for variable, noerrors but XPECT warnings --> "f is not defined in ~~B<SBEnum>." at "f"
 var b2 : ~~B<SBEnum> = { t: SBEnum.a, f: function (tt : SBEnum) : SBEnum {return tt;} };
 
 // structural field type for variable XPECT noerrors -->

--- a/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Interface_x_ST_DS/02_as_return_value.n4js.xt
+++ b/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Interface_x_ST_DS/02_as_return_value.n4js.xt
@@ -40,7 +40,7 @@ class C1 {
 	// return value must be ~I, all well XPECT noerrors -->
 	public f2b () : ~I<int> { return {x: 3, foo: this.f}; };
 
-	// return value must be ~~I, all well XPECT noerrors -->
+	// return value must be ~~I, all well noerrors but XPECT warnings --> "foo is not defined in ~~I<int>." at "foo"
 	public f3 () : ~~I<int> { return {x: 3, foo: this.f}; };
 }
 
@@ -57,7 +57,7 @@ class C2 {
 	// ~Object with { ~Object with { int i; } x; {function():void} foo; } is not a subtype of ~I<A>.
 	public f2b () : ~I<A> { return {x: {i: 3}, foo: this.f}; };
 
-	// GHOLD-250 ATTENTION return value must be ~~I, all well XPECT noerrors -->
+	// GHOLD-250 ATTENTION return value must be ~~I, all well, noerrors but XPECT warnings --> "foo is not defined in ~~I<A>." at "foo"
 	// ~Object with { ~Object with { int i; } x; {function():void} foo; } is not a subtype of ~~I<A>.
 	public f3 () : ~~I<A> { return {x: {i: 3}, foo: this.f}; };
 

--- a/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Lambda/07_ST_class.n4js.xt
+++ b/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Lambda/07_ST_class.n4js.xt
@@ -12,8 +12,8 @@
 /* XPECT_SETUP org.eclipse.n4js.expectmatrix.tests.N4JSExpectMatrixPendingTest END_SETUP  */
 
 class S {
-	num : number;
-	str : string;
+	public num : number;
+	public str : string;
 }
 
 //////////////
@@ -25,7 +25,6 @@ class A {
 	public s : ~S;
 
 	public bar () {
-		// setting ST inside a lambda expr. XPECT noerrors -->
 		(() => { this.s = { num: 5, str: "S" } })();
 	}
 

--- a/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Lambda/07_ST_function.n4js.xt
+++ b/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Lambda/07_ST_function.n4js.xt
@@ -12,8 +12,8 @@
 /* XPECT_SETUP org.eclipse.n4js.expectmatrix.tests.N4JSExpectMatrixPendingTest END_SETUP  */
 
 class S {
-	num : number;
-	str : string;
+	public num : number;
+	public str : string;
 }
 
 //////////////

--- a/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Lambda/07_ST_interface.n4js.xt
+++ b/tests/org.eclipse.n4js.expectmatrix.tests/xpect-tests/matrix/Lambda/07_ST_interface.n4js.xt
@@ -12,8 +12,8 @@
 /* XPECT_SETUP org.eclipse.n4js.expectmatrix.tests.N4JSExpectMatrixPendingTest END_SETUP  */
 
 class S {
-	num : number;
-	str : string;
+	public num : number;
+	public str : string;
 }
 
 //////////////

--- a/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch05_02_02_01__StructuralThisTypeInCtorAndSpecParameter/Constraints_55_9_Structural_Fields_Can_Be_Assigned_Via_Public_Accessors.n4js.xt
+++ b/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch05_02_02_01__StructuralThisTypeInCtorAndSpecParameter/Constraints_55_9_Structural_Fields_Can_Be_Assigned_Via_Public_Accessors.n4js.xt
@@ -31,7 +31,7 @@ new B({
 	pair: "",
 	// XPECT nowarnings --> "" at setter
 	setter: "",
-	// XPECT warnings --> "getter is not used in constructor." at "getter"
+	// XPECT warnings --> "getter is not defined in ~i~this[B]." at "getter"
 	getter: ""
 });
 

--- a/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch05_02_02_01__StructuralThisTypeInCtorAndSpecParameter/IDEBUG_0262_struc_this_calling_super_ctor--usage.n4js.xt
+++ b/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch05_02_02_01__StructuralThisTypeInCtorAndSpecParameter/IDEBUG_0262_struc_this_calling_super_ctor--usage.n4js.xt
@@ -56,5 +56,6 @@ class Y extends A2 {
 }
 var y1 : Y = new Y({k:1});
 console.log(y1) // expect output: { s: undefined }
+// XPECT warnings -->"s is not defined in ~~A2 with { k: number }." at "s"
 var y2 : Y = new Y({k:2, s:"y2"});
 console.log(y2) // expect output: { s: undefined }

--- a/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch05_02_02_01__StructuralThisTypeInCtorAndSpecParameter/Req59_4_AdditionalFieldsInSpecCtor.n4js.xt
+++ b/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch05_02_02_01__StructuralThisTypeInCtorAndSpecParameter/Req59_4_AdditionalFieldsInSpecCtor.n4js.xt
@@ -49,7 +49,7 @@ class C {
 }
 
 new A({greet:'Hello'}).log();
-// XPECT warnings --> "n is not used in constructor." at "n"
+// XPECT warnings --> "n is not defined in ~i~this[A]." at "n"
 new A({greet:'Hello', n: 42}).log();
 // XPECT nowarnings --> "n is given via the with keyword and assigned to the non-public field"
 new B({greet:'Hello', n: 42}).log();

--- a/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch05_02_02_01__StructuralThisTypeInCtorAndSpecParameter/Req59_8_Spec_Constructor_Ignores_Superfluous_Properties.n4js.xt
+++ b/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch05_02_02_01__StructuralThisTypeInCtorAndSpecParameter/Req59_8_Spec_Constructor_Ignores_Superfluous_Properties.n4js.xt
@@ -17,14 +17,14 @@ class C {
     constructor(@Spec spec : ~i~this) {}
 }
 
-// XPECT warnings --> "n is not used in constructor." at "n"
+// XPECT warnings --> "n is not defined in ~i~this[C]." at "n"
 new C( { s: "Hello", n: 42 });
 
 var ol = { s: "Hello", n: 42 };
 // XPECT nowarnings --> "ol may be used elsewhere, we cannot issue warning here" at "ol"
 new C(ol) ;
 
-// XPECT warnings --> "weird is not used in constructor." at "weird"
+// XPECT warnings --> "weird is not defined in ~i~this[C]." at "weird"
 new C( { s: "Hello", weird: true } );
 
 class D extends C {
@@ -38,12 +38,12 @@ class D extends C {
 // XPECT nowarnings -->
 new D( { s: "Hello", b: true} )
 
-// XPECT warnings --> "weird is not used in constructor." at "weird"
+// XPECT warnings --> "weird is not defined in ~i~this[D]." at "weird"
 new D( {s: "Hello", b: true, weird: true} )
 
 // XPECT warnings ---
-// "anotherWeird is not used in constructor." at "anotherWeird"
-// "weird is not used in constructor." at "weird"
+// "anotherWeird is not defined in ~i~this[D]." at "anotherWeird"
+// "weird is not defined in ~i~this[D]." at "weird"
 // ---
 new D( {s: "Hello", b: true, weird: true, anotherWeird: false} )
 
@@ -54,7 +54,7 @@ class E extends D {
 // XPECT nowarnings -->
 new E( { s: "Hello", b: true} )
 
-// XPECT warnings --> "weird is not used in constructor." at "weird"
+// XPECT warnings --> "weird is not defined in ~i~this[E]." at "weird"
 new E( {s: "Hello", b: true, weird: true} )
 
 class F<T> {

--- a/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch08_01_05_ObjectLiteral/ObjectLiteral_SuperfluousProperties.n4js.xt
+++ b/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch08_01_05_ObjectLiteral/ObjectLiteral_SuperfluousProperties.n4js.xt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.spec.tests.N4JSSpecTest END_SETUP */
+
+// Cf. requirement IDE-22501
+
+
+interface I {
+	public x?: int;
+	public get y?(): int;
+	public set z?(v: int);
+	public f();
+}
+
+// XPECT warnings --> "u is not defined in ~I." at "u"
+let s: ~I = 	{u: 1, x: 1, y: 1, z: 1, f: function(){}}; s; 
+/* XPECT warnings ---
+"f is not defined in ~~I." at "f"
+"u is not defined in ~~I." at "u"
+--- */
+let fs: ~~I = 	{u: 1, x: 1, y: 1, z: 1, f: function(){}}; fs; 
+/* XPECT warnings --- 
+"u is not defined in ~r~I." at "u"
+"z is not defined in ~r~I." at "z"
+"f is not defined in ~r~I." at "f"
+--- */
+let rs: ~r~I = 	{u: 1, x: 1, y: 1, z: 1, f: function(){}}; rs; 
+/* XPECT warnings --- 
+"u is not defined in ~w~I." at "u"
+"y is not defined in ~w~I." at "y"
+"f is not defined in ~w~I." at "f"
+--- */
+let ws: ~w~I = 	{u: 1, x: 1, y: 1, z: 1, f: function(){}}; ws; 
+/* XPECT warnings --- 
+"u is not defined in ~i~I." at "u"
+"y is not defined in ~i~I." at "y"
+"f is not defined in ~i~I." at "f"
+--- */
+let is: ~i~I = 	{u: 1, x: 1, y: 1, z: 1, f: function(){}}; is;
+
+// dynamic type XPECT nowarnings -->
+let id: ~I+ = {u: 1, x: 1, y: 1, z: 1, f: function(){}}; id;
+
+function f(p: ~~I) {}
+// XPECT warnings --> "u is not defined in ~~I." at "u"
+f({u: 1, x: 1, y: 1, z: 1}) 
+
+// no warnings if type is plain object XPECT nowarnings -->
+let os:~Object = {u: 1, x: 1, y: 1, z: 1, f: function(){}}; os;
+
+/* XPECT warnings --- 
+"f is not defined in ~Object with { x: int; y: int; z: int }." at "f"
+"u is not defined in ~Object with { x: int; y: int; z: int }." at "u"
+--- */
+let osw:~Object with {x:int, y:int,z:int} = {u: 1, x: 1, y: 1, z: 1, f: function(){}}; osw;
+
+class C {
+	public x: int
+	constructor(@Spec spec: ~i~this){}
+}
+
+// XPECT warnings --> "y is not defined in ~i~this[C]." at "y"
+new C({x:42, y:1});

--- a/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch08_02_01_SuperKeyword/SuperCall.n4js.xt
+++ b/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch08_02_01_SuperKeyword/SuperCall.n4js.xt
@@ -60,6 +60,7 @@ class T1Sub extends T1 {
 	public f : string;
 
 	constructor() {
+		// XPECT warnings --> "f is not defined in ~~this[T1]." at "f"
 		super( {f: "hi there!"} );				// ok
 	}
 }
@@ -69,7 +70,11 @@ class T1Sub2 extends T1 {
 	public f : string;
 
 	constructor() {
-		// No error since IDEBUG-262 XPECT noerrors --> "~Object with { number f; number n; } is not a structural subtype of ~~T1Sub2: f failed: number is not equal to string." at "{f: 43, n: 42}"
+		// No error since IDEBUG-262:  noerrors --> "~Object with { number f; number n; } is not a structural subtype of ~~T1Sub2: f failed: number is not equal to string." at "{f: 43, n: 42}"
+		/* XPECT warnings ---
+		   "f is not defined in ~~this[T1]." at "f"
+		   "n is not defined in ~~this[T1]." at "n"
+		   --- */
 		super( {f: 43, n: 42} );				// f here is only resolved against ~~T and there is no property !
 	}
 }

--- a/tests/org.eclipse.n4js.xpect.tests/model/typemodifier/optional_field_getter_setter.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/typemodifier/optional_field_getter_setter.n4js.xt
@@ -25,5 +25,5 @@ let v = { name: "N4" }
 foo(v);
 
 
-// XPECT noerrors -->
+// XPECT warnings --> "name is not defined in ~~I." at "name"
 foo({ name: "N4"});

--- a/tests/org.eclipse.n4js.xpect.tests/model/typemodifier/optional_getterSetterFieldCombinations.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/typemodifier/optional_getterSetterFieldCombinations.n4js.xt
@@ -395,7 +395,7 @@ rcs = d0;
 rcs = new D0();
 
 
-// XPECT noerrors
+// no errors but XPECT warnings -->"f is not defined in ~r~CS." at "get f(): string {return null;}"
 rcs = { get f(): string {return null;} };
 // XPECT noerrors --> "setter of CS not included in ~r~CS, so not required here"
 rcs = dg;
@@ -403,7 +403,7 @@ rcs = dg;
 rcs = new DG();
 
 
-// XPECT noerrors -->
+// no errors but XPECT warnings -->"f is not defined in ~r~CS." at "get f(): string {return null;}"
 rcs = { get f(): string {return null;} };
 // XPECT noerrors -->
 rcs = ds;
@@ -411,7 +411,10 @@ rcs = ds;
 rcs = new DS();
 
 
-// XPECT noerrors
+/* no errors but XPECT warnings ---
+"f is not defined in ~r~CS." at "get f(): string {return null;}"
+"f is not defined in ~r~CS." at "set f(value: string) {}"
+--- */
 rcs = { get f(): string {return null;}, set f(value: string) {} }
 // XPECT noerrors -->
 rcs = dgs;
@@ -419,7 +422,7 @@ rcs = dgs;
 rcs = new DGS();
 
 
-// XPECT noerrors
+// no errors but XPECT warnings -->"f is not defined in ~r~CS." at "f"
 rcs = { string f : null }
 // XPECT noerrors -->
 rcs = df;
@@ -621,7 +624,7 @@ wcg = d0;
 wcg = new D0();
 
 
-// XPECT noerrors
+// no errors but XPECT warnings -->"f is not defined in ~w~CG." at "get f(): string {return null;}"
 wcg = { get f(): string {return null;} }
 // XPECT noerrors -->
 wcg = dg;
@@ -629,7 +632,7 @@ wcg = dg;
 wcg = new DG();
 
 
-// XPECT noerrors
+// no errors but XPECT warnings -->"f is not defined in ~w~CG." at "set f(value: string) {}"
 wcg = { set f(value: string) {} }
 // XPECT noerrors -->
 wcg = ds;
@@ -637,7 +640,10 @@ wcg = ds;
 wcg = new DS();
 
 
-// XPECT noerrors
+/* no errors but XPECT warnings ---
+"f is not defined in ~w~CG." at "get f(): string {return null;}"
+"f is not defined in ~w~CG." at "set f(value: string) {}"
+--- */
 wcg = { get f(): string {return null;}, set f(value: string) {} }
 // XPECT noerrors -->
 wcg = dgs;
@@ -645,7 +651,7 @@ wcg = dgs;
 wcg = new DGS();
 
 
-// XPECT noerrors
+// no errors but XPECT warnings -->"f is not defined in ~w~CG." at "f"
 wcg = { string f: null }
 // XPECT noerrors -->
 wcg = df;
@@ -891,7 +897,7 @@ icg = d0;
 icg = new D0();
 
 
-// XPECT noerrors
+// no errors but XPECT warnings -->"f is not defined in ~i~CG." at "get f(): string {return null;}"
 icg = { get f(): string {return null;} }
 // XPECT noerrors -->
 icg = dg;
@@ -899,7 +905,7 @@ icg = dg;
 icg = new DG();
 
 
-// XPECT noerrors
+// no errors but XPECT warnings -->"f is not defined in ~i~CG." at "set f(value: string) {}"
 icg = { set f(value: string) {} }
 // XPECT noerrors -->
 icg = ds;
@@ -907,7 +913,10 @@ icg = ds;
 icg = new DS();
 
 
-// XPECT noerrors
+/* no errors but XPECT warnings ---
+"f is not defined in ~i~CG." at "get f(): string {return null;}"
+"f is not defined in ~i~CG." at "set f(value: string) {}"
+--- */
 icg = { get f(): string {return null;}, set f(value: string) {} }
 // XPECT noerrors -->
 icg = dgs;
@@ -915,7 +924,7 @@ icg = dgs;
 icg = new DGS();
 
 
-// XPECT noerrors
+// no errors but XPECT warnings -->"f is not defined in ~i~CG." at "f"
 icg = { string f: null }
 // XPECT noerrors -->
 icg = df;

--- a/tests/org.eclipse.n4js.xpect.tests/model/typesystem/AT_691_structuralTypingThisAndObjectLiteral.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/typesystem/AT_691_structuralTypingThisAndObjectLiteral.n4js.xt
@@ -29,7 +29,7 @@ foo({s: 42, f: function(){}});
 
 // ok
 bar({s: "Hello"});
-// ok
+// XPECT warnings --> "foo is not defined in ~~S." at "foo"
 bar({s: "Hello", foo: function(){}});
 // "s has wrong type: int is not a subtype of string" XPECT errors --> "~Object with { s: int; foo: {function():void} } is not a structural subtype of ~~S: s failed: int is not equal to string." at "{s: 42,  foo: function(){}}"
 bar({s: 42,  foo: function(){}});

--- a/tests/org.eclipse.n4js.xpect.tests/model/typesystem/GHOLD_0004_StructuralSubtypingMatrix.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/typesystem/GHOLD_0004_StructuralSubtypingMatrix.n4js.xt
@@ -302,7 +302,8 @@ class ~SA { public f : string}
 		let sn4O : ~N4Object = {};
 	}
 	{
-		// ~Object with additional members <: ~N4Object without additional  members XPECT noerrors -->
+		// ~Object with additional members <: ~N4Object without additional  members noerrors but
+		// XPECT warnings --> "f is not defined in ~N4Object." at "f"
 		let sn4O : ~N4Object = { f : "" }
 	}
 	{


### PR DESCRIPTION
#225 

This replaces old validation of superfluous properties in spec constructors, as that becomes a special case of this more general solution.