### PR TITLE
GH-366 Unnecessary scanning of the non source paths when wildcards are defined

### DIFF
--- a/plugins/org.eclipse.n4js.n4mf/src/org/eclipse/n4js/n4mf/validation/WildcardPathFilter.xtend
+++ b/plugins/org.eclipse.n4js.n4mf/src/org/eclipse/n4js/n4mf/validation/WildcardPathFilter.xtend
@@ -48,6 +48,9 @@ class WildcardPathFilter {
 	}
 
 	private def static Pair<List<String>, List<String>> collectAllFoldersAndFilesByWildcardPath(String absoluteProjectPath, String matchString, boolean addFileExtensionPattern) {
+		if(!(new File(absoluteProjectPath)).exists)
+			return #[]->#[]
+		
 		val newMatchString = matchString.replace("\\", File.separator).replace("/", File.separator).adaptWildcard(addFileExtensionPattern)
 		val separator = File.separator + ".."
 		val splittedMatchStringParts = newMatchString.split(Pattern.quote(separator)).iterator

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/internal/AbstractN4JSCore.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/internal/AbstractN4JSCore.java
@@ -103,14 +103,19 @@ public abstract class AbstractN4JSCore implements IN4JSCore {
 
 		List<String> relativeResolvedPaths = new ArrayList<>();
 		for (ModuleFilterSpecifier spec : moduleFilter.getModuleSpecifiers()) {
-			String moduleSpecWithWildcard = spec.getModuleSpecifierWithWildcard();
-			moduleSpecWithWildcard = ((spec.getSourcePath() != null) ? spec.getSourcePath()
-					: projectRelativeSourcePath) + "/" + moduleSpecWithWildcard;
-			List<String> resolvedPaths = WildcardPathFilter.collectPathsByWildcardPath(absoluteLocationPath,
-					moduleSpecWithWildcard);
-			for (String resolvedPath : resolvedPaths) {
-				relativeResolvedPaths.add(resolvedPath);
-			}
+			String specPath = spec.getSourcePath();
+			if (specPath != null)
+				if (projectRelativeSourcePath.equals(specPath) == false)
+					// different source container, different filter path
+					// nothing will be found here
+					continue;
+
+			String basePathToCheck = absoluteLocationPath + "/"
+					+ (specPath != null ? specPath : projectRelativeSourcePath);
+			String pathsToFind = "/" + spec.getModuleSpecifierWithWildcard();
+			List<String> resolvedPaths = WildcardPathFilter.collectPathsByWildcardPath(basePathToCheck,
+					pathsToFind);
+			relativeResolvedPaths.addAll(resolvedPaths);
 		}
 		return relativeResolvedPaths;
 	}


### PR DESCRIPTION
Changes to project paths scanning when handling module filters, i.e. ignore non source paths.