### PR TITLE
GH-438 adjust files archiving in new Jenkins

### DIFF
--- a/Jenkinsfile.new
+++ b/Jenkinsfile.new
@@ -99,7 +99,10 @@ pipeline {
 
     post {
         always {
-            archive 'builds/**/target/*.zip'
+            // zipped platform specific IDEs
+            archive '**/builds/**/target/products/*.zip'
+            // platform independent headless jar
+            archive '**/tools/**/target/n4jsc.jar'
             junit '**/surefire-reports/**/*.xml'
         }
     }


### PR DESCRIPTION
resolves #438 
small adjustment to the `Jenkinsfile.new` to archive relevant binaries when branch is build
  