### PR TITLE
CD-759: Ignore flaky test

### DIFF
--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/src/org/eclipse/n4js/jsdoc2spec/JSDoc2SpecProcessorFullTest.java
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/src/org/eclipse/n4js/jsdoc2spec/JSDoc2SpecProcessorFullTest.java
@@ -20,6 +20,7 @@ import org.eclipse.xtext.resource.XtextResourceSet;
 import org.eclipse.xtext.testing.InjectWith;
 import org.eclipse.xtext.testing.XtextRunner;
 import org.junit.ComparisonFailure;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -125,6 +126,7 @@ abstract public class JSDoc2SpecProcessorFullTest {
 	 * Full test with SpecSample9 project, cf. IDE-2160
 	 */
 	@Test
+  @Ignore
 	public void testSample9() throws IOException, InterruptedException {
 		fullTest("SpecSample9_StaticPolyfill");
 	}


### PR DESCRIPTION
This test fails very often. Probably because of a newer GTK version.