### PR TITLE
GH-874-fix: Library Manager unnecessarily uninstalls and then installs npms

### DIFF
--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/external/ExternalIndexSynchronizer.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/external/ExternalIndexSynchronizer.java
@@ -117,7 +117,7 @@ public abstract class ExternalIndexSynchronizer {
 
 	private String getVersionFromManifest(File manifest) {
 		ProjectDescription pDescr = getProjectDescription(manifest);
-		if (pDescr != null) {
+		if (pDescr != null && pDescr.eResource().getErrors().isEmpty()) {
 			DeclaredVersion pV = pDescr.getProjectVersion();
 			String version = pV.getMajor() + "." + pV.getMinor() + "." + pV.getMicro();
 			if (pV.getQualifier() != null) {

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/external/LibraryManager.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/external/LibraryManager.java
@@ -46,6 +46,7 @@ import org.eclipse.n4js.binaries.IllegalBinaryStateException;
 import org.eclipse.n4js.binaries.nodejs.NpmBinary;
 import org.eclipse.n4js.external.LibraryChange.LibraryChangeType;
 import org.eclipse.n4js.external.libraries.PackageJson;
+import org.eclipse.n4js.external.version.VersionConstraintFormatUtil;
 import org.eclipse.n4js.n4mf.ProjectDependency;
 import org.eclipse.n4js.n4mf.ProjectDescription;
 import org.eclipse.n4js.projectModel.IN4JSCore;
@@ -230,7 +231,7 @@ public class LibraryManager {
 						String name = pDep.getProjectId();
 						String version = NO_VERSION;
 						if (pDep.getVersionConstraint() != null) {
-							version = pDep.getVersionConstraint().toString();
+							version = VersionConstraintFormatUtil.npmFormat(pDep.getVersionConstraint());
 						}
 						dependencies.put(name, version);
 					}


### PR DESCRIPTION
follow-up fix for #874