### PR TITLE
GH-809: copy information from manifest.n4mf to package.json n4js section

### DIFF
--- a/n4js-libs/packages/n4js-es5/package.json
+++ b/n4js-libs/packages/n4js-es5/package.json
@@ -16,5 +16,25 @@
   "files": [
     "manifest.n4mf",
     "src-gen"
-  ]
+  ],
+  "n4js": {
+    "projectType": "runtimeEnvironment",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "external": [
+        "src/js"
+      ]
+    },
+    "moduleFilters": {
+      "noModuleWrapping": [
+        "**"
+      ]
+    },
+    "moduleLoader": "n4js",
+    "initModules": [
+      "rt"
+    ]
+  }
 }

--- a/n4js-libs/packages/n4js-node-mangelhaft/package.json
+++ b/n4js-libs/packages/n4js-node-mangelhaft/package.json
@@ -23,5 +23,37 @@
   "files": [
     "manifest.n4mf",
     "src-gen"
-  ]
+  ],
+  "n4js": {
+    "projectType": "runtimeEnvironment",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "external": [
+        "src/js"
+      ]
+    },
+    "moduleFilters": {
+      "noModuleWrapping": [
+        "**"
+      ]
+    },
+    "extendedRuntimeEnvironment": "n4js-node",
+    "providedRuntimeLibraries": [
+      "n4js-runtime-n4",
+      "n4js-runtime-v8",
+      "n4js-runtime-es2015",
+      "n4js-runtime-esnext",
+      "n4js-runtime-fetch",
+      "n4js-runtime-mangelhaft",
+      "n4js-runtime-ecma402",
+      "n4js.lang",
+      "org.eclipse.n4js.mangelhaft.runner.ide",
+      "org.eclipse.n4js.mangelhaft",
+      "org.eclipse.n4js.mangelhaft.reporter.ide"
+    ],
+    "moduleLoader": "n4js",
+    "execModule": "n4js-mangelhaft-cli"
+  }
 }

--- a/n4js-libs/packages/n4js-node/package.json
+++ b/n4js-libs/packages/n4js-node/package.json
@@ -35,5 +35,33 @@
   "files": [
     "manifest.n4mf",
     "src-gen"
-  ]
+  ],
+  "n4js": {
+    "projectType": "runtimeEnvironment",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "external": [
+        "src/js"
+      ]
+    },
+    "moduleFilters": {
+      "noModuleWrapping": [
+        "**"
+      ]
+    },
+    "extendedRuntimeEnvironment": "n4js-es5",
+    "providedRuntimeLibraries": [
+      "n4js-runtime-n4",
+      "n4js-runtime-v8",
+      "n4js-runtime-es2015",
+      "n4js-runtime-esnext",
+      "n4js-runtime-fetch",
+      "n4js-runtime-node",
+      "n4js-runtime-ecma402"
+    ],
+    "moduleLoader": "n4js",
+    "execModule": "n4js-cli"
+  }
 }

--- a/n4js-libs/packages/n4js-runtime-ecma402/package.json
+++ b/n4js-libs/packages/n4js-runtime-ecma402/package.json
@@ -16,5 +16,19 @@
   ],
   "engines": {
     "node": ">= 8.0.0"
+  },
+  "n4js": {
+    "projectType": "runtimeLibrary",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "source": [
+        "src/n4js"
+      ]
+    },
+    "moduleFilters": {
+    },
+    "moduleLoader": "n4js"
   }
 }

--- a/n4js-libs/packages/n4js-runtime-es2015/package.json
+++ b/n4js-libs/packages/n4js-runtime-es2015/package.json
@@ -17,5 +17,19 @@
   ],
   "engines": {
     "node": ">= 5.0.0"
+  },
+  "n4js": {
+    "projectType": "runtimeLibrary",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "source": [
+        "src/n4js"
+      ]
+    },
+    "moduleFilters": {
+    },
+    "moduleLoader": "n4js"
   }
 }

--- a/n4js-libs/packages/n4js-runtime-esnext/package.json
+++ b/n4js-libs/packages/n4js-runtime-esnext/package.json
@@ -17,5 +17,19 @@
   ],
   "engines": {
     "node": ">= 5.0.0"
+  },
+  "n4js": {
+    "projectType": "runtimeLibrary",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "source": [
+        "src/n4js"
+      ]
+    },
+    "moduleFilters": {
+    },
+    "moduleLoader": "n4js"
   }
 }

--- a/n4js-libs/packages/n4js-runtime-fetch/package.json
+++ b/n4js-libs/packages/n4js-runtime-fetch/package.json
@@ -16,5 +16,22 @@
   ],
   "engines": {
     "node": ">= 5.0.0"
+  },
+  "n4js": {
+    "projectType": "runtimeLibrary",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "source": [
+        "src/n4js"
+      ]
+    },
+    "moduleFilters": {
+    },
+    "requiredRuntimeLibraries": [
+      "n4js-runtime-es2015"
+    ],
+    "moduleLoader": "n4js"
   }
 }

--- a/n4js-libs/packages/n4js-runtime-mangelhaft/package.json
+++ b/n4js-libs/packages/n4js-runtime-mangelhaft/package.json
@@ -16,5 +16,16 @@
   ],
   "engines": {
     "node": ">= 5.0.0"
+  },
+  "n4js": {
+    "projectType": "runtimeLibrary",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+    },
+    "moduleFilters": {
+    },
+    "moduleLoader": "n4js"
   }
 }

--- a/n4js-libs/packages/n4js-runtime-n4-tests/package.json
+++ b/n4js-libs/packages/n4js-runtime-n4-tests/package.json
@@ -17,5 +17,33 @@
   ],
   "engines": {
     "node": ">= 5.0.0"
+  },
+  "n4js": {
+    "projectType": "test",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "external": [
+        "test/js"
+      ],
+      "test": [
+        "test/n4js"
+      ]
+    },
+    "moduleFilters": {
+      "noModuleWrapping": [
+        "runtime/n4/util/moduleloader/modules/TestModulePlainCJS"
+      ]
+    },
+    "requiredRuntimeLibraries": [
+      "n4js-runtime-n4",
+      "n4js-runtime-es2015",
+      "n4js-runtime-v8"
+    ],
+    "testedProjects": [
+      "n4js-runtime-n4"
+    ],
+    "moduleLoader": "n4js"
   }
 }

--- a/n4js-libs/packages/n4js-runtime-n4/package.json
+++ b/n4js-libs/packages/n4js-runtime-n4/package.json
@@ -16,5 +16,19 @@
   ],
   "engines": {
     "node": ">= 5.0.0"
+  },
+  "n4js": {
+    "projectType": "runtimeLibrary",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "source": [
+        "src/n4js"
+      ]
+    },
+    "moduleFilters": {
+    },
+    "moduleLoader": "n4js"
   }
 }

--- a/n4js-libs/packages/n4js-runtime-node-tests/package.json
+++ b/n4js-libs/packages/n4js-runtime-node-tests/package.json
@@ -19,5 +19,33 @@
     "babel-cli": "^6.6.5",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.7.4",
     "babel-preset-es2015": "^6.6.0"
+  },
+  "n4js": {
+    "projectType": "test",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "source": [
+        "src/n4js"
+      ],
+      "test": [
+        "test/n4js"
+      ]
+    },
+    "moduleFilters": {
+      "noModuleWrapping": [
+        "**/run-es5"
+      ]
+    },
+    "requiredRuntimeLibraries": [
+      "n4js-runtime-n4",
+      "n4js-runtime-es2015",
+      "n4js-runtime-node"
+    ],
+    "testedProjects": [
+      "n4js-runtime-node"
+    ],
+    "moduleLoader": "n4js"
   }
 }

--- a/n4js-libs/packages/n4js-runtime-node/package.json
+++ b/n4js-libs/packages/n4js-runtime-node/package.json
@@ -16,5 +16,19 @@
   ],
   "engines": {
     "node": ">= 5.0.0"
+  },
+  "n4js": {
+    "projectType": "runtimeLibrary",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "source": [
+        "src/n4js"
+      ]
+    },
+    "moduleFilters": {
+    },
+    "moduleLoader": "node_builtin"
   }
 }

--- a/n4js-libs/packages/n4js-runtime-v8/package.json
+++ b/n4js-libs/packages/n4js-runtime-v8/package.json
@@ -16,5 +16,19 @@
   ],
   "engines": {
     "node": ">= 5.0.0"
+  },
+  "n4js": {
+    "projectType": "runtimeLibrary",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "source": [
+        "src/n4js"
+      ]
+    },
+    "moduleFilters": {
+    },
+    "moduleLoader": "n4js"
   }
 }

--- a/n4js-libs/packages/n4js.lang/package.json
+++ b/n4js-libs/packages/n4js.lang/package.json
@@ -15,5 +15,22 @@
   ],
   "engines": {
     "node": ">= 5.0.0"
+  },
+  "n4js": {
+    "projectType": "library",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "source": [
+        "src/n4js"
+      ]
+    },
+    "moduleFilters": {
+    },
+    "requiredRuntimeLibraries": [
+      "n4js-runtime-es2015"
+    ],
+    "moduleLoader": "n4js"
   }
 }

--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft.assert.test/package.json
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft.assert.test/package.json
@@ -18,5 +18,24 @@
   ],
   "engines": {
     "node": ">= 5.0.0"
+  },
+  "n4js": {
+    "projectType": "test",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "test": [
+        "test/n4js"
+      ]
+    },
+    "moduleFilters": {
+    },
+    "requiredRuntimeLibraries": [
+      "n4js-runtime-n4",
+      "n4js-runtime-v8",
+      "n4js-runtime-es2015"
+    ],
+    "moduleLoader": "n4js"
   }
 }

--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft.assert/package.json
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft.assert/package.json
@@ -16,5 +16,24 @@
   ],
   "engines": {
     "node": ">= 5.0.0"
+  },
+  "n4js": {
+    "projectType": "library",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "source": [
+        "src/n4js"
+      ]
+    },
+    "moduleFilters": {
+    },
+    "requiredRuntimeLibraries": [
+      "n4js-runtime-n4",
+      "n4js-runtime-v8",
+      "n4js-runtime-es2015"
+    ],
+    "moduleLoader": "n4js"
   }
 }

--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft.reporter.ide.test/package.json
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft.reporter.ide.test/package.json
@@ -18,5 +18,26 @@
   ],
   "engines": {
     "node": ">= 5.0.0"
+  },
+  "n4js": {
+    "projectType": "test",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "test": [
+        "test/n4js"
+      ]
+    },
+    "moduleFilters": {
+    },
+    "requiredRuntimeLibraries": [
+      "n4js-runtime-fetch",
+      "n4js-runtime-mangelhaft"
+    ],
+    "testedProjects": [
+      "org.eclipse.n4js.mangelhaft.reporter.ide"
+    ],
+    "moduleLoader": "n4js"
   }
 }

--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft.reporter.ide/package.json
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft.reporter.ide/package.json
@@ -16,5 +16,22 @@
   ],
   "engines": {
     "node": ">= 5.0.0"
+  },
+  "n4js": {
+    "projectType": "library",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "source": [
+        "src/n4js"
+      ]
+    },
+    "moduleFilters": {
+    },
+    "requiredRuntimeLibraries": [
+      "n4js-runtime-fetch"
+    ],
+    "moduleLoader": "n4js"
   }
 }

--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft.runner.ide/package.json
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft.runner.ide/package.json
@@ -16,5 +16,24 @@
   ],
   "engines": {
     "node": ">= 5.0.0"
+  },
+  "n4js": {
+    "projectType": "library",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "source": [
+        "src/n4js"
+      ]
+    },
+    "moduleFilters": {
+    },
+    "requiredRuntimeLibraries": [
+      "n4js-runtime-n4",
+      "n4js-runtime-fetch",
+      "n4js-runtime-v8"
+    ],
+    "moduleLoader": "n4js"
   }
 }

--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft.test/package.json
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft.test/package.json
@@ -18,5 +18,27 @@
   ],
   "engines": {
     "node": ">= 5.0.0"
+  },
+  "n4js": {
+    "projectType": "test",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "source": [
+        "src/n4js"
+      ],
+      "test": [
+        "test/n4js"
+      ]
+    },
+    "moduleFilters": {
+    },
+    "requiredRuntimeLibraries": [
+      "n4js-runtime-n4",
+      "n4js-runtime-es2015",
+      "n4js-runtime-mangelhaft"
+    ],
+    "moduleLoader": "n4js"
   }
 }

--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft/package.json
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft/package.json
@@ -16,5 +16,24 @@
   ],
   "engines": {
     "node": ">= 5.0.0"
+  },
+  "n4js": {
+    "projectType": "library",
+    "vendorId": "org.eclipse.n4js",
+    "vendorName": "Eclipse N4JS Project",
+    "output": "src-gen",
+    "sources": {
+      "source": [
+        "src/n4js"
+      ]
+    },
+    "moduleFilters": {
+    },
+    "requiredRuntimeLibraries": [
+      "n4js-runtime-n4",
+      "n4js-runtime-v8",
+      "n4js-runtime-es2015"
+    ],
+    "moduleLoader": "n4js"
   }
 }


### PR DESCRIPTION
This prepares the `package.json` files in a backward compatible way, by copying all information from each `manifest.n4mf` to a new top-level property `n4js` in the `package.json` in the same folder.

See #809.