### PR TITLE
GH-402: Fix failing smoke tests on ConditionalExpression graph node creation

### DIFF
--- a/plugins/org.eclipse.n4js.flowgraphs/src/org/eclipse/n4js/flowgraphs/factories/ConditionalExpressionFactory.java
+++ b/plugins/org.eclipse.n4js.flowgraphs/src/org/eclipse/n4js/flowgraphs/factories/ConditionalExpressionFactory.java
@@ -35,7 +35,8 @@ class ConditionalExpressionFactory {
 		ComplexNode cNode = new ComplexNode(astpp.container(), condExpr);
 
 		HelperNode entryNode = new HelperNode(ENTRY_NODE, astpp.pos(), condExpr);
-		Node conditionNode = DelegatingNodeFactory.create(astpp, "condition", condExpr, condExpr.getExpression());
+		Node conditionNode = DelegatingNodeFactory.createOrHelper(astpp, "condition", condExpr,
+				condExpr.getExpression());
 		Node thenNode = DelegatingNodeFactory.create(astpp, "then", condExpr, condExpr.getTrueExpression());
 		Node elseNode = DelegatingNodeFactory.create(astpp, "else", condExpr, condExpr.getFalseExpression());
 		Node exitNode = new RepresentingNode(EXIT_NODE, astpp.pos(), condExpr);


### PR DESCRIPTION
see #402 