### PR TITLE
GH-466: Exported asciidoc output lacks an empty line in descriptions of class-jsdoc

### DIFF
--- a/plugins/org.eclipse.n4js.generator.headless/src/org/eclipse/n4js/generator/headless/N4HeadlessCompiler.java
+++ b/plugins/org.eclipse.n4js.generator.headless/src/org/eclipse/n4js/generator/headless/N4HeadlessCompiler.java
@@ -468,6 +468,9 @@ public class N4HeadlessCompiler {
 		// Register all projects with the file based workspace.
 		for (URI projectURI : projectURIs) {
 			try {
+				if (logger.isCreateDebugOutput()) {
+					logger.debug("Registering project '" + projectURI + "'");
+				}
 				n4jsFileBasedWorkspace.registerProject(projectURI);
 			} catch (N4JSBrokenProjectException e) {
 				throw new N4JSCompileException("Unable to register project '" + projectURI + "'", e);

--- a/plugins/org.eclipse.n4js.jsdoc2spec/src/org/eclipse/n4js/jsdoc2spec/adoc/ADocSerializer.xtend
+++ b/plugins/org.eclipse.n4js.jsdoc2spec/src/org/eclipse/n4js/jsdoc2spec/adoc/ADocSerializer.xtend
@@ -83,6 +83,8 @@ class ADocSerializer {
 	}
 
 	private def StringBuilder appendSpec(StringBuilder strb, SpecIdentifiableElementSection spec, Map<String, SpecSection> specsByKey) {
+		strb.append("\n");
+
 		var addedTaskLinks = false;
 		val taskTags = spec.getDoclet.lineTags(TAG_TASK.title);
 		for (tag : taskTags) {
@@ -117,7 +119,7 @@ class ADocSerializer {
 			strb.append("==== Description\n\n");
 
 		if (!reqID.isEmpty) {
-			strb.append("See req:"+reqID +"[].");
+			strb.append("See req:"+reqID +"[].\n");
 		}
 
 		strb.appendContents(doclet);

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample1/expectedADoc/A.adoc
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample1/expectedADoc/A.adoc
@@ -19,6 +19,9 @@ include::{find}config.adoc[]
 == Class A
 
 
+spec for class A from source code
+
+
 
 [[gsec:spec_A.A.bar]]
 [role=memberdoc]
@@ -27,6 +30,7 @@ include::{find}config.adoc[]
 ==== Signature
 
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample1:src/A:A#bar++[``++project bar(n: number): string++``]
+
 
 ==== Description
 
@@ -45,6 +49,7 @@ spec for method A.bar from source code
 
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample1:src/A:A#baz++[``++project baz(): string++``]
 
+
 ==== Description
 
 spec for method A.baz from source code
@@ -60,6 +65,7 @@ Add tests specifying semantics for ``++baz(): string++``
 
 
 
+
 [[gsec:spec_A.B.foo]]
 [role=memberdoc]
 === ++Method foo++
@@ -69,6 +75,7 @@ Add tests specifying semantics for ``++baz(): string++``
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample1:src/A:B#foo++[``++project foo(s: string): void++``]
 
 
+
 ==== Semantics
 [.todo, label="test ++B.foo++"]
 --
@@ -76,6 +83,7 @@ Add tests specifying semantics for ``++foo(s: string): void++``
 --
 
 == Class D
+
 
 
 [[gsec:spec_D.A.bar]]

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample1/expectedADoc/index.idx
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample1/expectedADoc/index.idx
@@ -13,17 +13,17 @@ n4js#tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc
 	SpecSample1#src
 		NO_PACKAGE
 			A.n4jsd
-				A::15::21::21
-				A#bar::20::22::38
-				A#baz::27::39::58
-				B::30::61::61
-				B#foo::31::62::77
-				D::36::80::109
+				A::15::21::24
+				A#bar::20::25::42
+				A#baz::27::43::63
+				B::30::66::67
+				B#foo::31::68::84
+				D::36::87::117
 	SpecSample1#test
 		NO_PACKAGE
 			ATests.n4js
-				ATest::12::21::21
-				ATest#testBarBasics::17::22::37
-				DTest::21::40::40
-				DTest#testBarAgain::27::41::56
-				DTest#testBazAgain::34::57::76
+				ATest::12::21::22
+				ATest#testBarBasics::17::23::39
+				DTest::21::42::43
+				DTest#testBarAgain::27::44::60
+				DTest#testBazAgain::34::61::81

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample1/src/A.n4jsd
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample1/src/A.n4jsd
@@ -10,7 +10,7 @@
  */
 
 /**
- * @Spec spec for class A from source code
+ * @spec spec for class A from source code
  */
 export external public class A {
 

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample10_TodoTags/expectedADoc/A.adoc
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample10_TodoTags/expectedADoc/A.adoc
@@ -20,6 +20,7 @@ include::{find}config.adoc[]
 
 todo:Hello[]
 
+
 [[gsec:spec_A.A.bar]]
 [role=memberdoc]
 === ++Method bar++
@@ -28,6 +29,7 @@ todo:To something here[]
 ==== Signature
 
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample10_TodoTags:src/A:A#bar++[``++public bar(n: number): string++``]
+
 
 ==== Description
 

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample10_TodoTags/expectedADoc/index.idx
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample10_TodoTags/expectedADoc/index.idx
@@ -13,10 +13,10 @@ n4js#tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc
 	SpecSample10_TodoTags#src
 		NO_PACKAGE
 			A.n4jsd
-				A::15::21::21
-				A#bar::21::22::39
+				A::15::21::22
+				A#bar::21::23::41
 	SpecSample10_TodoTags#test
 		NO_PACKAGE
 			ATests.n4js
-				ATest::15::21::21
-				ATest#testBarBasics::20::22::37
+				ATest::15::21::22
+				ATest#testBarBasics::20::23::39

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample2/expectedADoc/A.adoc
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample2/expectedADoc/A.adoc
@@ -20,6 +20,7 @@ include::{find}config.adoc[]
 
 
 
+
 [[gsec:spec_A.A.bar]]
 [role=memberdoc]
 === ++Method bar++
@@ -27,6 +28,7 @@ include::{find}config.adoc[]
 ==== Signature
 
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample2:src/A:A#bar++[``++public bar(n: number): string++``]
+
 
 ==== Description
 
@@ -39,6 +41,7 @@ spec for method A.bar from source code
 . *++Only in a++* ([.small]#srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample2:test/ATests:ATest#testOnlyInA++[Test]#)
 
 == Class B
+
 
 
 [[gsec:spec_B.A.bar]]

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample2/expectedADoc/index.idx
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample2/expectedADoc/index.idx
@@ -13,13 +13,13 @@ n4js#tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc
 	SpecSample2#src
 		NO_PACKAGE
 			A.n4jsd
-				A::15::21::21
-				A#bar::20::22::40
-				B::24::43::54
+				A::15::21::22
+				A#bar::20::23::42
+				B::24::45::57
 	SpecSample2#test
 		NO_PACKAGE
 			ATests.n4js
-				ATest::15::21::21
-				ATest#testBarBasics::20::22::37
-				ATest#testOnlyInA::26::38::53
-				BTest::33::56::56
+				ATest::15::21::22
+				ATest#testBarBasics::20::23::39
+				ATest#testOnlyInA::26::40::56
+				BTest::33::59::60

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample3_RedundantLines/expectedADoc/A.adoc
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample3_RedundantLines/expectedADoc/A.adoc
@@ -20,6 +20,7 @@ include::{find}config.adoc[]
 
 
 
+
 [[gsec:spec_A.A.foo]]
 [role=memberdoc]
 === ++Method foo++
@@ -27,6 +28,7 @@ include::{find}config.adoc[]
 ==== Signature
 
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample3_RedundantLines:src/A:A#foo++[``++public foo(): string++``]
+
 
 ==== Semantics
 

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample3_RedundantLines/expectedADoc/index.idx
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample3_RedundantLines/expectedADoc/index.idx
@@ -13,15 +13,15 @@ n4js#tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc
 	SpecSample3_RedundantLines#src
 		NO_PACKAGE
 			A.n4jsd
-				A::15::21::21
-				A#foo::17::22::41
+				A::15::21::22
+				A#foo::17::23::43
 	SpecSample3_RedundantLines#test
 		NO_PACKAGE
 			ATests.n4js
-				BaseTests::13::21::21
-				BaseTests#initFixture::21::22::31
-				BaseTests#testFoo::19::32::51
-				TestsFixture1::27::54::54
-				TestsFixture1#initFixture::28::55::70
-				TestsFixture2::33::73::73
-				TestsFixture2#initFixture::34::74::89
+				BaseTests::13::21::22
+				BaseTests#initFixture::21::23::33
+				BaseTests#testFoo::19::34::54
+				TestsFixture1::27::57::58
+				TestsFixture1#initFixture::28::59::75
+				TestsFixture2::33::78::79
+				TestsFixture2#initFixture::34::80::96

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample4_TesteeForFunctions/expectedADoc/A.adoc
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample4_TesteeForFunctions/expectedADoc/A.adoc
@@ -27,6 +27,7 @@ include::{find}config.adoc[]
 
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample4_TesteeForFunctions:src/A:bar2var++[``++bar2var: string++``]
 
+
 ==== Description
 
 Spec for Var bar2var
@@ -40,6 +41,7 @@ Spec for Var bar2var
 ==== Signature
 
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample4_TesteeForFunctions:src/A:barvar++[``++barvar: string++``]
+
 
 ==== Description
 
@@ -59,6 +61,7 @@ Spec for Var barvar
 ==== Signature
 
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample4_TesteeForFunctions:src/A:foofunc++[``++function foofunc(): void++``]
+
 
 ==== Description
 

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample4_TesteeForFunctions/expectedADoc/index.idx
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample4_TesteeForFunctions/expectedADoc/index.idx
@@ -13,12 +13,12 @@ n4js#tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc
 	SpecSample4_TesteeForFunctions#src
 		NO_PACKAGE
 			A.n4jsd
-				bar2var::26::21::34
-				barvar::21::35::51
-				foofunc::15::54::70
+				bar2var::26::21::35
+				barvar::21::36::53
+				foofunc::15::56::73
 	SpecSample4_TesteeForFunctions#test
 		NO_PACKAGE
 			ATests.n4js
-				ATest::12::21::21
-				ATest#testBarBasics::23::22::37
-				ATest#testFuncBasics::17::38::53
+				ATest::12::21::22
+				ATest#testBarBasics::23::23::39
+				ATest#testFuncBasics::17::40::56

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample5_LinkToReqIDs/expectedADoc/A.adoc
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample5_LinkToReqIDs/expectedADoc/A.adoc
@@ -20,6 +20,7 @@ include::{find}config.adoc[]
 
 
 
+
 [[gsec:spec_A.A.foo]]
 [role=memberdoc]
 === ++Method foo++
@@ -27,6 +28,7 @@ include::{find}config.adoc[]
 ==== Signature
 
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample5_LinkToReqIDs:src/A:A#foo++[``++project foo(): void++``]
+
 
 ==== Semantics
 
@@ -38,3 +40,4 @@ srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSamp
 Foo Test Description
 
 ====
+

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample5_LinkToReqIDs/expectedADoc/index.idx
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample5_LinkToReqIDs/expectedADoc/index.idx
@@ -13,12 +13,12 @@ n4js#tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc
 	SpecSample5_LinkToReqIDs#src
 		NO_PACKAGE
 			A.n4jsd
-				A::12::21::21
-				A#foo::13::22::41
+				A::12::21::22
+				A#foo::13::23::43
 	SpecSample5_LinkToReqIDs#test
 		NO_PACKAGE
 			ReqTest.n4js
-				ReqTest::12::21::21
-				ReqTest#_02_basics___1_Case::18::22::35
-				ReqTest#ext___Case::25::36::49
-				ReqTest#testFoo::33::50::63
+				ReqTest::12::21::22
+				ReqTest#_02_basics___1_Case::18::23::38
+				ReqTest#ext___Case::25::39::54
+				ReqTest#testFoo::33::55::70

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample6_ExtendedSignature/expectedADoc/A.adoc
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample6_ExtendedSignature/expectedADoc/A.adoc
@@ -28,6 +28,7 @@ include::{find}config.adoc[]
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample6_ExtendedSignature:src/A:func++[``++async function func(x: string, n: number=…, ...p: string): string++``]
 
 
+
 ==== Semantics
 [.todo, label="test function ++func++"]
 --
@@ -38,6 +39,7 @@ Add tests specifying semantics for ``++func++``
 
 
 
+
 [[gsec:spec_A.A.constructor]]
 [role=memberdoc]
 === ++Constructor constructor++
@@ -45,6 +47,7 @@ Add tests specifying semantics for ``++func++``
 ==== Signature
 
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample6_ExtendedSignature:src/A:A#constructor++[``++public constructor(s: ~i~this): this[A]++``]
+
 
 
 ==== Semantics
@@ -63,6 +66,7 @@ Add tests specifying semantics for ``++constructor(s: ~i~this): this[A]?++``
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample6_ExtendedSignature:src/A:A#bar++[``++project async bar(): string++``]
 
 
+
 ==== Semantics
 [.todo, label="test ++A.bar++"]
 --
@@ -77,6 +81,7 @@ Add tests specifying semantics for ``++async bar(): Promise<string,?>++``
 ==== Signature
 
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample6_ExtendedSignature:src/A:A#baz++[``++@TestAPI @Final @Internal public baz(): string++``]
+
 
 
 ==== Semantics
@@ -95,6 +100,7 @@ Add tests specifying semantics for ``++baz(): string++``
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample6_ExtendedSignature:src/A:A#foo++[``++public foo(x: string, n: number=…, ...p: string): void++``]
 
 
+
 ==== Semantics
 [.todo, label="test ++A.foo++"]
 --
@@ -109,6 +115,7 @@ Add tests specifying semantics for ``++foo(x: string, n: number=…, ...p: strin
 ==== Signature
 
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample6_ExtendedSignature:src/A:A@xgreet++[``++project xgreet(some: union{string,number}): void++``]
+
 
 
 ==== Semantics

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample6_ExtendedSignature/expectedADoc/index.idx
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample6_ExtendedSignature/expectedADoc/index.idx
@@ -13,10 +13,10 @@ n4js#tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc
 	SpecSample6_ExtendedSignature#src
 		NO_PACKAGE
 			A.n4jsd
-				A::14::39::39
-				A#bar::17::56::71
-				A#baz::18::72::87
-				A#constructor::15::40::55
-				A#foo::16::88::103
-				A@xgreet::19::104::119
-				func::12::21::36
+				A::14::40::41
+				A#bar::17::59::75
+				A#baz::18::76::92
+				A#constructor::15::42::58
+				A#foo::16::93::109
+				A@xgreet::19::110::126
+				func::12::21::37

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample7_StaticPolyfills/expectedADoc/A.adoc
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample7_StaticPolyfills/expectedADoc/A.adoc
@@ -20,6 +20,7 @@ include::{find}config.adoc[]
 
 
 
+
 [[gsec:spec_A.A.bar]]
 [role=memberdoc]
 === ++Method bar++
@@ -28,6 +29,7 @@ include::{find}config.adoc[]
 
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample7_StaticPolyfills:src/n4js/A:A#bar++[``++public bar(): void++``]
 footnote:[Polyfilled from n4js:testresources]
+
 
 
 ==== Semantics
@@ -46,6 +48,7 @@ Add tests specifying semantics for ``++bar(): void++``
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample7_StaticPolyfills:src/n4js-gen/A:A#base++[``++public base(x: number): void++``]
 
 
+
 ==== Semantics
 [.todo, label="test ++A.base++"]
 --
@@ -61,6 +64,7 @@ Add tests specifying semantics for ``++base(x: number): void++``
 
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample7_StaticPolyfills:src/n4js/A:A#foo++[``++public foo(x: any, n: number=…): void++``]
 footnote:[Polyfilled from n4js:testresources]
+
 
 
 ==== Semantics

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample7_StaticPolyfills/expectedADoc/index.idx
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample7_StaticPolyfills/expectedADoc/index.idx
@@ -13,10 +13,10 @@ n4js#tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc
 	SpecSample7_StaticPolyfills#src.n4js-gen
 		NO_PACKAGE
 			A.n4js
-				A::13::21::21
-				A#base::14::39::54
+				A::13::21::22
+				A#base::14::41::57
 	SpecSample7_StaticPolyfills#src.n4js
 		NO_PACKAGE
 			A.n4js
-				A#bar::17::22::38::n4js:tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc:SpecSample7_StaticPolyfills:testresources
-				A#foo::15::55::71::n4js:tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc:SpecSample7_StaticPolyfills:testresources
+				A#bar::17::23::40::n4js:tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc:SpecSample7_StaticPolyfills:testresources
+				A#foo::15::58::75::n4js:tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc:SpecSample7_StaticPolyfills:testresources

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample8_NoTodoForReqIDs/expectedADoc/A.adoc
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample8_NoTodoForReqIDs/expectedADoc/A.adoc
@@ -20,6 +20,7 @@ include::{find}config.adoc[]
 
 
 
+
 [[gsec:spec_A.A.foo]]
 [role=memberdoc]
 === ++Method foo++
@@ -28,7 +29,9 @@ include::{find}config.adoc[]
 
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample8_NoTodoForReqIDs:src/A:A#foo++[``++project foo(): void++``]
 
+
 ==== Description
 
 See req:1000_a[].
+
 

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample8_NoTodoForReqIDs/expectedADoc/index.idx
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample8_NoTodoForReqIDs/expectedADoc/index.idx
@@ -13,11 +13,11 @@ n4js#tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc
 	SpecSample8_NoTodoForReqIDs#src
 		NO_PACKAGE
 			A.n4jsd
-				A::12::21::21
-				A#foo::16::22::34
+				A::12::21::22
+				A#foo::16::23::37
 	SpecSample8_NoTodoForReqIDs#test
 		NO_PACKAGE
 			ReqTest.n4js
-				ReqTest::12::21::21
-				ReqTest#basics___Case::18::22::35
-				ReqTest#ext___Case::39::36::66
+				ReqTest::12::21::22
+				ReqTest#basics___Case::18::23::38
+				ReqTest#ext___Case::39::39::71

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample9_StaticPolyfill/expectedADoc/X.adoc
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample9_StaticPolyfill/expectedADoc/X.adoc
@@ -20,6 +20,7 @@ include::{find}config.adoc[]
 
 
 
+
 [[gsec:spec_X.X.bar]]
 [role=memberdoc]
 === ++Method bar++
@@ -28,6 +29,7 @@ include::{find}config.adoc[]
 
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample9_StaticPolyfill:src/X:X#bar++[``++project bar(): void++``]
 footnote:[Polyfilled from n4js:testresourcesADoc/SpecSample9_StaticPolyfill/poly]
+
 
 ==== Semantics
 
@@ -44,6 +46,7 @@ srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSamp
 footnote:[Polyfilled from n4js:testresourcesADoc/SpecSample9_StaticPolyfill/poly]
 
 
+
 ==== Semantics
 [.todo, label="test ++X.foo++"]
 --
@@ -58,6 +61,7 @@ Add tests specifying semantics for ``++foo(): void++``
 ==== Signature
 
 srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSample9_StaticPolyfill:src/X:X#my++[``++project my(): void++``]
+
 
 
 ==== Semantics

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample9_StaticPolyfill/expectedADoc/index.idx
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample9_StaticPolyfill/expectedADoc/index.idx
@@ -13,12 +13,12 @@ n4js#tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc
 	SpecSample9_StaticPolyfill#src
 		NO_PACKAGE
 			X.n4js
-				X::14::21::21
-				X#bar::16::22::35::n4js:tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc:SpecSample9_StaticPolyfill:testresourcesADoc.SpecSample9_StaticPolyfill.poly
-				X#foo::17::36::52::n4js:tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc:SpecSample9_StaticPolyfill:testresourcesADoc.SpecSample9_StaticPolyfill.poly
-				X#my::15::53::68
+				X::14::21::22
+				X#bar::16::23::37::n4js:tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc:SpecSample9_StaticPolyfill:testresourcesADoc.SpecSample9_StaticPolyfill.poly
+				X#foo::17::38::55::n4js:tests.org.eclipse.n4js.jsdoc2spec.tests.testresourcesADoc:SpecSample9_StaticPolyfill:testresourcesADoc.SpecSample9_StaticPolyfill.poly
+				X#my::15::56::72
 	SpecSample9_StaticPolyfill#tests
 		NO_PACKAGE
 			XTest.n4js
-				XTest::12::21::21
-				XTest#test::18::22::37
+				XTest::12::21::22
+				XTest#test::18::23::39


### PR DESCRIPTION
see #466 