### PR TITLE
GH-537: Add null-check for cast expression validation

### DIFF
--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSExpressionValidator.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSExpressionValidator.xtend
@@ -880,37 +880,37 @@ class N4JSExpressionValidator extends AbstractN4JSDeclarativeValidator {
 			doCheckMathOperandTypeSymbol(ae.lhs, ae.rhs)
 		}
 	}
-			
+
 	/**
 	 * Note: Division by 0 may lead to infinity or NaN, depending on the value of the rhs.
 	 * I.e. 0/0=NaN, but 1/0=Infinity. So we cannot infer from the type the result in these cases.
-	 */	
+	 */
 	@Check
 	def checkMultiplicativeExpression(MultiplicativeExpression me) {
 		doCheckMathOperandTypes(me.lhs, me.rhs);
 	}
-	
+
 	@Check
 	def checkShiftExpression(ShiftExpression se) {
 		doCheckMathOperandTypes(se.lhs, se.rhs);
 	}
 
 	def doCheckMathOperandTypes(Expression lhs, Expression rhs) {
-		if (lhs===null || rhs===null) return;	
+		if (lhs===null || rhs===null) return;
 		val tlhs = ts.tau(lhs)
 		if (tlhs===null) return;
 		val trhs = ts.tau(rhs)
 		if (trhs===null) return;
-		
+
 		val bits = BuiltInTypeScope.get(lhs.eResource.resourceSet)
-		
+
 		if (tlhs.declaredType === bits.undefinedType) {
 			issueMathResultIsConstant("of type undefined", "NaN", lhs);
 		}
 		if (trhs.declaredType === bits.undefinedType) {
 			issueMathResultIsConstant("of type undefined", "NaN", rhs);
 		}
-		
+
 		if (tlhs.declaredType===bits.nullType) {
 			issueMathOperandIsConstant("null", "0", lhs);
 		}
@@ -924,14 +924,14 @@ class N4JSExpressionValidator extends AbstractN4JSDeclarativeValidator {
 			issueMathOperandTypeNotPermitted("symbol", rhs);
 		}
 	}
-		
-	def doCheckMathOperandTypeSymbol(Expression lhs, Expression rhs) {	
-		if (lhs===null || rhs===null) return;	
+
+	def doCheckMathOperandTypeSymbol(Expression lhs, Expression rhs) {
+		if (lhs===null || rhs===null) return;
 		val tlhs = ts.tau(lhs)
 		if (tlhs===null) return;
 		val trhs = ts.tau(rhs)
 		if (trhs===null) return;
-		
+
 		val bits = BuiltInTypeScope.get(lhs.eResource.resourceSet)
 		if (tlhs.declaredType==bits.symbolType) {
 			issueMathOperandTypeNotPermitted("symbol", lhs);
@@ -940,7 +940,7 @@ class N4JSExpressionValidator extends AbstractN4JSDeclarativeValidator {
 			issueMathOperandTypeNotPermitted("symbol", rhs);
 		}
 	}
-	
+
 
 	def issueMathResultIsConstant(String operand, String constResult, Expression location) {
 		addIssue(IssueCodes.getMessageForEXP_MATH_OPERATION_RESULT_IS_CONSTANT(operand, constResult),
@@ -959,10 +959,10 @@ class N4JSExpressionValidator extends AbstractN4JSDeclarativeValidator {
 			location,
 			IssueCodes.EXP_MATH_TYPE_NOT_PERMITTED);
 	}
-	
-	
-	
-	
+
+
+
+
 	/**
 	 * IDE-731 / IDE-773
 	 * Cf. 6.1.17. Equality Expression
@@ -1237,6 +1237,10 @@ class N4JSExpressionValidator extends AbstractN4JSDeclarativeValidator {
 	 */
 	@Check
 	def checkCastExpression(CastExpression castExpression) {
+		// avoid validating a broken AST
+		if (castExpression.expression === null)
+			return;
+
 		val S = ts.tau(castExpression.expression, castExpression);
 		val T = castExpression.targetTypeRef
 

--- a/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/scoping/ErrorTest.xtend
+++ b/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/scoping/ErrorTest.xtend
@@ -125,6 +125,13 @@ class ErrorTest extends AbstractParserTest {
 		'''.parse
 		analyser.analyse(script, "script", "script")
 	}
+	
+	@Test
+	def void testNoNPE_06() {
+		val script = '''mport * as 1 from 'a/X';
+			var N1.x: X;'''.parse
+		analyser.analyse(script, "script", "script");
+	}
 
 	@Test
 	def void testNoCyclicResolution_01() {

--- a/tests/org.eclipse.n4js.n4idl.lang.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.n4js.n4idl.lang.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.n4js.n4idl.lang.tests
 Bundle-Vendor: %providerName
 Bundle-Version: 0.0.1.qualifier
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
-Fragment-Host: org.eclipse.n4js;bundle-version="0.0.1.qualifier"
+Fragment-Host: org.eclipse.n4js
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.ui.workbench;resolution:=optional,
  org.eclipse.xtext.testing,


### PR DESCRIPTION
Ticket: https://github.com/eclipse/n4js/issues/537

The change in the MANIFEST.MF is to prevent CI builds to completely fail.