### PR TITLE
GH-326d brings back runners required by the Xpect

### DIFF
--- a/features/org.eclipse.n4js.dependencies.ui.sdk/feature.xml
+++ b/features/org.eclipse.n4js.dependencies.ui.sdk/feature.xml
@@ -435,6 +435,13 @@ Contributors:
          unpack="false"/>
 
    <plugin
+         id="org.eclipse.jdt.junit.runners"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.xpect.xtext.lib"
          download-size="0"
          install-size="0"

--- a/features/org.eclipse.n4js.dependencies.ui.sdk/pom.xml
+++ b/features/org.eclipse.n4js.dependencies.ui.sdk/pom.xml
@@ -33,6 +33,7 @@ Contributors:
 					<excludes>
 
 						<plugin id="org.eclipse.swt" />
+						<plugin id="org.eclipse.jdt.junit.runners" />
 						<plugin id="org.eclipse.jdt" />
 						<plugin id="org.eclipse.gef" />
 						<plugin id="org.eclipse.draw2d" />

--- a/releng/org.eclipse.n4js.targetplatform/N4JS.setup
+++ b/releng/org.eclipse.n4js.targetplatform/N4JS.setup
@@ -246,6 +246,15 @@
         url="http://download.eclipse.org/modeling/emft/mwe/updates/releases/2.9.0"/>
   </setupTask>
   <setupTask
+       xsi:type="setup.p2:P2Task"
+       label="JUnit Runners">
+     <requirement
+         name="org.eclipse.jdt.junit.runners.feature.feature.group"
+         versionRange="[0.1.0,0.1.1)"/>
+     <repository
+         url="http://meysholdt.github.io/eclipse_jdt_junit_runners/updatesite"/>
+   </setupTask>
+  <setupTask
       xsi:type="setup.p2:P2Task"
       label="XPect">
     <requirement
@@ -381,6 +390,8 @@
             url="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository"/>
         <repository
             url="http://boothen.github.io/Json-Eclipse-Plugin"/>
+        <repository
+            url="http://meysholdt.github.io/eclipse_jdt_junit_runners/updatesite"/>
         <repository
             url="https://ci.eclipse.org/xsemantics/job/xsemantics-nightly/lastSuccessfulBuild/artifact/releng/org.eclipse.xsemantics.repository/target/repository/"/>
         <repository

--- a/releng/org.eclipse.n4js.targetplatform/org.eclipse.n4js.targetplatform.target
+++ b/releng/org.eclipse.n4js.targetplatform/org.eclipse.n4js.targetplatform.target
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde version="3.8"?>
-<target name="Generated target-platform N4JS:N4JS_Neon.2.GH-18" sequenceNumber="132">
+<target name="Generated target-platform N4JS:N4JS_Neon.2.GH-18" sequenceNumber="133">
   <locations>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.equinox.executable.feature.group" version="3.6.300.v20161122-1740"/>
@@ -56,16 +56,16 @@
       <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20160520211859/repository"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+      <unit id="org.eclipse.jdt.junit.runners" version="0.1.0.201411181552"/>
+      <repository location="http://meysholdt.github.io/eclipse_jdt_junit_runners/updatesite"/>
+    </location>
+    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.xsemantics.runtime" version="1.12.1.v20171102-1951"/>
       <repository location="https://ci.eclipse.org/xsemantics/job/xsemantics-nightly/lastSuccessfulBuild/artifact/releng/org.eclipse.xsemantics.repository/target/repository/"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.xpect.xtext.lib" version="0.2.0.201712151701"/>
       <repository location="https://ci.eclipse.org/xpect/job/Xpect-Integration-Release/lastSuccessfulBuild/artifact/org.eclipse.xpect.releng/p2-repository/target/repository/"/>
-    </location>
-    <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-      <unit id="org.eclipse.jdt.junit.runners" version="0.1.0.201411181552"/>
-      <repository location="http://meysholdt.github.io/eclipse_jdt_junit_runners/updatesite"/>
     </location>
     <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
       <unit id="org.eclipse.license.feature.group" version="1.0.1.v20140414-1359"/>


### PR DESCRIPTION
resolves #326 

Adds back junit runners integrations:
 - Oomph worked locally
 - maven builds passed, this time ;)

Note that jdt_runners integration might be re-worked / dropped with https://github.com/eclipse/Xpect/issues/224