### PR TITLE
GH-346: Graceful handling of missing "react" dependency for N4JSX

### DIFF
--- a/plugins/org.eclipse.n4js.transpiler.es/src/org/eclipse/n4js/transpiler/es/transform/SanitizeImportsTransformation.xtend
+++ b/plugins/org.eclipse.n4js.transpiler.es/src/org/eclipse/n4js/transpiler/es/transform/SanitizeImportsTransformation.xtend
@@ -84,6 +84,10 @@ class SanitizeImportsTransformation extends Transformation {
 		val jsxBackendsName = steFor_React
 		// We lookup react's module using react helper.
 		val iMod = reactHelper.lookUpReactTModule(state.resource)
+		
+		if(iMod === null)
+			throw new RuntimeException("Cannot locate JSX backend for the " + state.resource.URI)
+		
 		val iSpec = _NamespaceImportSpecifier(jsxBackendsName.name, true)
 		val iDecl = _ImportDecl(null, iSpec);
 		insertBefore(state.im.scriptElements.get(0), iDecl);

--- a/plugins/org.eclipse.n4js.transpiler.es/src/org/eclipse/n4js/transpiler/es/transform/SanitizeImportsTransformation.xtend
+++ b/plugins/org.eclipse.n4js.transpiler.es/src/org/eclipse/n4js/transpiler/es/transform/SanitizeImportsTransformation.xtend
@@ -86,7 +86,7 @@ class SanitizeImportsTransformation extends Transformation {
 		val iMod = reactHelper.lookUpReactTModule(state.resource)
 		
 		if(iMod === null)
-			throw new RuntimeException("Cannot locate JSX backend for the " + state.resource.URI)
+			throw new RuntimeException("Cannot locate JSX backend for " + state.resource.URI)
 		
 		val iSpec = _NamespaceImportSpecifier(jsxBackendsName.name, true)
 		val iDecl = _ImportDecl(null, iSpec);

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/N4JSValidator.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/N4JSValidator.xtend
@@ -42,7 +42,6 @@ import org.eclipse.n4js.validation.validators.N4JSSuperValidator
 import org.eclipse.n4js.validation.validators.N4JSSyntaxValidator
 import org.eclipse.n4js.validation.validators.N4JSTypeValidator
 import org.eclipse.n4js.validation.validators.N4JSVariableValidator
-import org.eclipse.n4js.validation.validators.N4JSXReactBindingValidator
 import org.eclipse.n4js.validation.validators.ThirdPartyValidator
 import org.eclipse.n4js.validation.validators.UnsupportedFeatureValidator
 import org.eclipse.n4js.xsemantics.validation.InternalTypeSystemValidator
@@ -50,6 +49,7 @@ import org.eclipse.xtext.service.OperationCanceledManager
 import org.eclipse.xtext.validation.AbstractDeclarativeValidator
 import org.eclipse.xtext.validation.AbstractDeclarativeValidator.State
 import org.eclipse.xtext.validation.ComposedChecks
+import org.eclipse.n4js.validation.validators.N4JSXValidator
 
 /**
  * Validation rules for N4JS.
@@ -100,7 +100,7 @@ import org.eclipse.xtext.validation.ComposedChecks
 	N4JSSyntaxValidator,
 	N4JSTypeValidator,
 	N4JSVariableValidator,
-	N4JSXReactBindingValidator,
+	N4JSXValidator,
 	ThirdPartyValidator,
 	UnsupportedFeatureValidator
 

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/messages.properties
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/messages.properties
@@ -973,6 +973,8 @@ JSX_JSXSPROPERTYATTRIBUTE_NOT_DECLARED_IN_PROPS=warning;;;Attribute {0} is not a
 JSX_JSXELEMENT_IN_NON_JSX_RESOURCE=error;;;JSX element is expected to be placed in JSX like resource, was {0}.
 # No parameter
 JSX_REACT_NAMESPACE_NOT_ALLOWED=error;;;Namespace to react must be React.
+# No parameter
+JSX_REACT_NOT_RESOLVED=error;;;Cannot resolve JSX implementation.
 
 
 ### THIRD PARTY

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSImportValidator.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSImportValidator.xtend
@@ -29,6 +29,7 @@ import org.eclipse.n4js.ts.typeRefs.ParameterizedTypeRef
 import org.eclipse.n4js.ts.types.ModuleNamespaceVirtualType
 import org.eclipse.n4js.ts.types.TModule
 import org.eclipse.n4js.utils.Log
+import org.eclipse.n4js.utils.ResourceType
 import org.eclipse.n4js.validation.AbstractN4JSDeclarativeValidator
 import org.eclipse.n4js.validation.IssueCodes
 import org.eclipse.n4js.validation.JavaScriptVariantHelper
@@ -105,7 +106,22 @@ class N4JSImportValidator extends AbstractN4JSDeclarativeValidator {
 			}
 		}
 	}
-	
+
+	/**
+	 * We need jsx resources to depend on jsx backend. We are patching imports in the transpiler (to add the import to jsx backend if it is missing),
+	 * but transpiler will crash if that import will be invalid, i.e. project has no dependency on jsx backend. It would be ideal to add validation 
+	 * on manifest and not transpile, at least jsx files. Unfortunately changes to the manifest are a bit disconnected to changes of the individual 
+	 * files, e.g. adding jsx file does not trigger manifest validation. Also errors in the manifest do not prevent single file compilation. 
+	 * @see https://github.com/eclipse/n4js/issues/346
+	 */
+	@Check
+	def checkProjectDependsOnReact(Script script) {
+		val resourceType = ResourceType.getResourceType(script)
+		if (ResourceType.N4JSX === resourceType || ResourceType.JSX === resourceType)
+			if (reactHelper.lookUpReactTModule(script.eResource) === null)
+				addIssue(IssueCodes.getMessageForJSX_REACT_NOT_RESOLVED(), script, JSX_REACT_NOT_RESOLVED);
+	}
+
 	/** Make sure the namespace to react module is React. */
 	@Check
 	def checkReactImport(NamespaceImportSpecifier importSpecifier) {

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSImportValidator.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSImportValidator.xtend
@@ -41,6 +41,7 @@ import static org.eclipse.n4js.validation.IssueCodes.*
 
 import static extension org.eclipse.n4js.n4JS.N4JSASTUtils.*
 import static extension org.eclipse.n4js.organize.imports.ImportSpecifiersUtil.*
+import org.eclipse.n4js.n4JS.JSXElement
 
 /** Validations for the import statements. */
 @Log
@@ -117,9 +118,12 @@ class N4JSImportValidator extends AbstractN4JSDeclarativeValidator {
 	@Check
 	def checkProjectDependsOnReact(Script script) {
 		val resourceType = ResourceType.getResourceType(script)
-		if (ResourceType.N4JSX === resourceType || ResourceType.JSX === resourceType)
-			if (reactHelper.lookUpReactTModule(script.eResource) === null)
-				addIssue(IssueCodes.getMessageForJSX_REACT_NOT_RESOLVED(), script, JSX_REACT_NOT_RESOLVED);
+		if (!(ResourceType.N4JSX === resourceType || ResourceType.JSX === resourceType))
+			return
+
+		val firstJSXElement = script.eAllContents.findFirst[it instanceof JSXElement]
+		if (firstJSXElement !== null && reactHelper.lookUpReactTModule(script.eResource) === null)
+			addIssue(IssueCodes.getMessageForJSX_REACT_NOT_RESOLVED(), firstJSXElement, JSX_REACT_NOT_RESOLVED);
 	}
 
 	/** Make sure the namespace to react module is React. */

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSXReactBindingValidator.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSXReactBindingValidator.xtend
@@ -19,8 +19,9 @@ import org.eclipse.n4js.n4JS.IdentifierRef
 import org.eclipse.n4js.n4JS.JSXElement
 import org.eclipse.n4js.n4JS.JSXPropertyAttribute
 import org.eclipse.n4js.n4JS.JSXSpreadAttribute
-import org.eclipse.n4js.n4JS.N4JSPackage
+import org.eclipse.n4js.n4JS.NamespaceImportSpecifier
 import org.eclipse.n4js.n4JS.ParameterizedPropertyAccessExpression
+import org.eclipse.n4js.n4JS.Script
 import org.eclipse.n4js.n4jsx.ReactHelper
 import org.eclipse.n4js.ts.typeRefs.FunctionTypeExprOrRef
 import org.eclipse.n4js.ts.typeRefs.TypeRef
@@ -39,6 +40,13 @@ import org.eclipse.xsemantics.runtime.Result
 import org.eclipse.xtext.validation.Check
 import org.eclipse.xtext.validation.EValidatorRegistrar
 
+import static org.eclipse.n4js.n4JS.N4JSPackage.Literals.JSX_ELEMENT__JSX_CLOSING_NAME
+import static org.eclipse.n4js.n4JS.N4JSPackage.Literals.JSX_ELEMENT__JSX_ELEMENT_NAME
+import static org.eclipse.n4js.n4JS.N4JSPackage.Literals.JSX_PROPERTY_ATTRIBUTE__PROPERTY
+import static org.eclipse.n4js.n4JS.N4JSPackage.Literals.JSX_SPREAD_ATTRIBUTE__EXPRESSION
+import static org.eclipse.n4js.validation.IssueCodes.*
+
+import static extension org.eclipse.n4js.organize.imports.ImportSpecifiersUtil.*
 import static extension org.eclipse.n4js.typesystem.RuleEnvironmentExtensions.*
 
 /**
@@ -91,11 +99,44 @@ class N4JSXReactBindingValidator extends AbstractN4JSDeclarativeValidator {
 			case N4JSX: return
 			case JSX: return
 			default: {
-				val message = IssueCodes.getMessageForJSX_JSXELEMENT_IN_NON_JSX_RESOURCE(resType.name)
-				addIssue(message,jsxElem,IssueCodes.JSX_JSXELEMENT_IN_NON_JSX_RESOURCE);
+				val message = getMessageForJSX_JSXELEMENT_IN_NON_JSX_RESOURCE(resType.name)
+				addIssue(message,jsxElem, JSX_JSXELEMENT_IN_NON_JSX_RESOURCE);
 			}
 		}
 	}
+
+
+	/**
+	 * We need jsx resources to depend on jsx backend. We are patching imports in the transpiler (to add the import to jsx backend if it is missing),
+	 * but transpiler will crash if that import will be invalid, i.e. project has no dependency on jsx backend. It would be ideal to add validation 
+	 * on manifest and not transpile, at least jsx files. Unfortunately changes to the manifest are a bit disconnected to changes of the individual 
+	 * files, e.g. adding jsx file does not trigger manifest validation. Also errors in the manifest do not prevent single file compilation. 
+	 * @see https://github.com/eclipse/n4js/issues/346
+	 */
+	@Check
+	def checkProjectDependsOnReact(Script script) {
+		val resourceType = ResourceType.getResourceType(script)
+		if (!(ResourceType.N4JSX === resourceType || ResourceType.JSX === resourceType))
+			return
+
+		val firstJSXElement = script.eAllContents.findFirst[it instanceof JSXElement]
+		if (firstJSXElement !== null && reactHelper.lookUpReactTModule(script.eResource) === null)
+			addIssue(getMessageForJSX_REACT_NOT_RESOLVED(), firstJSXElement, JSX_REACT_NOT_RESOLVED);
+	}
+
+	/** Make sure the namespace to react module is React. */
+	@Check
+	def checkReactImport(NamespaceImportSpecifier importSpecifier) {
+		val module = importSpecifier.importedModule
+		if (reactHelper.isReactModule(module)) {
+			if (importSpecifier.alias != ReactHelper.REACT_NAMESPACE) {
+						addIssue(
+							getMessageForJSX_REACT_NAMESPACE_NOT_ALLOWED(),
+							importSpecifier, JSX_REACT_NAMESPACE_NOT_ALLOWED);
+			}
+		}
+	}
+
 
 	/**
 	 * This method checks that JSXElement bind to a valid React component function or class React component declaration
@@ -108,12 +149,12 @@ class N4JSXReactBindingValidator extends AbstractN4JSDeclarativeValidator {
 
 		if ((jsxElem.jsxClosingName !==null) && !(openingName == closingName)) {
 			//Only check if the closing element exists, e.g. not null
-			val message = IssueCodes.getMessageForJSX_JSXELEMENT_OPENING_CLOSING_ELEMENT_NOT_MATCH(openingName, closingName);
+			val message = getMessageForJSX_JSXELEMENT_OPENING_CLOSING_ELEMENT_NOT_MATCH(openingName, closingName);
 			addIssue(
 				message,
 				jsxElem,
-				N4JSPackage.Literals.JSX_ELEMENT__JSX_CLOSING_NAME,
-				IssueCodes.JSX_JSXELEMENT_OPENING_CLOSING_ELEMENT_NOT_MATCH
+				JSX_ELEMENT__JSX_CLOSING_NAME,
+				JSX_JSXELEMENT_OPENING_CLOSING_ELEMENT_NOT_MATCH
 			);
 		}
 	}
@@ -134,20 +175,19 @@ class N4JSXReactBindingValidator extends AbstractN4JSDeclarativeValidator {
 				// See Req. IDE-241118
 				// If the JSX element name starts with lower case, warning if it is unknown HTML tag
 				if (!htmlTags.contains(refName)) {
-					val message = IssueCodes.getMessageForJSX_HTMLTAG_UNKNOWN(refName);
+					val message = getMessageForJSX_HTMLTAG_UNKNOWN(refName);
 					addIssue(
 						message,
 						jsxElem,
-						N4JSPackage.Literals.JSX_ELEMENT__JSX_ELEMENT_NAME,
-						IssueCodes.JSX_HTMLTAG_UNKNOWN
+						JSX_ELEMENT__JSX_ELEMENT_NAME,
+						JSX_HTMLTAG_UNKNOWN
 					);
 				}
 			} else {
 				// JSX element name starts with an upper case, error because it does not bind to a class or function
 				// See Req. IDE-241115
-				val message = IssueCodes.
-					getMessageForJSX_REACT_ELEMENT_NOT_FUNCTION_OR_CLASS_ERROR(exprTypeRef.typeRefAsString);
-				addIssue(message, expr, IssueCodes.JSX_REACT_ELEMENT_NOT_FUNCTION_OR_CLASS_ERROR);
+				val message = getMessageForJSX_REACT_ELEMENT_NOT_FUNCTION_OR_CLASS_ERROR(exprTypeRef.typeRefAsString);
+				addIssue(message, expr, JSX_REACT_ELEMENT_NOT_FUNCTION_OR_CLASS_ERROR);
 			}
 			return;
 		}
@@ -175,20 +215,20 @@ class N4JSXReactBindingValidator extends AbstractN4JSDeclarativeValidator {
 		val String refName = expr.refName
 		if ((refName !== null) && (!refName.isEmpty) && Character::isLowerCase(refName.charAt(0))) {
 			if (isFunctionalComponent) {
-				val message = IssueCodes.getMessageForJSX_REACT_FUNCTIONAL_COMPONENT_CANNOT_START_WITH_LOWER_CASE(refName);
+				val message = getMessageForJSX_REACT_FUNCTIONAL_COMPONENT_CANNOT_START_WITH_LOWER_CASE(refName);
 				addIssue(
 					message,
 					jsxElem,
-					N4JSPackage.Literals.JSX_ELEMENT__JSX_ELEMENT_NAME,
-					IssueCodes.JSX_REACT_FUNCTIONAL_COMPONENT_CANNOT_START_WITH_LOWER_CASE
+					JSX_ELEMENT__JSX_ELEMENT_NAME,
+					JSX_REACT_FUNCTIONAL_COMPONENT_CANNOT_START_WITH_LOWER_CASE
 				);
 			} else {
 				val message = IssueCodes.getMessageForJSX_REACT_CLASS_COMPONENT_CANNOT_START_WITH_LOWER_CASE(refName);
 				addIssue(
 					message,
 					jsxElem,
-					N4JSPackage.Literals.JSX_ELEMENT__JSX_ELEMENT_NAME,
-					IssueCodes.JSX_REACT_CLASS_COMPONENT_CANNOT_START_WITH_LOWER_CASE
+					JSX_ELEMENT__JSX_ELEMENT_NAME,
+					JSX_REACT_CLASS_COMPONENT_CANNOT_START_WITH_LOWER_CASE
 				);
 			}
 		}
@@ -212,7 +252,7 @@ class N4JSXReactBindingValidator extends AbstractN4JSDeclarativeValidator {
 			addIssue(
 				message,
 				expr,
-				IssueCodes.JSX_REACT_ELEMENT_FUNCTION_NOT_REACT_ELEMENT_ERROR
+				JSX_REACT_ELEMENT_FUNCTION_NOT_REACT_ELEMENT_ERROR
 			);
 		}
 	}
@@ -232,8 +272,8 @@ class N4JSXReactBindingValidator extends AbstractN4JSDeclarativeValidator {
 		val tclassTypeRef = TypeUtils.createTypeRef(tclass);
 		val resultSubType = ts.subtype(G, tclassTypeRef, TypeUtils.createTypeRef(componentClassTypeRef))
 		if (resultSubType.failed) {
-			val message = IssueCodes.getMessageForJSX_REACT_ELEMENT_CLASS_NOT_REACT_ELEMENT_ERROR();
-			addIssue(message, expr, IssueCodes.JSX_REACT_ELEMENT_CLASS_NOT_REACT_ELEMENT_ERROR);
+			val message = getMessageForJSX_REACT_ELEMENT_CLASS_NOT_REACT_ELEMENT_ERROR();
+			addIssue(message, expr, JSX_REACT_ELEMENT_CLASS_NOT_REACT_ELEMENT_ERROR);
 		}
 	}
 
@@ -258,8 +298,8 @@ class N4JSXReactBindingValidator extends AbstractN4JSDeclarativeValidator {
 					addIssue(
 						message,
 						propertyAttribute,
-						N4JSPackage.Literals.JSX_PROPERTY_ATTRIBUTE__PROPERTY,
-						IssueCodes.JSX_JSXSPROPERTYATTRIBUTE_NOT_DECLARED_IN_PROPS
+						JSX_PROPERTY_ATTRIBUTE__PROPERTY,
+						JSX_JSXSPROPERTYATTRIBUTE_NOT_DECLARED_IN_PROPS
 					);
 		}
 	}
@@ -306,7 +346,7 @@ class N4JSXReactBindingValidator extends AbstractN4JSDeclarativeValidator {
 					addIssue(
 						message,
 						spreadAttribute,
-						N4JSPackage.Literals.JSX_SPREAD_ATTRIBUTE__EXPRESSION,
+						JSX_SPREAD_ATTRIBUTE__EXPRESSION,
 						IssueCodes.JSX_JSXSPREADATTRIBUTE_WRONG_SUBTYPE
 					);
 				}
@@ -382,8 +422,8 @@ class N4JSXReactBindingValidator extends AbstractN4JSDeclarativeValidator {
 			addIssue(
 				message,
 				jsxElem,
-				N4JSPackage.Literals.JSX_ELEMENT__JSX_ELEMENT_NAME,
-				IssueCodes.JSX_JSXPROPERTY_ATTRIBUTE_NON_OPTIONAL_PROPERTY_NOT_SPECIFIED
+				JSX_ELEMENT__JSX_ELEMENT_NAME,
+				JSX_JSXPROPERTY_ATTRIBUTE_NON_OPTIONAL_PROPERTY_NOT_SPECIFIED
 			);
 		}
 	}

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSXValidator.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSXValidator.xtend
@@ -52,7 +52,7 @@ import static extension org.eclipse.n4js.typesystem.RuleEnvironmentExtensions.*
 /**
  * Validation of React bindings including naming convention (components in upper case and HTML tags in lower case)
  */
-class N4JSXReactBindingValidator extends AbstractN4JSDeclarativeValidator {
+class N4JSXValidator extends AbstractN4JSDeclarativeValidator {
 	@Inject private N4JSTypeSystem ts;
 	@Inject private TypeSystemHelper tsh
 	@Inject private extension ReactHelper reactHelper;

--- a/tests/org.eclipse.n4js.n4jsx.xpect.ui.tests/manifest_no_react.n4mf
+++ b/tests/org.eclipse.n4js.n4jsx.xpect.ui.tests/manifest_no_react.n4mf
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+ProjectId: N4JSXXpectTests
+VendorId: org.eclipse.n4js
+VendorName: "Eclipse N4JS Project"
+ProjectType: library
+ProjectVersion: 0.0.1-SNAPSHOT
+Output: "src-gen"
+Sources {
+	source {
+		"model",
+		"model_ui"
+	}
+}
+//testing cases without react!!
+//ProjectDependencies {
+//    react
+//}

--- a/tests/org.eclipse.n4js.n4jsx.xpect.ui.tests/testdata/imports/NoReact.n4jsx.xt
+++ b/tests/org.eclipse.n4js.n4jsx.xpect.ui.tests/testdata/imports/NoReact.n4jsx.xt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.n4jsx.xpect.ui.tests.N4JSXXpectPluginTest
+
+	Workspace {
+		Project "N4JSXXpectTests" {
+			Folder "model" {
+				Folder "crossvariant" {
+					ThisFile {}
+				}
+			}
+			File "manifest.n4mf" { from="../../manifest_no_react.n4mf" }
+		}
+	}
+
+   END_SETUP
+ */
+
+
+
+/*
+JSX files need to depend on react. Even if user does not add it, it is added by the transpiler.
+Added import will cause exceptions if react will not be reachable from JSX file. 
+Validation prevents react file from being compiled if react is not reachable.
+XPECT errors ---
+"Cannot resolve JSX implementation." at "<div></div>"
+--- */
+let elem = <div></div>;
+elem;

--- a/tests/org.eclipse.n4js.n4jsx.xpect.ui.tests/testdata/imports/NoReact.n4jsx.xt
+++ b/tests/org.eclipse.n4js.n4jsx.xpect.ui.tests/testdata/imports/NoReact.n4jsx.xt
@@ -28,8 +28,8 @@
 
 
 /*
-JSX files need to depend on react. Even if user does not add it, it is added by the transpiler.
-Added import will cause exceptions if react will not be reachable from JSX file. 
+JSX files need to import react. Even if user does not do it, import is added by the transpiler.
+Transpiler will throw exception if react will not be reachable from JSX file. 
 Validation prevents react file from being compiled if react is not reachable.
 XPECT errors ---
 "Cannot resolve JSX implementation." at "<div></div>"

--- a/tests/org.eclipse.n4js.n4jsx.xpect.ui.tests/testdata/imports/NoReactUnsused.n4jsx.xt
+++ b/tests/org.eclipse.n4js.n4jsx.xpect.ui.tests/testdata/imports/NoReactUnsused.n4jsx.xt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.n4jsx.xpect.ui.tests.N4JSXXpectPluginTest
+
+	Workspace {
+		Project "N4JSXXpectTests" {
+			Folder "model" {
+				Folder "crossvariant" {
+					ThisFile {}
+				}
+			}
+			File "manifest.n4mf" { from="../../manifest_no_react.n4mf" }
+		}
+	}
+
+   END_SETUP
+ */
+
+
+
+/*
+Since transpiler is not patching react import if not needed,
+there will be no validation error.
+XPECT noerrors ---
+--- */
+console.log(1)


### PR DESCRIPTION
resolves #346 

This adds validation to N4JSX files, that will issue an error if `react` is not reachable from that module.

Validation issue will prevent file from being compiled when it is in invalid state.