### PR TITLE
GH-743: Declare synchronizeTypeDefinitions method as synchronized

### DIFF
--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/external/GitCloneSupplier.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/external/GitCloneSupplier.java
@@ -86,7 +86,7 @@ public class GitCloneSupplier implements Supplier<File> {
 	 * Synchronizes the local clone of the type definitions repository. Does nothing if Internet connection is
 	 * unavailable.
 	 */
-	public void synchronizeTypeDefinitions() {
+	public synchronized void synchronizeTypeDefinitions() {
 		initLocations();
 
 		final String remoteURL = currentGitLocation.getRepositoryRemoteURL();


### PR DESCRIPTION
Fixes https://github.com/eclipse/n4js/issues/743

A race condition could lead to a deletion of the type definitions repo on startup (see issue for a more thorough description).