### PR TITLE
IDE-2896: Experimental: turn off canLoadFromDescription logic

### DIFF
--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/scoping/utils/CanLoadFromDescriptionHelper.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/scoping/utils/CanLoadFromDescriptionHelper.java
@@ -10,11 +10,7 @@
  */
 package org.eclipse.n4js.scoping.utils;
 
-import java.util.ArrayDeque;
 import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.Queue;
 import java.util.Set;
 
 import org.eclipse.emf.common.util.URI;
@@ -25,7 +21,6 @@ import org.eclipse.n4js.resource.UserdataMapper;
 import org.eclipse.xtext.resource.IResourceDescription;
 import org.eclipse.xtext.resource.IResourceDescriptions;
 
-import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
@@ -165,61 +160,68 @@ public class CanLoadFromDescriptionHelper {
 	 */
 	protected boolean dependsOnAny(URI thisURI, Set<URI> candidates, IResourceDescriptions index,
 			boolean considerOnlySameProject) {
-		if (candidates.isEmpty()) {
-			return false;
-		}
-		// Keep track of all visited resources
-		final Set<URI> visited = Sets.newHashSet();
-		// breadth first search since it is more likely to find resources from the same project
-		// in our own dependencies rather than in the transitive dependencies
-		final Queue<URI> queue = new ArrayDeque<>();
-		// the starting point. It is deliberately not added to the visited resources
-		// to allow to detect cycles.
-		queue.add(thisURI);
-
-		while (!queue.isEmpty()) {
-			// try to find the direct dependencies for the next URI in the queue
-			Optional<List<String>> dependencies = readDirectDependencies(index, queue.poll());
-			if (!dependencies.isPresent()) {
-				// none found - be pessimistic and return false
-				return true;
-			}
-			// traverse the direct dependencies
-			for (String dependency : dependencies.get()) {
-				// and convert each string based dependency to a URI
-				URI dependencyURI = URI.createURI(dependency);
-				// mark the dependency as visited and if its the first occurrence
-				if (visited.add(dependencyURI)) {
-					// are we only interested in the project local dependency graph?
-					if (considerOnlySameProject) {
-						// the initial URI and the current candidate stem from the same project?
-						if (n4jsCore.isInSameProject(thisURI, dependencyURI)) {
-							// it is part of the interesting resources, return true
-							if (candidates.contains(dependencyURI)) {
-								return true;
-							}
-							// enque the dependency
-							queue.add(dependencyURI);
-						}
-					} else {
-						// it is part of the interesting resources, return true
-						if (candidates.contains(dependencyURI)) {
-							return true;
-						}
-						// enqueue the dependency
-						queue.add(dependencyURI);
-					}
-				}
-			}
-		}
-		// the entire relevant graph was successfully traversed. There is no transitive dependency
-		// to one of the candidates
+		// disable this temporarily and go back to old behavior (i.e. can always load from index)
+		// FIXME IDE-2896 re-enable CanLoadFromDescription logic
 		return false;
+// @formatter:off
+//		if (candidates.isEmpty()) {
+//			return false;
+//		}
+//		// Keep track of all visited resources
+//		final Set<URI> visited = Sets.newHashSet();
+//		// breadth first search since it is more likely to find resources from the same project
+//		// in our own dependencies rather than in the transitive dependencies
+//		final Queue<URI> queue = new ArrayDeque<>();
+//		// the starting point. It is deliberately not added to the visited resources
+//		// to allow to detect cycles.
+//		queue.add(thisURI);
+//
+//		while (!queue.isEmpty()) {
+//			// try to find the direct dependencies for the next URI in the queue
+//			Optional<List<String>> dependencies = readDirectDependencies(index, queue.poll());
+//			if (!dependencies.isPresent()) {
+//				// none found - be pessimistic and return false
+//				return true;
+//			}
+//			// traverse the direct dependencies
+//			for (String dependency : dependencies.get()) {
+//				// and convert each string based dependency to a URI
+//				URI dependencyURI = URI.createURI(dependency);
+//				// mark the dependency as visited and if its the first occurrence
+//				if (visited.add(dependencyURI)) {
+//					// are we only interested in the project local dependency graph?
+//					if (considerOnlySameProject) {
+//						// the initial URI and the current candidate stem from the same project?
+//						if (n4jsCore.isInSameProject(thisURI, dependencyURI)) {
+//							// it is part of the interesting resources, return true
+//							if (candidates.contains(dependencyURI)) {
+//								return true;
+//							}
+//							// enque the dependency
+//							queue.add(dependencyURI);
+//						}
+//					} else {
+//						// it is part of the interesting resources, return true
+//						if (candidates.contains(dependencyURI)) {
+//							return true;
+//						}
+//						// enqueue the dependency
+//						queue.add(dependencyURI);
+//					}
+//				}
+//			}
+//		}
+//		// the entire relevant graph was successfully traversed. There is no transitive dependency
+//		// to one of the candidates
+//		return false;
+// @formatter:on
 	}
 
-	private Optional<List<String>> readDirectDependencies(IResourceDescriptions index, URI next) {
-		IResourceDescription description = index.getResourceDescription(next);
-		return Optional.ofNullable(description).flatMap(UserdataMapper::readDependenciesFromDescription);
-	}
+// @formatter:off
+//	private Optional<List<String>> readDirectDependencies(IResourceDescriptions index, URI next) {
+//		IResourceDescription description = index.getResourceDescription(next);
+//		return Optional.ofNullable(description).flatMap(UserdataMapper::readDependenciesFromDescription);
+//	}
+// @formatter:on
 
 }

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/scoping/utils/CanLoadFromDescriptionHelper.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/scoping/utils/CanLoadFromDescriptionHelper.java
@@ -21,7 +21,6 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.n4js.projectModel.IN4JSCore;
-import org.eclipse.n4js.resource.N4JSResource;
 import org.eclipse.n4js.resource.UserdataMapper;
 import org.eclipse.xtext.resource.IResourceDescription;
 import org.eclipse.xtext.resource.IResourceDescriptions;
@@ -75,33 +74,38 @@ public class CanLoadFromDescriptionHelper {
 	 * @return true, if the resource must be loaded from source.
 	 */
 	public boolean mustLoadFromSource(URI resourceURI, ResourceSet resourceSet) {
-		// We do already know the resource. Nothing fancy to happen here.
-		Resource knownResource = resourceSet.getResource(resourceURI, false);
-		if (knownResource != null) {
-			return false;
-		}
-
-		/*
-		 * Iterate all the resources in the resource set and check the instances that have been loaded from source. If
-		 * the to-be-loaded resource has a transitive dependency to any resource, that was loaded from source, we need
-		 * to load this resource from source, too.
-		 */
-		Set<URI> sourceURIs = Sets.newHashSet();
-		/*
-		 * We load resources concurrently in tests thus we may face a concurrent modification exception here if we
-		 * simply iterate over the resources. Therefore a classical for loop is used here.
-		 */
-		List<Resource> listOfResources = resourceSet.getResources();
-		for (int i = 0, size = listOfResources.size(); i < size; i++) {
-			Resource existingResource = listOfResources.get(i);
-			if (existingResource instanceof N4JSResource) {
-				N4JSResource casted = (N4JSResource) existingResource;
-				if (!casted.isLoadedFromDescription()) {
-					sourceURIs.add(casted.getURI());
-				}
-			}
-		}
-		return dependsOnAny(resourceURI, sourceURIs, getIndex(resourceSet), true);
+		// disable this temporarily and go back to old behavior (i.e. can always load from index)
+		// FIXME IDE-2896 re-enable CanLoadFromDescription logic
+		return false;
+// @formatter:off
+//		// We do already know the resource. Nothing fancy to happen here.
+//		Resource knownResource = resourceSet.getResource(resourceURI, false);
+//		if (knownResource != null) {
+//			return false;
+//		}
+//
+//		/*
+//		 * Iterate all the resources in the resource set and check the instances that have been loaded from source. If
+//		 * the to-be-loaded resource has a transitive dependency to any resource, that was loaded from source, we need
+//		 * to load this resource from source, too.
+//		 */
+//		Set<URI> sourceURIs = Sets.newHashSet();
+//		/*
+//		 * We load resources concurrently in tests thus we may face a concurrent modification exception here if we
+//		 * simply iterate over the resources. Therefore a classical for loop is used here.
+//		 */
+//		List<Resource> listOfResources = resourceSet.getResources();
+//		for (int i = 0, size = listOfResources.size(); i < size; i++) {
+//			Resource existingResource = listOfResources.get(i);
+//			if (existingResource instanceof N4JSResource) {
+//				N4JSResource casted = (N4JSResource) existingResource;
+//				if (!casted.isLoadedFromDescription()) {
+//					sourceURIs.add(casted.getURI());
+//				}
+//			}
+//		}
+//		return dependsOnAny(resourceURI, sourceURIs, getIndex(resourceSet), true);
+// @formatter:on
 	}
 
 	/**

--- a/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/scoping/CircularReferencesScopingTest.xtend
+++ b/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/scoping/CircularReferencesScopingTest.xtend
@@ -44,6 +44,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 import static org.junit.Assert.*
+import org.junit.Ignore
 
 /**
  * @see N4JSScopeProvider
@@ -90,6 +91,7 @@ class CircularReferencesScopingTest implements N4Scheme {
 		childURI = null
 	}
 
+	@Ignore("IDE-2896") // FIXME IDE-2896 re-enable this test!
 	@Test
 	def void testCircularDependencies() {
 		assertEquals(3, resourceDescriptions.getExportedObjectsByType(TypesPackage.Literals.TMODULE).size)

--- a/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/dirtystate/CanLoadFromDescriptionCyclicPluginUITest.xtend
+++ b/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/dirtystate/CanLoadFromDescriptionCyclicPluginUITest.xtend
@@ -16,12 +16,14 @@ import org.eclipse.core.resources.IProject
 import org.eclipse.core.resources.ResourcesPlugin
 import org.eclipse.core.runtime.ICoreRunnable
 import org.eclipse.core.runtime.NullProgressMonitor
-import org.junit.Test
 import org.eclipse.emf.common.util.URI
+import org.junit.Ignore
+import org.junit.Test
 
 /**
  * Test builder / editor behavior with multiple files and cyclic dependencies.
  */
+@Ignore("IDE-2896") // FIXME IDE-2896 re-enable this test!
 class CanLoadFromDescriptionCyclicPluginUITest extends AbstractCanLoadFromDescriptionTest {
 	/*
 	 * X <- Y <- A <- B <- C <- D

--- a/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/dirtystate/CanLoadFromDescriptionPluginUITest.xtend
+++ b/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/dirtystate/CanLoadFromDescriptionPluginUITest.xtend
@@ -17,11 +17,13 @@ import org.eclipse.core.resources.ResourcesPlugin
 import org.eclipse.core.runtime.ICoreRunnable
 import org.eclipse.core.runtime.NullProgressMonitor
 import org.eclipse.emf.common.util.URI
+import org.junit.Ignore
 import org.junit.Test
 
 /**
  * 
  */
+@Ignore("IDE-2896") // FIXME IDE-2896 re-enable this test!
 class CanLoadFromDescriptionPluginUITest extends AbstractCanLoadFromDescriptionTest {
 	/*
 	 * A1 -> B1 -> C -> D


### PR DESCRIPTION
Merging this will temporarily disable the CanLoadFromDescriptionHelper, i.e. all dependencies will be loaded from Xtext index, none from AST (the old behavior).