### PR TITLE
GH-771: Fix N4JS_IDE launch configuration

### DIFF
--- a/builds/org.eclipse.n4js.product.build/N4JS__IDE.launch
+++ b/builds/org.eclipse.n4js.product.build/N4JS__IDE.launch
@@ -28,6 +28,7 @@
 <stringAttribute key="pde.version" value="3.3"/>
 <stringAttribute key="product" value="org.eclipse.n4js.product.product"/>
 <setAttribute key="selected_features">
+<setEntry value="org.eclipse.n4js.sdk:default"/>
 <setEntry value="org.eclipse.e4.rcp:default"/>
 <setEntry value="org.eclipse.ecf.core.feature:default"/>
 <setEntry value="org.eclipse.ecf.core.ssl.feature:default"/>
@@ -38,26 +39,18 @@
 <setEntry value="org.eclipse.egit:default"/>
 <setEntry value="org.eclipse.emf.common:default"/>
 <setEntry value="org.eclipse.emf.ecore:default"/>
-<setEntry value="org.eclipse.epp.mpc:default"/>
 <setEntry value="org.eclipse.equinox.p2.core.feature:default"/>
 <setEntry value="org.eclipse.equinox.p2.extras.feature:default"/>
 <setEntry value="org.eclipse.equinox.p2.rcp.feature:default"/>
 <setEntry value="org.eclipse.equinox.p2.user.ui:default"/>
 <setEntry value="org.eclipse.help:default"/>
 <setEntry value="org.eclipse.jgit:default"/>
-<setEntry value="org.eclipse.n4js.compiler.sdk:default"/>
-<setEntry value="org.eclipse.n4js.dependencies.sdk:default"/>
-<setEntry value="org.eclipse.n4js.dependencies.ui.sdk:default"/>
 <setEntry value="org.eclipse.n4js.jsdoc2spec.sdk:default"/>
-<setEntry value="org.eclipse.n4js.lang.sdk:default"/>
 <setEntry value="org.eclipse.n4js.n4mf.sdk:default"/>
 <setEntry value="org.eclipse.n4js.regex.sdk:default"/>
 <setEntry value="org.eclipse.n4js.runner.sdk:default"/>
-<setEntry value="org.eclipse.n4js.sdk:default"/>
 <setEntry value="org.eclipse.n4js.smith.sdk:default"/>
-<setEntry value="org.eclipse.n4js.tester.sdk:default"/>
 <setEntry value="org.eclipse.n4js.ts.sdk:default"/>
-<setEntry value="org.eclipse.n4js.unicode.sdk:default"/>
 <setEntry value="org.eclipse.n4js.xpect.sdk:default"/>
 <setEntry value="org.eclipse.platform:default"/>
 <setEntry value="org.eclipse.rcp:default"/>
@@ -66,6 +59,8 @@
 <setEntry value="org.eclipse.wst.xml_core.feature:default"/>
 <setEntry value="org.eclipse.wst.xml_ui.feature:default"/>
 <setEntry value="org.eclipse.wst.xml_userdoc.feature:default"/>
+<setEntry value="org.eclipse.epp.mpc:default"/>
+<setEntry value="org.eclipse.userstorage:default"/>
 </setAttribute>
 <booleanAttribute key="show_selected_only" value="false"/>
 <stringAttribute key="templateConfig" value="${target_home}/configuration/config.ini"/>


### PR DESCRIPTION
Fixes https://github.com/eclipse/n4js/issues/771.

A previous misconfiguration of the included features lead to a validation issue of a dependency with regard to slf4j. This PR fixes this issue.