### PR TITLE
GH-347: Safer access to DirtyStateEditorSupport of dirty resources

### DIFF
--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/PrevStateAwareDirtyStateManager.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/PrevStateAwareDirtyStateManager.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtext.resource.IResourceDescription;
 import org.eclipse.xtext.resource.impl.ResourceDescriptionChangeEvent;
+import org.eclipse.xtext.ui.editor.DirtyStateEditorSupport;
 import org.eclipse.xtext.ui.editor.DirtyStateManager;
 import org.eclipse.xtext.ui.editor.DocumentBasedDirtyResource;
 import org.eclipse.xtext.ui.editor.IDirtyResource;
@@ -97,8 +98,12 @@ public class PrevStateAwareDirtyStateManager extends DirtyStateManager {
 		try {
 			Field field = declaredFields[0];
 			field.setAccessible(true);
-			N4JSDirtyStateEditorSupport thingy = (N4JSDirtyStateEditorSupport) field.get(dirtyResource);
-			myDirtyResource = thingy.getDirtyResource();
+
+			Object fieldValue = field.get(dirtyResource);
+
+			if (fieldValue instanceof DirtyStateEditorSupport) {
+				myDirtyResource = ((DirtyStateEditorSupport) fieldValue).getDirtyResource();
+			}
 		} catch (IllegalArgumentException | IllegalAccessException e) {
 			// ignore
 		}


### PR DESCRIPTION
Issue: https://github.com/eclipse/n4js/issues/347

The existing implementation didn't allow for other subclasses of `DirtyStateEditorSupport`.
However, in case of manifest files the actual implementation was an instance of N4MFDirtyStateEditorSupport.

Since the method in use `getDirtyResource()` is part of the common superclass, this should fix the issue.