### PR TITLE
Post GH-766: Fix workspace setup (remove obsolete xtend-gen + warning)

### DIFF
--- a/plugins/org.eclipse.n4js.json.ui/.classpath
+++ b/plugins/org.eclipse.n4js.json.ui/.classpath
@@ -2,7 +2,6 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="src-gen"/>
-	<classpathentry kind="src" path="xtend-gen"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>

--- a/plugins/org.eclipse.n4js.json.ui/build.properties
+++ b/plugins/org.eclipse.n4js.json.ui/build.properties
@@ -1,8 +1,6 @@
 source.. = src/,\
-           src-gen/,\
-           xtend-gen/
+           src-gen/
 bin.includes = .,\
                META-INF/,\
                plugin.xml,\
                icons/
-bin.excludes = **/*.xtend

--- a/testhelpers/org.eclipse.n4js.tests.helper/src/org/eclipse/n4js/xpect/validation/suppression/SuppressIssuesSetupRoot.xtend
+++ b/testhelpers/org.eclipse.n4js.tests.helper/src/org/eclipse/n4js/xpect/validation/suppression/SuppressIssuesSetupRoot.xtend
@@ -15,7 +15,7 @@ import org.eclipse.xpect.setup.XpectSetupRoot
 import org.eclipse.xpect.xtext.lib.setup.InjectorSetup
 
 /**
- * An xpect setup root which allows to configure a {@link SuppressIssuesSetup}.
+ * An xpect setup root which allows to configure a {@link N4JSSuppressIssuesSetup}.
  *
  * Also see {@link IssueConfiguration}.
  */


### PR DESCRIPTION
A fresh Oomph install after the merge of PR #789 causes workspace warnings due to a misconfigured obsolete `xtend-gen` folder.

This has slipped through the builds since this is not validated in a maven build. Also it only came to my attention now, because I didn't perform a fresh Oomph install after merging this PR. 

Also, I somehow overlooked a small JavaDoc related warning which this PR fixes as well.