### PR TITLE
GH-616: Cache miss exception for (v) => v..foo()

### DIFF
--- a/plugins/org.eclipse.n4js.model/emf-gen/org/eclipse/n4js/n4JS/ArrowFunction.java
+++ b/plugins/org.eclipse.n4js.model/emf-gen/org/eclipse/n4js/n4JS/ArrowFunction.java
@@ -96,6 +96,9 @@ public interface ArrowFunction extends FunctionExpression {
 	 * *
 	 * If {@link #isSingleExprImplicitReturn()} returns <code>true</code>, this method will return the single expression
 	 * that makes up the body of this arrow function, otherwise the behavior is undefined (might throw exception).
+	 * <p>
+	 * In case of broken AST, this method may return <code>null</code> even if {@link #isSingleExprImplicitReturn()}
+	 * returns <code>true</code>.
 	 * <!-- end-model-doc -->
 	 * @model kind="operation" unique="false"
 	 *        annotation="http://www.eclipse.org/emf/2002/GenModel body='<%org.eclipse.n4js.n4JS.Statement%> _head = <%org.eclipse.xtext.xbase.lib.IterableExtensions%>.<<%org.eclipse.n4js.n4JS.Statement%>>head(this.getBody().getStatements());\nreturn ((<%org.eclipse.n4js.n4JS.ExpressionStatement%>) _head).getExpression();'"

--- a/plugins/org.eclipse.n4js.model/model/N4JS.xcore
+++ b/plugins/org.eclipse.n4js.model/model/N4JS.xcore
@@ -619,6 +619,9 @@ class ArrowFunction extends FunctionExpression {
 	/**
 	 * If {@link #isSingleExprImplicitReturn()} returns <code>true</code>, this method will return the single expression
 	 * that makes up the body of this arrow function, otherwise the behavior is undefined (might throw exception).
+	 * <p>
+	 * In case of broken AST, this method may return <code>null</code> even if {@link #isSingleExprImplicitReturn()}
+	 * returns <code>true</code>.
 	 */
 	op Expression getSingleExpression() {
 		return (body.statements.head as ExpressionStatement).expression;

--- a/tests/org.eclipse.n4js.smoke.tests/src/org/eclipse/n4js/smoke/tests/GeneratedSmokeTestCases4.xtend
+++ b/tests/org.eclipse.n4js.smoke.tests/src/org/eclipse/n4js/smoke/tests/GeneratedSmokeTestCases4.xtend
@@ -3121,4 +3121,15 @@ class GeneratedSmokeTestCases4 {
 			}
 		'''.assertNoException
 	}
+
+	/**
+	 * GH-616
+	 */
+	@Test
+	def void test_GH_616() {
+		// removing the second dot removes the exception
+		'''
+			let r = (v) => v..foo();
+		'''.assertNoException
+	}
 }


### PR DESCRIPTION
See #616.