### PR TITLE
GH-691 Handle broken project / unknown projects in the dependency calculation

### DIFF
--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/handler/LibrariesFixHandler.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/handler/LibrariesFixHandler.java
@@ -1,6 +1,8 @@
 package org.eclipse.n4js.ui.handler;
 
 import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.jface.dialogs.MessageDialog.openError;
+import static org.eclipse.n4js.ui.utils.UIUtils.getDisplay;
 import static org.eclipse.ui.PlatformUI.isWorkbenchRunning;
 
 import java.io.File;
@@ -95,6 +97,12 @@ public class LibrariesFixHandler extends AbstractHandler {
 			dependenciesDialog.run(true, true, iRunnableWithProgress);
 		} catch (InvocationTargetException | InterruptedException | SWTException err) {
 			LOGGER.error("unhandled error while setting up dependencies", err);
+			getDisplay().asyncExec(() -> openError(
+					UIUtils.getShell(),
+					"Setting up external libraries failed.",
+					"Error while setting up external libraries.\n"
+							+ "Please check your Error Log view for the detailed log about the failure.\n" +
+							" (note that autobuild is " + wasAutoBuilding + ")"));
 		}
 
 		return null;

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/handler/LibrariesFixHandler.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/handler/LibrariesFixHandler.java
@@ -102,7 +102,7 @@ public class LibrariesFixHandler extends AbstractHandler {
 					"Setting up external libraries failed.",
 					"Error while setting up external libraries.\n"
 							+ "Please check your Error Log view for the detailed log about the failure.\n" +
-							" (note that autobuild is " + wasAutoBuilding + ")"));
+							" (note that autobuild is " + getAutobuildSetting() + ")"));
 		}
 
 		return null;

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/projectModel/dependencies/DependenciesCollectingUtil.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/projectModel/dependencies/DependenciesCollectingUtil.java
@@ -44,8 +44,12 @@ public class DependenciesCollectingUtil {
 			Iterable<ProjectDescription> projectDescriptions) {
 		final Set<String> availableProjectsIds = new HashSet<>();
 		projectDescriptions.forEach(pd -> {
-			availableProjectsIds.add(pd.getProjectId());
-			updateFromProjectDescription(versionedPackages, pd);
+			// in case we get non N4JS projects, user docs projects that are not N4JS projects, or something created by
+			// the plugins e.g RemoteSystemsTempFiles (see https://stackoverflow.com/q/3627463/52564 )
+			if (pd != null) {
+				availableProjectsIds.add(pd.getProjectId());
+				updateFromProjectDescription(versionedPackages, pd);
+			}
 		});
 		availableProjectsIds.forEach(versionedPackages::remove);
 	}


### PR DESCRIPTION
resolves #691 

* adds graceful handling for unknown / broken projects during dependency calculation
* adds error dialog to notify user about issues (instead of terminating silently)