### PR TITLE
GH-891 As a smith I want to have a build image that can be run as non-root user.

### DIFF
--- a/Jenkinsfile.new
+++ b/Jenkinsfile.new
@@ -15,7 +15,7 @@ pipeline {
             // Reuse repository.volume container if one exists, to speed up subsequent builds.
             args '-v n4js-m2-repository:/usr/share/maven/ref/repository/'
             additionalBuildArgs '--build-arg MAVEN_CENTRAL_URL=' + env.MAVEN_CENTRAL_URL
-            label 'mesos-xlarge'
+            label 'test-ec2-m5xlarge'
         }
     }
     options {

--- a/ci-master.jenkinsfile
+++ b/ci-master.jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
             // Reuse repository.volume container if one exists, to speed up subsequent builds.
             args '-v n4js-m2-repository:/usr/share/maven/ref/repository/'
             additionalBuildArgs '--build-arg MAVEN_CENTRAL_URL=' + env.MAVEN_CENTRAL_URL
-            label 'mesos-xlarge'
+            label 'test-ec2-m5xlarge'
         }
     }
 

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,6 +1,6 @@
-FROM openjdk:8u151-jdk
+FROM openjdk:8u171-jdk-stretch
 
-LABEL version="0.1.2" \
+LABEL version="0.1.3" \
       description="Build n4js with Maven. Includes xvfb, node." \
       maintainer="N4JS Team <n4js-dev@eclipse.org>"
 

--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8u151-jdk
 
-LABEL version="0.1.0" \
+LABEL version="0.1.2" \
       description="Build n4js with Maven. Includes xvfb, node." \
       maintainer="N4JS Team <n4js-dev@eclipse.org>"
 
@@ -19,17 +19,23 @@ CMD ["mvn"]
 # and https://hub.docker.com/_/maven/
 #
 ARG MAVEN_VERSION=3.5.2
-ARG USER_HOME_DIR="/root"
+ARG USER_HOME_DIR="/home/build"
 ARG SHA=707b1f6e390a65bde4af4cdaf2a24d45fc19a6ded00fff02e91626e3e42ceaff
 ARG BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries
 ARG MAVEN_CENTRAL_URL=https://repo.maven.apache.org/maven2/
+
+# Assigning build-user to 1000
+RUN groupadd --gid 1000 build && \
+    useradd --uid 1000 --gid build --shell /bin/bash --create-home build
+
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref && \
     curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-$MAVEN_VERSION-bin.tar.gz && \
     echo "${SHA}  /tmp/apache-maven.tar.gz" | sha256sum -c - && \
     tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1 && \
     rm -f /tmp/apache-maven.tar.gz && \
-    ln -s /usr/share/maven/bin/mvn /usr/bin/mvn
+    ln -s /usr/share/maven/bin/mvn /usr/bin/mvn && \
+    chown -R build:build /usr/share/maven
 
 ENV MAVEN_HOME   /usr/share/maven
 ENV MAVEN_CONFIG "$USER_HOME_DIR/.m2"
@@ -39,15 +45,19 @@ COPY copy-reference-files.sh /usr/local/bin/
 COPY mvn-entrypoint.sh /usr/local/bin/
 COPY settings.xml /usr/share/maven/ref/
 RUN sed -i -e 's|MAVEN_CENTRAL_URL|'"$MAVEN_CENTRAL_URL"'|g' /usr/share/maven/ref/settings.xml && \
-    /usr/local/bin/copy-reference-files.sh
+    /usr/local/bin/copy-reference-files.sh && \
+    mkdir -p /usr/share/maven/ref/repository/ && \
+    chown -R build:build /usr/share/maven/ref
+
 
 #
 # The remaining part has been inspired by:
 # https://github.com/nodejs/docker-node/blob/master/8.9/wheezy/Dockerfile
 #
 
-RUN groupadd --gid 1000 node && \
-    useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+# Assigning node-user to 1001
+RUN groupadd --gid 1001 node && \
+    useradd --uid 1001 --gid node --shell /bin/bash --create-home node
 
 RUN set -ex && \
     for key in \
@@ -68,7 +78,7 @@ RUN set -ex && \
 #
 # Node install
 #
-ENV NODE_VERSION 8.11.1
+ENV NODE_VERSION 8.11.2
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \


### PR DESCRIPTION
resolves #891 

* adjusted docker to run as non-root
* bumps java `openjdk:8u151-jdk` -> `openjdk:8u171-jdk-stretch`
* bumps node version `8.11.1` -> `8.11.2`
* bumps docker label version `0.1.0` -> `0.1.3`
* adjusts node label `mesos-xlarge` -> `test-ec2-m5xlarge`