### PR TITLE
GH-232: fullyPostProcessed flag in N4JSResource and cache is out of sync

### DIFF
--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/ASTMetaInfoCacheHelper.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/ASTMetaInfoCacheHelper.java
@@ -37,7 +37,7 @@ import it.xsemantics.runtime.RuleEnvironment;
 @Singleton
 public final class ASTMetaInfoCacheHelper {
 
-	private static final boolean DEBUG_TRACK_CACHE_CREATION_DELETION = false;
+	private static final boolean DEBUG_TRACK_CACHE_CREATION_DELETION = true;
 
 	@Inject
 	private IResourceScopeCache resourceScopeCacheHelper;
@@ -86,20 +86,25 @@ public final class ASTMetaInfoCacheHelper {
 			// DEBUG: use the following code to track cache creation/deletion
 			if (DEBUG_TRACK_CACHE_CREATION_DELETION) {
 				final String newCacheId = Integer.toHexString(newCache.hashCode());
-				System.out.println("!! creating new cache " + newCacheId
-						+ " (on resource " + Integer.toHexString(res.hashCode()) + "; URI: " + res.getURI() + ")");
+				// System.out.println("!! creating new cache " + newCacheId
+				// + " (on resource " + Integer.toHexString(res.hashCode()) + "; URI: " + res.getURI() + ")");
 				((OnChangeEvictingCache) resourceScopeCacheHelper).getOrCreate(res).addCacheListener((cacheAdapter) -> {
 					if (!newCache.isEmpty()) {
-						System.out.println("!!!! clearing non-empty cache " + newCacheId + " (on resource "
-								+ Integer.toHexString(res.hashCode()) + "; URI: " + res.getURI() + ").");
+						// System.out.println("!!!! clearing non-empty cache " + newCacheId + " (on resource "
+						// + Integer.toHexString(res.hashCode()) + "; URI: " + res.getURI() + ").");
+						res.lastOtherCacheClearTrace = new IllegalStateException();
 					} else {
-						System.out.println("!!!! clearing empty cache " + newCacheId + " (on resource "
-								+ Integer.toHexString(res.hashCode()) + "; URI: " + res.getURI() + ").");
+						// System.out.println("!!!! clearing empty cache " + newCacheId + " (on resource "
+						// + Integer.toHexString(res.hashCode()) + "; URI: " + res.getURI() + ").");
+						res.lastOtherCacheClearTrace = new IllegalStateException();
 					}
 					if (newCache.isProcessingInProgress()) {
 						// DEBUG: good place for a break point when hunting down an accidental cache clear
 						System.out.println("!!!! WARNING suspicious cache clear (cache " + newCacheId + " (on resource "
 								+ Integer.toHexString(res.hashCode()) + "; URI: " + res.getURI() + ").");
+						res.suspiciousCacheClearTrace = new IllegalStateException();
+						res.suspiciousCacheClearTrace.printStackTrace();
+
 					}
 				});
 			}

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/ASTMetaInfoCacheHelper.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/ASTMetaInfoCacheHelper.java
@@ -21,10 +21,7 @@ import org.eclipse.n4js.resource.N4JSResource;
 import org.eclipse.n4js.ts.typeRefs.TypeRef;
 import org.eclipse.n4js.ts.types.TypableElement;
 import org.eclipse.n4js.typesystem.N4JSTypeSystem;
-import org.eclipse.xtext.util.IResourceScopeCache;
-import org.eclipse.xtext.util.OnChangeEvictingCache;
 
-import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 import it.xsemantics.runtime.Result;
@@ -36,11 +33,6 @@ import it.xsemantics.runtime.RuleEnvironment;
  */
 @Singleton
 public final class ASTMetaInfoCacheHelper {
-
-	private static final boolean DEBUG_TRACK_CACHE_CREATION_DELETION = true;
-
-	@Inject
-	private IResourceScopeCache resourceScopeCacheHelper;
 
 	/**
 	 * <b>IMPORTANT:</b> most clients should use {@link N4JSTypeSystem#type(RuleEnvironment, TypableElement)} instead!
@@ -77,39 +69,6 @@ public final class ASTMetaInfoCacheHelper {
 	 * Returns the {@link ASTMetaInfoCache} of the given resource, optionally creating it if it does not exist already.
 	 */
 	public ASTMetaInfoCache getOrCreate(N4JSResource res) {
-		return resourceScopeCacheHelper.get(ASTMetaInfoCache.class, res, () -> {
-			// at the time the cache is created (i.e. quite early), we can assume that all errors are syntax errors
-			// created by the parser or the ASTStructureValidator
-			final boolean hasBrokenAST = !res.getErrors().isEmpty();
-			final ASTMetaInfoCache newCache = new ASTMetaInfoCache(res, hasBrokenAST);
-
-			// DEBUG: use the following code to track cache creation/deletion
-			if (DEBUG_TRACK_CACHE_CREATION_DELETION) {
-				final String newCacheId = Integer.toHexString(newCache.hashCode());
-				// System.out.println("!! creating new cache " + newCacheId
-				// + " (on resource " + Integer.toHexString(res.hashCode()) + "; URI: " + res.getURI() + ")");
-				((OnChangeEvictingCache) resourceScopeCacheHelper).getOrCreate(res).addCacheListener((cacheAdapter) -> {
-					if (!newCache.isEmpty()) {
-						// System.out.println("!!!! clearing non-empty cache " + newCacheId + " (on resource "
-						// + Integer.toHexString(res.hashCode()) + "; URI: " + res.getURI() + ").");
-						res.lastOtherCacheClearTrace = new IllegalStateException();
-					} else {
-						// System.out.println("!!!! clearing empty cache " + newCacheId + " (on resource "
-						// + Integer.toHexString(res.hashCode()) + "; URI: " + res.getURI() + ").");
-						res.lastOtherCacheClearTrace = new IllegalStateException();
-					}
-					if (newCache.isProcessingInProgress()) {
-						// DEBUG: good place for a break point when hunting down an accidental cache clear
-						System.out.println("!!!! WARNING suspicious cache clear (cache " + newCacheId + " (on resource "
-								+ Integer.toHexString(res.hashCode()) + "; URI: " + res.getURI() + ").");
-						res.suspiciousCacheClearTrace = new IllegalStateException();
-						res.suspiciousCacheClearTrace.printStackTrace();
-
-					}
-				});
-			}
-
-			return newCache;
-		});
+		return res.getASTMetaInfoCache();
 	}
 }

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/ASTProcessor.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/ASTProcessor.xtend
@@ -127,9 +127,6 @@ public class ASTProcessor extends AbstractProcessor {
 			if (G.canceled) {
 				log(0, "CANCELED by cancelIndicator");
 			}
-
-			// note: doesn't matter if processing succeeded, failed or was canceled
-			// (even if it failed or was canceled, we do not want to try again)
 			cache.endProcessing();
 
 			if (isDEBUG_LOG_RESULT) {
@@ -191,15 +188,6 @@ public class ASTProcessor extends AbstractProcessor {
 		log(indentLevel, "processing: " + node.objectInfo);
 
 		checkCanceled(G);
-
-
-if(node instanceof N4MethodDeclaration) {
-	for(var i=0;i<10;i++) {
-		checkCanceled(G);
-		Thread.sleep(500);
-	}
-}
-
 
 		// already done as part of a forward processing?
 		if (cache.forwardProcessedSubTrees.contains(node)) {

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/ASTProcessor.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/ASTProcessor.xtend
@@ -55,6 +55,7 @@ import org.eclipse.xtext.util.CancelIndicator
 
 import static extension org.eclipse.n4js.typesystem.RuleEnvironmentExtensions.*
 import static extension org.eclipse.n4js.utils.N4JSLanguageUtils.*
+import org.eclipse.n4js.n4JS.N4MethodDeclaration
 
 /**
  * Main processor used during {@link N4JSPostProcessor post-processing} of N4JS resources. It controls the overall
@@ -190,6 +191,15 @@ public class ASTProcessor extends AbstractProcessor {
 		log(indentLevel, "processing: " + node.objectInfo);
 
 		checkCanceled(G);
+
+
+if(node instanceof N4MethodDeclaration) {
+	for(var i=0;i<10;i++) {
+		checkCanceled(G);
+		Thread.sleep(500);
+	}
+}
+
 
 		// already done as part of a forward processing?
 		if (cache.forwardProcessedSubTrees.contains(node)) {

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/ASTProcessor.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/ASTProcessor.xtend
@@ -55,7 +55,6 @@ import org.eclipse.xtext.util.CancelIndicator
 
 import static extension org.eclipse.n4js.typesystem.RuleEnvironmentExtensions.*
 import static extension org.eclipse.n4js.utils.N4JSLanguageUtils.*
-import org.eclipse.n4js.n4JS.N4MethodDeclaration
 
 /**
  * Main processor used during {@link N4JSPostProcessor post-processing} of N4JS resources. It controls the overall

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/TypeProcessor.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/TypeProcessor.xtend
@@ -267,7 +267,13 @@ public class TypeProcessor extends AbstractProcessor {
 					// (HINT: if you get an exception here, this often indicates an accidental cache clear; use the
 					// debug code in ASTMetaInfoCacheHelper to track creation/deletion of typing caches to investigate this)
 					val e = new IllegalStateException("typing of entire AST not initiated yet (hint: this is often caused by an accidental cache clear!!)")
-					e.printStackTrace // make sure we see this on the console (some clients eat up all exceptions!)
+					println("-------------main exception:")
+					e.printStackTrace(System.out) // make sure we see this on the console (some clients eat up all exceptions!)
+					println("-------------lastOther:")
+					res.lastOtherCacheClearTrace?.printStackTrace(System.out);
+					println("-------------suspicious:")
+					res.suspiciousCacheClearTrace?.printStackTrace(System.out);
+					println("-------------end")
 					throw e;
 				} else if (cache.isProcessingInProgress) {
 

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/TypeProcessor.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/TypeProcessor.xtend
@@ -262,18 +262,11 @@ public class TypeProcessor extends AbstractProcessor {
 			} else if (obj.isASTNode && obj.isTypableNode) {
 				// here we read from the cache (if AST node 'obj' was already processed) or forward-process 'obj'
 				val cache = astMetaInfoCacheHelper.getOrCreate(res);
-				if (!cache.isProcessingInProgress && !cache.isFullyProcessed) {
+				if (!cache.isProcessingInProgress && !res.isFullyProcessed) {
 					// we have called #performPostProcessing() on the containing resource above, so this is "impossible"
 					// (HINT: if you get an exception here, this often indicates an accidental cache clear; use the
 					// debug code in ASTMetaInfoCacheHelper to track creation/deletion of typing caches to investigate this)
 					val e = new IllegalStateException("typing of entire AST not initiated yet (hint: this is often caused by an accidental cache clear!!)")
-					println("-------------main exception:")
-					e.printStackTrace(System.out) // make sure we see this on the console (some clients eat up all exceptions!)
-					println("-------------lastOther:")
-					res.lastOtherCacheClearTrace?.printStackTrace(System.out);
-					println("-------------suspicious:")
-					res.suspiciousCacheClearTrace?.printStackTrace(System.out);
-					println("-------------end")
 					throw e;
 				} else if (cache.isProcessingInProgress) {
 
@@ -291,7 +284,7 @@ public class TypeProcessor extends AbstractProcessor {
 						// -> simply read from cache
 						return resultFromCache;
 					}
-				} else if (cache.isFullyProcessed) {
+				} else if (res.isFullyProcessed) {
 					return cache.getType(obj); // will throw exception in case of cache miss
 				}
 			} else {

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSCache.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSCache.java
@@ -35,6 +35,9 @@ public class N4JSCache extends OnChangeEvictingCache {
 	@Inject
 	private OperationCanceledManager operationCanceledManager;
 
+	@Inject
+	private N4JSDerivedStateComputer derivedStateComputer;
+
 	@Override
 	public CacheAdapter getOrCreate(Resource resource) {
 		// copied from super method, but we expect N4JSCacheAdapter here

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSResource.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSResource.java
@@ -91,6 +91,9 @@ import com.google.inject.Inject;
  */
 public class N4JSResource extends PostProcessingAwareResource implements ProxyResolvingResource {
 
+	public Throwable lastOtherCacheClearTrace = null;
+	public Throwable suspiciousCacheClearTrace = null;
+
 	/**
 	 * Special contents list which allows for the first slot to be a proxy in case the resource has been created by
 	 * loading the type information (slot 1) from the xtext index, i.e. the IObjectDescrition's user data.

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSResource.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSResource.java
@@ -49,6 +49,7 @@ import org.eclipse.n4js.n4JS.N4JSFactory;
 import org.eclipse.n4js.n4JS.N4JSPackage;
 import org.eclipse.n4js.n4JS.Script;
 import org.eclipse.n4js.parser.InternalSemicolonInjectingParser;
+import org.eclipse.n4js.postprocessing.ASTMetaInfoCache;
 import org.eclipse.n4js.projectModel.IN4JSCore;
 import org.eclipse.n4js.scoping.diagnosing.N4JSScopingDiagnostician;
 import org.eclipse.n4js.scoping.utils.CanLoadFromDescriptionHelper;
@@ -91,8 +92,20 @@ import com.google.inject.Inject;
  */
 public class N4JSResource extends PostProcessingAwareResource implements ProxyResolvingResource {
 
-	public Throwable lastOtherCacheClearTrace = null;
-	public Throwable suspiciousCacheClearTrace = null;
+	private ASTMetaInfoCache metaInfoCache;
+
+	/**
+	 * Retrieve the ASTMetaInfo cache of this resource. If not exist, a new cache is created.
+	 */
+	public ASTMetaInfoCache getASTMetaInfoCache() {
+		if (metaInfoCache == null) {
+			final boolean hasBrokenAST = !getErrors().isEmpty();
+			metaInfoCache = new ASTMetaInfoCache(this, hasBrokenAST);
+		}
+		final boolean hasBrokenAST = !getErrors().isEmpty();
+		metaInfoCache.setHasBrokenAST(hasBrokenAST);
+		return metaInfoCache;
+	}
 
 	/**
 	 * Special contents list which allows for the first slot to be a proxy in case the resource has been created by

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/PostProcessingAwareResource.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/PostProcessingAwareResource.java
@@ -174,12 +174,13 @@ public class PostProcessingAwareResource extends DerivedStateAwareResource {
 					super.resolveLazyCrossReferences(cancelIndicator);
 				}
 				postProcessor.performPostProcessing(this, cancelIndicator);
+				// fullyPostProcessed is only set to true when performPostProcessing above is successful and does not
+				// throw any exception. When a resource's fullPostProcessed flag is true, it is guaranteed that the
+				// resource's ASTMetaInfoCache
+				// contains cached types.
+				fullyPostProcessed = true;
 			} finally {
 				isPostProcessing = false;
-				// note: doesn't matter if processing succeeded, failed or was canceled
-				// (even if it failed or was canceled, we do not want to try again)
-				// Identical behavior as in ASTProcessor.processAST(RuleEnvironment, N4JSResource, CancelIndicator)
-				fullyPostProcessed = true;
 			}
 		}
 	}

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/PostProcessingAwareResource.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/PostProcessingAwareResource.java
@@ -45,13 +45,7 @@ public class PostProcessingAwareResource extends DerivedStateAwareResource {
 	private OutdatedStateManager outdatedStateManager;
 
 	/**
-	 * New semantics to fix IDE-2503: Set to true if the resource is loaded and fully initialized and
-	 * {@link #performPostProcessing(CancelIndicator)} has been invoked for it. It does not matter whether or not
-	 * processing was successful. However, this can be set to false later. It is crucial that this flag is in sync with
-	 * ASTMetaInfoCache's isFullyPostProcessed at all time.
-	 *
-	 * Note that the previous semantics before IDE-2503 bug fix is: True iff
-	 * {@link #performPostProcessing(CancelIndicator)} has been invoked and has completed successfully.
+	 * True iff {@link #performPostProcessing(CancelIndicator)} has been invoked and has completed successfully.
 	 */
 	protected volatile boolean fullyPostProcessed = false;
 	/**

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSMemberValidator.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSMemberValidator.xtend
@@ -67,14 +67,7 @@ import org.eclipse.xtext.service.OperationCanceledManager
  */
 class N4JSMemberValidator extends AbstractN4JSDeclarativeValidator {
 
-@Check
-def void checkTEMP(N4MethodDeclaration mdecl) {
-	//Thread.sleep(1000);
-}
-
-
 	@Inject ContainerTypesHelper containerTypesHelper;
-
 	@Inject
 	private JavaScriptVariantHelper jsVariantHelper;
 

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSMemberValidator.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSMemberValidator.xtend
@@ -52,6 +52,7 @@ import static org.eclipse.n4js.n4JS.N4JSPackage.Literals.*
 import static org.eclipse.n4js.validation.IssueCodes.*
 
 import static extension org.eclipse.n4js.typesystem.RuleEnvironmentExtensions.*
+import org.eclipse.xtext.service.OperationCanceledManager
 
 /**
  * Validation of rules that apply to individual members of a classifier.<p>
@@ -65,6 +66,12 @@ import static extension org.eclipse.n4js.typesystem.RuleEnvironmentExtensions.*
  * </ul>
  */
 class N4JSMemberValidator extends AbstractN4JSDeclarativeValidator {
+
+@Check
+def void checkTEMP(N4MethodDeclaration mdecl) {
+	//Thread.sleep(1000);
+}
+
 
 	@Inject ContainerTypesHelper containerTypesHelper;
 

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSMemberValidator.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSMemberValidator.xtend
@@ -11,6 +11,7 @@
 package org.eclipse.n4js.validation.validators
 
 import com.google.inject.Inject
+import java.util.List
 import org.eclipse.n4js.AnnotationDefinition
 import org.eclipse.n4js.n4JS.N4ClassDeclaration
 import org.eclipse.n4js.n4JS.N4ClassDefinition
@@ -41,7 +42,6 @@ import org.eclipse.n4js.utils.N4JSLanguageUtils
 import org.eclipse.n4js.validation.AbstractN4JSDeclarativeValidator
 import org.eclipse.n4js.validation.IssueCodes
 import org.eclipse.n4js.validation.JavaScriptVariantHelper
-import java.util.List
 import org.eclipse.xtext.EcoreUtil2
 import org.eclipse.xtext.util.Tuples
 import org.eclipse.xtext.validation.Check
@@ -52,7 +52,6 @@ import static org.eclipse.n4js.n4JS.N4JSPackage.Literals.*
 import static org.eclipse.n4js.validation.IssueCodes.*
 
 import static extension org.eclipse.n4js.typesystem.RuleEnvironmentExtensions.*
-import org.eclipse.xtext.service.OperationCanceledManager
 
 /**
  * Validation of rules that apply to individual members of a classifier.<p>


### PR DESCRIPTION
## Task
Link: https://github.com/eclipse/n4js/issues/232

This PR changes the way we cache meta info (i.e. types) of N4JSResource. In the particular, the following changes are made:

- We do not use Xtext cache to cache ASTMetaInfo anymore. The rational behind this is that at any time, Xtext or our code can trigger a cache clear which will removes the cache. However, when a cache clear occurs, the N4JSResource state (as defined by flags fullyInitialized/fullPostProcessed) remains unchanged. In other words, the state of cache and the state of N4JSResource will become out of sync.
- The flag N4JSResource's fullyPostProcessed has a new semantics. If this flag is true, then the AST has been successfully processed and the cache contains types of all typable AST nodes.
- Cache's flag fullyPostProcessed has been removed.