### PR TITLE
Remove explicit version in n4idl.lang.tests manifest

### DIFF
--- a/tests/org.eclipse.n4js.n4idl.lang.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.n4js.n4idl.lang.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.n4js.n4idl.lang.tests
 Bundle-Vendor: %providerName
 Bundle-Version: 0.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Fragment-Host: org.eclipse.n4js;bundle-version="0.0.1.qualifier"
+Fragment-Host: org.eclipse.n4js
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.workbench;resolution:=optional,
  org.eclipse.xtext.testing,


### PR DESCRIPTION
The explicit declaration of the fragment host bundle version may break the builds in some cases.

I removed it with this PR.