### PR TITLE
GH-658: Hover supports formatting of JSDoc including some markdown

### DIFF
--- a/plugins/org.eclipse.n4js.jsdoc/src/org/eclipse/n4js/jsdoc/JSDoc2HoverSerializer.java
+++ b/plugins/org.eclipse.n4js.jsdoc/src/org/eclipse/n4js/jsdoc/JSDoc2HoverSerializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2016 NumberFour AG.
+ * Copyright (c) 2018 NumberFour AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -33,9 +33,8 @@ import org.eclipse.n4js.jsdoc.dom.util.DomSwitch;
 import org.eclipse.xtext.util.Strings;
 
 /**
- * Reproduces comment string from doclet, basically for debugging and testing purposes. This serializer tries to create
- * the original doclet as close as possible. It uses the {@link MD2HTMLConvertingBuilder} to convert the markdown to
- * HTML.
+ * Creates a HTML version of the JSDoc string to be shown in the hover. It uses the {@link MD2HTMLConvertingBuilder} to
+ * convert markdown to HTML.
  * <p>
  * Tags are added as items of a definition list with the tag name as title.
  */

--- a/plugins/org.eclipse.n4js.jsdoc/src/org/eclipse/n4js/jsdoc/JSDoc2HoverSerializer.java
+++ b/plugins/org.eclipse.n4js.jsdoc/src/org/eclipse/n4js/jsdoc/JSDoc2HoverSerializer.java
@@ -178,21 +178,25 @@ public class JSDoc2HoverSerializer extends DomSwitch<Boolean> {
 				}
 				if (tagHandler != null) {
 					List<LineTag> lineTags = groupedLineTags.get(tagDef);
-					if (lineTags != null && !lineTags.isEmpty()) {
-						tagHandler.open(tagDef, this);
-						boolean first = true;
-						for (LineTag lineTag : lineTags) {
-							md2HtmlBuilder.resetMarkdownConverter();
-							tagHandler.content(lineTag, this, first);
-							first = false;
-						}
-						tagHandler.close(tagDef, this);
-					}
+					handleLineTags(tagDef, tagHandler, lineTags);
 				}
 			}
 			md2HtmlBuilder.append("\n</dl>");
 		}
 		return false;
+	}
+
+	private void handleLineTags(ITagDefinition tagDef, TagHandler tagHandler, List<LineTag> lineTags) {
+		if (lineTags != null && !lineTags.isEmpty()) {
+			tagHandler.open(tagDef, this);
+			boolean first = true;
+			for (LineTag lineTag : lineTags) {
+				md2HtmlBuilder.resetMarkdownConverter();
+				tagHandler.content(lineTag, this, first);
+				first = false;
+			}
+			tagHandler.close(tagDef, this);
+		}
 	}
 
 	@Override

--- a/plugins/org.eclipse.n4js.jsdoc/src/org/eclipse/n4js/jsdoc/JSDoc2HoverSerializer.java
+++ b/plugins/org.eclipse.n4js.jsdoc/src/org/eclipse/n4js/jsdoc/JSDoc2HoverSerializer.java
@@ -1,0 +1,288 @@
+/**
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+package org.eclipse.n4js.jsdoc;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.emf.common.util.EList;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.n4js.jsdoc.dom.Composite;
+import org.eclipse.n4js.jsdoc.dom.ContentNode;
+import org.eclipse.n4js.jsdoc.dom.Doclet;
+import org.eclipse.n4js.jsdoc.dom.FullMemberReference;
+import org.eclipse.n4js.jsdoc.dom.FullTypeReference;
+import org.eclipse.n4js.jsdoc.dom.InlineTag;
+import org.eclipse.n4js.jsdoc.dom.LineTag;
+import org.eclipse.n4js.jsdoc.dom.Literal;
+import org.eclipse.n4js.jsdoc.dom.SimpleTypeReference;
+import org.eclipse.n4js.jsdoc.dom.TagTitle;
+import org.eclipse.n4js.jsdoc.dom.TagValue;
+import org.eclipse.n4js.jsdoc.dom.Text;
+import org.eclipse.n4js.jsdoc.dom.util.DomSwitch;
+import org.eclipse.xtext.util.Strings;
+
+/**
+ * Reproduces comment string from doclet, basically for debugging and testing purposes. This serializer tries to create
+ * the original doclet as close as possible. It uses the {@link MD2HTMLConvertingBuilder} to convert the markdown to
+ * HTML.
+ * <p>
+ * Tags are added as items of a definition list with the tag name as title.
+ */
+public class JSDoc2HoverSerializer extends DomSwitch<Boolean> {
+
+	/**
+	 * Used internally for registering handlers for different types of tags.
+	 */
+	private abstract static class TagHandler {
+		@SuppressWarnings("unused")
+		void open(ITagDefinition tagDef, JSDoc2HoverSerializer serializer) {
+			// nothing per default
+		}
+
+		void content(LineTag lineTag, JSDoc2HoverSerializer serializer, boolean isFirstLine) {
+			if (!isFirstLine) {
+				serializer.md2HtmlBuilder.append("<p>");
+			}
+			for (TagValue val : lineTag.getValues()) {
+				serializer.appendContents(val.getContents());
+			}
+		}
+
+		@SuppressWarnings("unused")
+		void close(ITagDefinition tagDef, JSDoc2HoverSerializer serializer) {
+			// nothing per default
+		}
+	}
+
+	private static TagHandler TAG_IGNORE = new TagHandler() {
+		@Override
+		void content(LineTag lineTag, JSDoc2HoverSerializer serializer, boolean isFirstLine) {
+			// ignore
+		}
+	};
+
+	/**
+	 * This is the default handler if no handler is registered for a tag.
+	 */
+	private static TagHandler TAG_SECTION = new TagHandler() {
+		@Override
+		void open(ITagDefinition tagDef, JSDoc2HoverSerializer serializer) {
+			serializer.md2HtmlBuilder.append("\n<dt>").append(Strings.toFirstUpper(tagDef.getTitle()))
+					.append(":</dt>\n<dd>");
+		}
+	};
+
+	/**
+	 * Creates an unordered list of all tags with the same definition.
+	 */
+	private static TagHandler TAG_LIST = new TagHandler() {
+		@Override
+		void open(ITagDefinition tagDef, JSDoc2HoverSerializer serializer) {
+			serializer.md2HtmlBuilder.append("\n<dt>").append(Strings.toFirstUpper(tagDef.getTitle()))
+					.append(":</dt>\n<dd>");
+			serializer.md2HtmlBuilder.append("\n<ul>");
+		}
+
+		@Override
+		void content(LineTag lineTag, JSDoc2HoverSerializer serializer, boolean isFirstLine) {
+			serializer.md2HtmlBuilder.append("<li>");
+			for (TagValue val : lineTag.getValues()) {
+				serializer.appendContents(val.getContents());
+			}
+			serializer.md2HtmlBuilder.append("</li>");
+		}
+
+		@Override
+		void close(ITagDefinition tagDef, JSDoc2HoverSerializer serializer) {
+			serializer.md2HtmlBuilder.append("</ul></dd>");
+		}
+	};
+
+	static Map<ITagDefinition, TagHandler> LINETAG_HANDLERS;
+
+	static {
+		LINETAG_HANDLERS = new HashMap<>();
+		LINETAG_HANDLERS.put(N4JSDocletParser.TAG_SPEC, TAG_SECTION);
+		LINETAG_HANDLERS.put(N4JSDocletParser.TAG_AUTHOR, TAG_SECTION);
+		LINETAG_HANDLERS.put(N4JSDocletParser.TAG_TODO, TAG_LIST);
+		LINETAG_HANDLERS.put(N4JSDocletParser.TAG_PARAM, TAG_LIST);
+		LINETAG_HANDLERS.put(N4JSDocletParser.TAG_RETURN, TAG_SECTION);
+		LINETAG_HANDLERS.put(N4JSDocletParser.TAG_SPECFROMDESCR, TAG_IGNORE);
+		LINETAG_HANDLERS.put(N4JSDocletParser.TAG_TASK, TAG_IGNORE);
+		LINETAG_HANDLERS.put(N4JSDocletParser.TAG_REQID, TAG_IGNORE);
+		LINETAG_HANDLERS.put(N4JSDocletParser.TAG_API_NOTE, TAG_SECTION);
+		LINETAG_HANDLERS.put(N4JSDocletParser.TAG_API_STATE, TAG_IGNORE);
+		LINETAG_HANDLERS.put(N4JSDocletParser.TAG_TESTEE, TAG_IGNORE);
+		LINETAG_HANDLERS.put(N4JSDocletParser.TAG_TESTEEFROMTYPE, TAG_IGNORE);
+		LINETAG_HANDLERS.put(N4JSDocletParser.TAG_TESTEETYPE, TAG_IGNORE);
+		LINETAG_HANDLERS.put(N4JSDocletParser.TAG_TESTEEMEMBER, TAG_IGNORE);
+	}
+
+	/**
+	 * new line
+	 *
+	 * @author x
+	 */
+	public final static String NL = "\n * ";
+
+	/**
+	 * prefix of new line in multi-line comments (does not apply to first&last markers)
+	 */
+	public final static String NL_PREFIX = " * ";
+
+	MD2HTMLConvertingBuilder md2HtmlBuilder = new MD2HTMLConvertingBuilder();
+
+	/**
+	 * serialize given {@link EObject} as string representing JSDoc
+	 */
+	public static String toJSDocString(EObject obj) {
+		JSDoc2HoverSerializer serializer = new JSDoc2HoverSerializer();
+		if (obj == null) {
+			return "";
+		}
+		serializer.doSwitch(obj);
+		return serializer.md2HtmlBuilder.done();
+	}
+
+	@Override
+	public Boolean caseDoclet(Doclet doclet) {
+		md2HtmlBuilder.resetMarkdownConverter();
+		appendContents(doclet.getContents());
+
+		Map<ITagDefinition, List<LineTag>> groupedLineTags = new HashMap<>();
+		for (LineTag lineTag : doclet.getLineTags()) {
+			ITagDefinition tagDef = lineTag.getTagDefinition();
+			List<LineTag> group = groupedLineTags.get(tagDef);
+			if (group == null) {
+				group = new ArrayList<>(5);
+				groupedLineTags.put(tagDef, group);
+			}
+			group.add(lineTag);
+		}
+		if (!groupedLineTags.isEmpty()) {
+			md2HtmlBuilder.append("\n<dl>");
+			for (ITagDefinition tagDef : N4JSDocletParser.N4JS_LINE_TAGS) {
+				TagHandler tagHandler = LINETAG_HANDLERS.get(tagDef);
+				if (tagHandler == null) {
+					tagHandler = TAG_SECTION; // default tag handler
+				}
+				if (tagHandler != null) {
+					List<LineTag> lineTags = groupedLineTags.get(tagDef);
+					if (lineTags != null && !lineTags.isEmpty()) {
+						tagHandler.open(tagDef, this);
+						boolean first = true;
+						for (LineTag lineTag : lineTags) {
+							md2HtmlBuilder.resetMarkdownConverter();
+							tagHandler.content(lineTag, this, first);
+							first = false;
+						}
+						tagHandler.close(tagDef, this);
+					}
+				}
+			}
+			md2HtmlBuilder.append("\n</dl>");
+		}
+		return false;
+	}
+
+	@Override
+	public Boolean caseLiteral(Literal object) {
+		md2HtmlBuilder.append(object.getValue());
+		return false;
+	}
+
+	@Override
+	public Boolean caseSimpleTypeReference(SimpleTypeReference object) {
+		md2HtmlBuilder.append("<code>").append(object.getTypeName()).append("</code>");
+		return false;
+	}
+
+	@Override
+	public Boolean caseFullTypeReference(FullTypeReference object) {
+		md2HtmlBuilder.append("<code>");
+		md2HtmlBuilder.append(object.getModuleName()).append(".");
+		md2HtmlBuilder.append(object.getTypeName());
+		md2HtmlBuilder.append("</code>");
+		return false;
+	}
+
+	@Override
+	public Boolean caseFullMemberReference(FullMemberReference object) {
+		md2HtmlBuilder.append("<code>");
+		md2HtmlBuilder.append(object.getModuleName()).append(".");
+		md2HtmlBuilder.append(object.getTypeName());
+		if (!object.getMemberName().isEmpty()) {
+			if (object.isStaticMember()) {
+				md2HtmlBuilder.append("#");
+			} else {
+				md2HtmlBuilder.append("'.");
+			}
+			md2HtmlBuilder.append(object.getMemberName());
+		}
+		md2HtmlBuilder.append("</code>");
+		return false;
+	}
+
+	@Override
+	public Boolean caseComposite(Composite object) {
+		appendContents(object.getContents());
+		return false;
+	}
+
+	private void appendContents(EList<ContentNode> contents) {
+		if (contents.isEmpty()) {
+			return;
+		}
+
+		for (ContentNode content : contents) {
+			doSwitch(content);
+		}
+
+	}
+
+	@Override
+	public Boolean caseText(Text text) {
+		md2HtmlBuilder.convertAndAppend(text.getText());
+		return false;
+	}
+
+	@Override
+	public Boolean caseLineTag(LineTag lineTag) {
+		// handled in caseDoclet
+		return false;
+	}
+
+	@Override
+	public Boolean caseTagTitle(TagTitle object) {
+		return false;
+	}
+
+	@Override
+	public Boolean caseInlineTag(InlineTag tag) {
+		// strb.append("{").append(JSDocCharScanner.TAG_START).append(object.getTitle().getTitle());
+		String htag = "i";
+		if (tag.getTagDefinition() == N4JSDocletParser.TAG_CODE) {
+			htag = "code";
+		}
+
+		md2HtmlBuilder.append("<" + htag + ">");
+		for (TagValue tagValue : tag.getValues()) {
+			doSwitch(tagValue);
+		}
+		md2HtmlBuilder.append("</" + htag + ">");
+		return false;
+
+	}
+
+}

--- a/plugins/org.eclipse.n4js.jsdoc/src/org/eclipse/n4js/jsdoc/MD2HTMLConvertingBuilder.java
+++ b/plugins/org.eclipse.n4js.jsdoc/src/org/eclipse/n4js/jsdoc/MD2HTMLConvertingBuilder.java
@@ -1,0 +1,375 @@
+/**
+ * Copyright (c) 2018 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+package org.eclipse.n4js.jsdoc;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * StringBuilder-like converter either simply appending strings (just as StringBuilder) or converting strings from
+ * markdown to HTML on the fly. <b>Warning: Do not use {@link #toString()} to get the emitted string</b>, but use
+ * {@link #done()} instead. Note that {@link #done()} is changing the internal state and cannot be called multiple
+ * times.
+ * <p>
+ * Strings can be appended without modification via {@link #append(CharSequence)}.
+ * <p>
+ * With {@link #convertAndAppend(CharSequence)}, the given char sequence is first converted from markdown to HTML. This
+ * is not a full markdown parser, only the following markdown formattings are recognized;
+ * <ul>
+ * <li>paragraphs (empty line)
+ * <li>unordered lists starting with "-", tab and space aware; nested lists are recognized.
+ * </ul>
+ * The emitted HTML is minimal, just enough to produce correct output in hovers for example. That is, paragraphs or list
+ * items are not closed.
+ */
+public class MD2HTMLConvertingBuilder {
+
+	/**
+	 * Helper type for modeling block structure of the converted markdown.
+	 */
+	private static class Block {
+		final int depth;
+		final String startTag;
+		final String endTag;
+		final String mdTag;
+
+		Block(int depth, String mdTag, String startTag, String endTag) {
+			this.depth = depth;
+			this.startTag = startTag;
+			this.endTag = endTag;
+			this.mdTag = mdTag;
+		}
+
+		/**
+		 * Only for debugging purposes.
+		 */
+		@Override
+		public String toString() {
+			return depth + " " + encode(mdTag) + " --> " + encode(startTag) + " / " + encode(endTag);
+		}
+	}
+
+	/**
+	 * Converts markdown string to html for hovers. This is basically for testing.
+	 */
+	public static String convert(String markdown) {
+		MD2HTMLConvertingBuilder m2h = new MD2HTMLConvertingBuilder();
+		m2h.convertAndAppend(markdown);
+		return m2h.done();
+	}
+
+	/**
+	 * The markdown currently processed, set in {@link #convertAndAppend(CharSequence)}.
+	 */
+	private String md;
+	/**
+	 * The position in md, set in {@link #convertAndAppend(CharSequence)}
+	 */
+	private int pos;
+	/**
+	 * The html builder to which outout is appended.
+	 */
+	private final StringBuilder html;
+
+	/**
+	 * Beginning of line, set to recognize special handling of list item identifiers.
+	 */
+	private boolean bol = true;
+	/**
+	 * The last consumed character (via next()).
+	 */
+	private char current;
+
+	/**
+	 * The blocks created during conversion (for lists etc.). These blocks are closed either on {@link #done()} or
+	 * {@link #resetMarkdownConverter()} via {@link #closeNestedBlocks(String)}
+	 */
+	private final List<Block> blocks = new ArrayList<>();
+
+	/**
+	 * The current indentation depth of the line, used to detect end of list items.
+	 */
+	private int depth = 0;
+
+	/**
+	 * Creates parser
+	 */
+	public MD2HTMLConvertingBuilder() {
+		html = new StringBuilder();
+		resetMarkdownConverter();
+	}
+
+	/**
+	 * Converts the given string, internal state is preserved, open blocks are not closed. Call {@link #done()} to close
+	 * all blocks and return generated html string.
+	 */
+	public void convertAndAppend(CharSequence markdown) {
+		if (markdown == null) {
+			return;
+		}
+		this.md = markdown.toString();
+		pos = 0;
+
+		do {
+			next();
+			switch (current) {
+			case 0:
+				break;
+			case '\r':
+				break; // ignore
+			case '\n':
+				handleEOL();
+				break;
+			case '-':
+				handleUL();
+				break;
+			default:
+				handleChar();
+			}
+		} while (current != 0);
+
+	}
+
+	/**
+	 * Appends raw text without converting it.
+	 */
+	public MD2HTMLConvertingBuilder append(CharSequence cs) {
+		html.append(cs);
+		return this;
+
+	}
+
+	/**
+	 * Returns the converted html as string after closing all open blocks. Resets internal state, that is, when called
+	 * again, it will return an empty string.
+	 */
+	public String done() {
+		closeAllBlocks();
+		String result = html.toString();
+		resetMarkdownConverter();
+		return result;
+	}
+
+	/**
+	 * Resets internal state so that all blocks are closed. Emitted HTML is not removed.
+	 */
+	public void resetMarkdownConverter() {
+		closeAllBlocks();
+		bol = true;
+		depth = 0;
+		md = "";
+		pos = 0;
+	}
+
+	private void handleChar() {
+		if (bol) {
+			closeNestedBlocks(null);
+			bol = false;
+		}
+		html.append(current);
+	}
+
+	/**
+	 * Opens a new block, emitting the opening html tag.
+	 */
+	private void openBlock(int blockDepth, String mdTag, String startTag, String endTag) {
+		Block b = new Block(blockDepth, mdTag, startTag, endTag);
+		html.append(startTag);
+		blocks.add(b);
+	}
+
+	/**
+	 * Closes the current block if it exists, emitting the closing html tag.
+	 */
+	private void closeBlock() {
+		int i = blocks.size() - 1;
+		if (i >= 0) {
+			html.append(blocks.get(i).endTag);
+			html.append("\n");
+		}
+		blocks.remove(i);
+	}
+
+	/**
+	 * Closes all blocks.
+	 */
+	private void closeAllBlocks() {
+		while (!blocks.isEmpty())
+			closeBlock();
+	}
+
+	/**
+	 * Closes all blocks with a greater depth than the current depth, if depth is similar it is closed if it contains
+	 * the same markdown tag. The latter case is used for detecting list item siblings.
+	 *
+	 * @return current block or null, if no block is found.
+	 */
+	private Block closeNestedBlocks(String mdTag) {
+		for (int i = blocks.size() - 1; i >= 0; i--) {
+			Block b = blocks.get(i);
+			if (b.depth > depth) {
+				closeBlock();
+			} else if (b.depth == depth) {
+				if (mdTag != null && mdTag.equals(b.mdTag)) {
+					return b;
+				} else {
+					closeBlock();
+				}
+			} else { // b.depth<depth
+				return b;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Consumes the next character in the converting markdown string and assings it to {@link #current}. If end of
+	 * string is found, {@link #current} is set to 0.
+	 */
+	private void next() {
+		if (pos < md.length()) {
+			current = md.charAt(pos);
+			pos++;
+		} else {
+			current = 0;
+		}
+	}
+
+	/**
+	 * Returns the character which would be consumed next (in {@link #next()}) without consuming it. If the end of the
+	 * string is found, 0 is returned.
+	 */
+	private char peek() {
+		if (pos < md.length()) {
+			char p = md.charAt(pos);
+			return p;
+		}
+		return 0;
+	}
+
+	/**
+	 * Handles "end of line" (EOL) recognizing paragraphs (two empty lines in a row) and computing the depth of the next
+	 * line.
+	 */
+	private void handleEOL() {
+		html.append("\n");
+		depth = 0;
+		boolean parFound = false;
+		char s = peek();
+		while (Character.isWhitespace(s)) {
+			switch (s) {
+			case '\n': {
+				parFound = true;
+				depth = 0;
+				break;
+			}
+			case '\t': {
+				depth += 4;
+				break;
+			}
+			case ' ': {
+				depth++;
+			}
+			}
+			next();
+			s = peek();
+		}
+		if (parFound) {
+			html.append("<p>");
+		}
+		bol = true;
+	}
+
+	/**
+	 * Handles unsorted lists (UL), that is, list items in markdown.
+	 */
+	private void handleUL() {
+		if (!bol) {
+			html.append(current);
+			return;
+		}
+		String mdTag = String.valueOf(current);
+		Block b = closeNestedBlocks(mdTag);
+		if (b == null || depth > b.depth) {
+			openBlock(depth, mdTag, "<ul>\n", "</ul>");
+		}
+		html.append("<li>");
+		bol = false;
+	}
+
+	/**
+	 * Only for debugging -- do not use to get the emitted html string, use {@link #done()} instead.
+	 */
+	@Override
+	public String toString() {
+		int from = pos - 4;
+		int to = pos + 4;
+		if (from < 0)
+			from = 0;
+		if (to >= md.length())
+			to = md.length() - 1;
+
+		StringBuilder strb = new StringBuilder();
+
+		if (from > 0)
+			strb.append("…");
+
+		for (int i = from; i <= to; i++) {
+			if (i == pos - 1) {
+				strb.append("»");
+			}
+			strb.append(encode(md.charAt(i)));
+			if (i == pos - 1) {
+				strb.append("«");
+			}
+		}
+		if (to < md.length() - 1)
+			strb.append("…");
+		strb.append(", depth " + depth);
+		if (!blocks.isEmpty()) {
+			strb.append(", blocks[" + (blocks.size() - 1) + "]=");
+			strb.append(blocks.get(blocks.size() - 1));
+		}
+		return strb.toString();
+	}
+
+	/**
+	 * Used for improving string debug output.
+	 */
+	private static String encode(char raw) {
+		switch (raw) {
+		case '\n':
+			return "\\n";
+		case '\t':
+			return "\\t";
+		case '\r':
+			return "\\r";
+		case '0':
+			return "†";
+		default:
+			return String.valueOf(raw);
+		}
+	}
+
+	/**
+	 * Used for improving string debug output.
+	 */
+	private static String encode(String raw) {
+		if (raw == null)
+			return "null";
+		StringBuilder strb = new StringBuilder();
+		for (int i = 0; i < raw.length(); i++) {
+			strb.append(encode(raw.charAt(i)));
+		}
+		return strb.toString();
+	}
+
+}

--- a/plugins/org.eclipse.n4js.jsdoc/src/org/eclipse/n4js/jsdoc/N4JSDocletParser.java
+++ b/plugins/org.eclipse.n4js.jsdoc/src/org/eclipse/n4js/jsdoc/N4JSDocletParser.java
@@ -123,12 +123,13 @@ public class N4JSDocletParser extends DocletParser {
 	public final static LineTagWithSimpleTextDefinition TAG_REQID = new LineTagWithSimpleTextDefinition("reqid");
 
 	/**
-	 * All N4JS tag comments.
+	 * All N4JS tag comments. The order of these tags also define the default order in which the
+	 * {@link JSDoc2HoverSerializer} orders them.
 	 */
 	final static AbstractLineTagDefinition[] N4JS_LINE_TAGS = {
-			TAG_SPEC, TAG_AUTHOR, TAG_TODO, TAG_PARAM, TAG_RETURN, TAG_SPECFROMDESCR, TAG_TASK, TAG_REQID,
+			TAG_SPEC, TAG_PARAM, TAG_RETURN, TAG_AUTHOR, TAG_TODO, TAG_TASK, TAG_REQID,
 			TAG_API_NOTE,
-			TAG_API_STATE,
+			TAG_API_STATE, TAG_SPECFROMDESCR,
 			TAG_TESTEE, TAG_TESTEEFROMTYPE, TAG_TESTEETYPE, TAG_TESTEEMEMBER
 	};
 

--- a/tests/org.eclipse.n4js.jsdoc.tests/.classpath
+++ b/tests/org.eclipse.n4js.jsdoc.tests/.classpath
@@ -3,5 +3,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="xtend-gen"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/tests/org.eclipse.n4js.jsdoc.tests/.gitignore
+++ b/tests/org.eclipse.n4js.jsdoc.tests/.gitignore
@@ -1,0 +1,1 @@
+/xtend-gen/

--- a/tests/org.eclipse.n4js.jsdoc.tests/.gitignore
+++ b/tests/org.eclipse.n4js.jsdoc.tests/.gitignore
@@ -1,1 +1,0 @@
-/xtend-gen/

--- a/tests/org.eclipse.n4js.jsdoc.tests/.project
+++ b/tests/org.eclipse.n4js.jsdoc.tests/.project
@@ -6,6 +6,11 @@
 	</projects>
 	<buildSpec>
 		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
 			<name>org.eclipse.jdt.core.javabuilder</name>
 			<arguments>
 			</arguments>
@@ -24,5 +29,6 @@
 	<natures>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
 </projectDescription>

--- a/tests/org.eclipse.n4js.jsdoc.tests/META-INF/MANIFEST.MF
+++ b/tests/org.eclipse.n4js.jsdoc.tests/META-INF/MANIFEST.MF
@@ -9,5 +9,9 @@ Require-Bundle: org.junit,
  org.eclipse.n4js.jsdoc,
  org.eclipse.emf.ecore,
  org.eclipse.xtext.testing,
- org.eclipse.n4js.tests.helper
+ org.eclipse.n4js.tests.helper,
+ com.google.guava,
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtend.lib,
+ org.eclipse.xtend.lib.macro
 

--- a/tests/org.eclipse.n4js.jsdoc.tests/build.properties
+++ b/tests/org.eclipse.n4js.jsdoc.tests/build.properties
@@ -1,4 +1,5 @@
-source.. = src/
+source.. = src/,\
+           xtend-gen/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\

--- a/tests/org.eclipse.n4js.jsdoc.tests/pom.xml
+++ b/tests/org.eclipse.n4js.jsdoc.tests/pom.xml
@@ -28,6 +28,14 @@ Contributors:
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-clean-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.eclipse.xtend</groupId>
+				<artifactId>xtend-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
 			</plugin>
 		</plugins>

--- a/tests/org.eclipse.n4js.jsdoc.tests/src/org/eclipse/n4js/jsdoc/JSDoc2HoverSerializerTest.xtend
+++ b/tests/org.eclipse.n4js.jsdoc.tests/src/org/eclipse/n4js/jsdoc/JSDoc2HoverSerializerTest.xtend
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2018 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+package org.eclipse.n4js.jsdoc
+
+import org.eclipse.n4js.jsdoc.JSDoc2HoverSerializer
+import org.eclipse.n4js.jsdoc.N4JSDocletParser
+import org.junit.Assert
+import org.junit.Test
+
+class JSDoc2HoverSerializerTest {
+	
+	
+	def assertHover(CharSequence jsdocString, CharSequence expectedHover) {
+		val docletParser = new N4JSDocletParser();
+		val doclet = docletParser.parse(jsdocString.toString);
+		val out = JSDoc2HoverSerializer.toJSDocString(doclet);
+		Assert.assertEquals(expectedHover.toString, out);
+	}
+	
+	
+	@Test
+	def testEmpty() {
+		assertHover("", "");	
+	}
+	
+	@Test
+	def testSingleLine() {
+		assertHover("Single line.", "Single line.");	
+	}
+	
+	@Test
+	def testTwoLines() {
+		assertHover(
+			'''
+			First line.
+			Second line.
+			''',
+			'''
+			First line.
+			Second line.'''
+			
+		);	
+	}
+	
+	@Test
+	def testTwoShortParagraphs() {
+		assertHover(
+			'''
+			/**
+			 * 1
+			 *
+			 * 2
+			 */
+			''',
+			'''
+			1
+			<p>2'''
+		);	
+	}
+	
+
+	@Test
+	def testTwoParagraphs() {
+		assertHover(
+			'''
+			/**
+			 * First par.
+			 * 
+			 * Second par.
+			 */
+			''',
+			'''
+			First par.
+			<p>Second par.'''
+		);	
+	}
+	
+	@Test
+	def testInlineCode() {
+		assertHover(
+			'''
+			/**
+			 * Some {@code inline}.
+			 */
+			''',
+			'''
+			Some <code> inline</code>.'''
+		);
+	}
+
+	@Test
+	def testListWithInlineCode() {
+		assertHover(
+			'''
+			/**
+			 * - item {@code inline}.
+			 */
+			''',
+			'''
+			<ul>
+			<li> item <code> inline</code>.</ul>
+			'''
+		);
+	}
+	
+	@Test
+	def testRealWorld() {
+		assertHover(
+			'''
+			/**
+			 * First par.
+			 * - some
+			 * - details 
+			 * Second par.
+			 * @param p string
+			 * @author Nobody
+			 * @specFromDecscription
+			 * @param t int
+			 * @author Anybody
+			 */
+			''',
+			'''
+			First par.
+			<ul>
+			<li> some
+			<li> details 
+			</ul>
+			Second par.
+			<dl>
+			<dt>Param:</dt>
+			<dd>
+			<ul><li>p string</li><li>t int</li></ul></dd>
+			<dt>Author:</dt>
+			<dd>Nobody<p>Anybody
+			</dl>'''
+		);	
+	}
+	
+}

--- a/tests/org.eclipse.n4js.jsdoc.tests/src/org/eclipse/n4js/jsdoc/JSDocCharScannerTest.java
+++ b/tests/org.eclipse.n4js.jsdoc.tests/src/org/eclipse/n4js/jsdoc/JSDocCharScannerTest.java
@@ -54,21 +54,30 @@ public class JSDocCharScannerTest {
 	@SuppressWarnings("javadoc")
 	@Test
 	public void testWhitespaces() {
-		doTestContent(" Test", new JSDocCharScanner(" Test")); // preserve leading ws
-		doTestContent("Test", new JSDocCharScanner("Test ")); // remove trailing ws at end
-		doTestContent(" Test", new JSDocCharScanner(" Test ")); // preserve leading ws only
-		doTestContent(" Test", new JSDocCharScanner("/**\n *  Test\n */")); // end of JSDoc
-		doTestContent("Test", new JSDocCharScanner("/**\n * Test\n */")); // start and end
+		doTestContent(" Test", new JSDocCharScanner(" Test"), "preserve leading ws");
+		doTestContent("Test", new JSDocCharScanner("Test "), "remove trailing ws at end");
+		doTestContent(" Test", new JSDocCharScanner(" Test "), "preserve leading ws only");
+		doTestContent(" Test", new JSDocCharScanner("/**\n *  Test\n */"), "only skip one space after *");
+		doTestContent("Test", new JSDocCharScanner("/**\n * Test\n */"), "start and end");
 	}
 
-	/***/
+	/**
+	 * Tests whether next scanner token is as expected.
+	 */
 	protected void doTestContent(String expected, JSDocCharScanner scanner) {
+		doTestContent(expected, scanner, null);
+	}
+
+	/**
+	 * Tests whether next scanner token is as expected, shows message in case of failure.
+	 */
+	protected void doTestContent(String expected, JSDocCharScanner scanner, String message) {
 		String actual = "";
 		while (scanner.hasNext()) {
 			actual += scanner.next();
 		}
 
-		assertEquals(expected, actual);
+		assertEquals(message, expected, actual);
 
 	}
 

--- a/tests/org.eclipse.n4js.jsdoc.tests/src/org/eclipse/n4js/jsdoc/MD2HTMLConvertingBuilderTest.xtend
+++ b/tests/org.eclipse.n4js.jsdoc.tests/src/org/eclipse/n4js/jsdoc/MD2HTMLConvertingBuilderTest.xtend
@@ -70,8 +70,8 @@ class MD2HTMLConvertingBuilderTest {
 			'''
 			This is a list:
 			<ul>
-			<li> hello
-			<li> world
+			<li>hello
+			<li>world
 			</ul>
 			''');	
 	}
@@ -88,9 +88,9 @@ class MD2HTMLConvertingBuilderTest {
 			'''
 			This is a list:
 			<ul>
-			<li> hello
+			<li>hello
 			hallo
-			<li> world
+			<li>world
 			</ul>
 			''');	
 	}
@@ -102,15 +102,18 @@ class MD2HTMLConvertingBuilderTest {
 			This is a list:
 			- hello
 			- world
+			cont
+			
 			More text
 			''',
 			'''
 			This is a list:
 			<ul>
-			<li> hello
-			<li> world
+			<li>hello
+			<li>world
+			cont
 			</ul>
-			More text
+			<p>More text
 			''');	
 	}
 
@@ -125,22 +128,23 @@ class MD2HTMLConvertingBuilderTest {
 				- is
 			- world
 				- some text
+				
 			More text
 			''',
 			'''
 			This is a list:
 			<ul>
-			<li> hello
+			<li>hello
 			<ul>
-			<li> this
-			<li> is
+			<li>this
+			<li>is
 			</ul>
-			<li> world
+			<li>world
 			<ul>
-			<li> some text
+			<li>some text
 			</ul>
 			</ul>
-			More text
+			<p>More text
 			''');	
 	}
 	

--- a/tests/org.eclipse.n4js.jsdoc.tests/src/org/eclipse/n4js/jsdoc/MD2HTMLConvertingBuilderTest.xtend
+++ b/tests/org.eclipse.n4js.jsdoc.tests/src/org/eclipse/n4js/jsdoc/MD2HTMLConvertingBuilderTest.xtend
@@ -1,0 +1,147 @@
+/**
+ * Copyright (c) 2018 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+package org.eclipse.n4js.jsdoc
+
+import org.junit.Assert
+import org.junit.Test
+
+class MD2HTMLConvertingBuilderTest {
+	
+	
+	def assertConvert(CharSequence markdown, CharSequence expectedHTML) {
+		val html = MD2HTMLConvertingBuilder.convert(markdown.toString);
+		Assert.assertEquals(expectedHTML.toString, html);
+	}
+	
+	
+	@Test
+	def testEmpty() {
+		assertConvert("", "");	
+	}
+	
+	@Test
+	def testSingleLine() {
+		assertConvert("Single line.", "Single line.");	
+	}
+	
+	@Test
+	def testTwoLines() {
+		assertConvert(
+			'''
+			First line.
+			Second line.
+			''',
+			'''
+			First line.
+			Second line.
+			''');	
+	}
+
+	@Test
+	def testTwoParagraphs() {
+		assertConvert(
+			'''
+			First par.
+			
+			Second par.
+			''',
+			'''
+			First par.
+			<p>Second par.
+			''');	
+	}
+	
+	@Test
+	def testList() {
+		assertConvert(
+			'''
+			This is a list:
+			- hello
+			- world
+			''',
+			'''
+			This is a list:
+			<ul>
+			<li> hello
+			<li> world
+			</ul>
+			''');	
+	}
+	
+	@Test
+	def testMultiLineList() {
+		assertConvert(
+			'''
+			This is a list:
+			- hello
+			  hallo
+			- world
+			''',
+			'''
+			This is a list:
+			<ul>
+			<li> hello
+			hallo
+			<li> world
+			</ul>
+			''');	
+	}
+	
+	@Test
+	def testListCont() {
+		assertConvert(
+			'''
+			This is a list:
+			- hello
+			- world
+			More text
+			''',
+			'''
+			This is a list:
+			<ul>
+			<li> hello
+			<li> world
+			</ul>
+			More text
+			''');	
+	}
+
+
+	@Test
+	def testNestedListCont() {
+		assertConvert(
+			'''
+			This is a list:
+			- hello
+				- this
+				- is
+			- world
+				- some text
+			More text
+			''',
+			'''
+			This is a list:
+			<ul>
+			<li> hello
+			<ul>
+			<li> this
+			<li> is
+			</ul>
+			<li> world
+			<ul>
+			<li> some text
+			</ul>
+			</ul>
+			More text
+			''');	
+	}
+	
+}

--- a/tests/org.eclipse.n4js.jsdoc.tests/xtend-gen/.gitignore
+++ b/tests/org.eclipse.n4js.jsdoc.tests/xtend-gen/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
#658 

- added markdown to html converter (similar to a string builder) and JSDoc to hover html serializer
- adjusted hover provider to use JSDoc serializer, also added over support on declarations
- fixed minor problems in JSDoc parser/scanner

- [x] http://build-master.corp.numberfour.eu:8080/view/N4JS-Y/job/n4js-inhouse-multibranch/job/GH-658/2/