### PR TITLE
GH-291: Remove API Compare View from disabled contributions

### DIFF
--- a/plugins/org.eclipse.n4js.product/plugin.xml
+++ b/plugins/org.eclipse.n4js.product/plugin.xml
@@ -349,10 +349,6 @@ Contributors:
       </activityPatternBinding>
       <activityPatternBinding
             activityId="org.eclipse.n4js.product.activity"
-            pattern=".*/org.eclipse.n4js.ui.apicompareview">
-      </activityPatternBinding>
-      <activityPatternBinding
-            activityId="org.eclipse.n4js.product.activity"
             pattern=".*/org.eclipse.rse.ui.view.monitorView">
       </activityPatternBinding>
       <activityPatternBinding


### PR DESCRIPTION
Issue: https://github.com/eclipse/n4js/issues/291

The API Compare View extension had been associated with an Eclipse Activity (http://help.eclipse.org/neon/index.jsp?topic=%2Forg.eclipse.platform.doc.isv%2Freference%2Fextension-points%2Forg_eclipse_ui_activities.html) that we use to suppress unwanted plugin contributions in the IDE.

