### PR TITLE
GH-907: Library manager should install transitive dependencies without building in between

### DIFF
--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/external/NpmCLI.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/external/NpmCLI.java
@@ -130,6 +130,9 @@ public class NpmCLI {
 					actualChanges.add(actChg);
 				}
 				subMonitor.worked(1);
+				if (!batchStatus.isOK()) {
+					break; // fail fast and do not let the user wait for the problem
+				}
 			}
 		}
 

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/external/NpmCLI.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/external/NpmCLI.java
@@ -172,7 +172,7 @@ public class NpmCLI {
 			actualChangeType = LibraryChangeType.Removed;
 		}
 
-		if (packageProcessingStatus != null && packageProcessingStatus.isOK() && batchStatus.isOK()) {
+		if (packageProcessingStatus != null && packageProcessingStatus.isOK()) {
 			URI actualLocation = URI.createFileURI(completePath.toString());
 			actualChange = new LibraryChange(actualChangeType, actualLocation, reqChg.name, actualVersion);
 		}


### PR DESCRIPTION
see #907

This PR fixes:
- bug of #907 
- re-build during NPM-install in case of transitive dependencies