### PR TITLE
GH-759: Type modifiers dropped / not merged when capturing wildcards with upper bounds

### DIFF
--- a/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch04_09__TypeModifiers/TypeModifiers_withWildcardsWithUpperBounds.n4js.xt
+++ b/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch04_09__TypeModifiers/TypeModifiers_withWildcardsWithUpperBounds.n4js.xt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.spec.tests.N4JSSpecTest END_SETUP */
+
+
+class C {}
+
+
+// ------------------------------------------------
+// typing strategy:
+
+
+class G1<T extends ~w~C> {
+	public value: ~i~T;
+}
+let g1: G1<?>;
+let result1 = g1.value;
+// XPECT type of 'result1' --> ~i~C
+result1;
+
+
+class G2<T extends ~i~C> {
+	public value: ~w~T;
+}
+let g2: G2<?>;
+let result2 = g2.value;
+// XPECT type of 'result2' --> ~∅~C
+result2;
+
+
+class G3<T> {
+	public value: ~i~T;
+}
+let g3: G3<? extends ~w~C>;
+let result3 = g3.value;
+// XPECT type of 'result3' --> ~i~C
+result3;
+
+
+class G4<T> {
+	public value: ~w~T;
+}
+let g4: G4<? extends ~i~C>;
+let result4 = g4.value;
+// XPECT type of 'result4' --> ~∅~C
+result4;
+
+
+// ------------------------------------------------
+// dynamic flag:
+
+
+class G11<T> {
+	public value: T+;
+}
+let g11: G11<? extends C>;
+let result11 = g11.value;
+// XPECT type of 'result11' --> C+
+result11;
+
+
+class G12<T extends C> {
+	public value: T+;
+}
+let g12: G12<?>;
+let result12 = g12.value;
+// XPECT type of 'result12' --> C+
+result12;


### PR DESCRIPTION
See #759.

Not that many changes, actually, but I had to move things around a bit in `TypeUtils`, so the diff is a bit messy.