### PR TITLE
 Prepare build-image to container docker-host for DinD

### DIFF
--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -28,6 +28,9 @@ ARG MAVEN_CENTRAL_URL=https://repo.maven.apache.org/maven2/
 RUN groupadd --gid 1000 build && \
     useradd --uid 1000 --gid build --shell /bin/bash --create-home build
 
+# Add build user to the docker group
+RUN groupadd -g 994 docker && usermod -aG docker build
+
 
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref && \
     curl -fsSL -o /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-$MAVEN_VERSION-bin.tar.gz && \
@@ -123,3 +126,28 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         xauth \
         xvfb
+
+#
+# docker install
+# See https://docs.docker.com/install/linux/docker-ce/debian/#install-using-the-repository
+# 
+RUN apt-get update && \ 
+  apt-get install -y --no-install-recommends \
+     apt-transport-https \
+     ca-certificates \
+     curl \
+     gnupg2 \
+     software-properties-common
+
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+
+RUN lsb_release -cs
+
+RUN add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/debian \
+   $(lsb_release -cs) \
+   stable"
+
+RUN apt-get update && \
+  apt-get install -y docker-ce
+        

--- a/inhouse-ci.jenkinsfile
+++ b/inhouse-ci.jenkinsfile
@@ -52,6 +52,7 @@ pipeline {
                                 pwd
                                 git status
                                 ls -la
+                                docker --help
                                 // IDE-3069: Test calling docker, remove before merging to master!
                                 docker ps
                            """

--- a/inhouse-ci.jenkinsfile
+++ b/inhouse-ci.jenkinsfile
@@ -55,6 +55,10 @@ pipeline {
                                 docker --help
                                 ls -la /var/run/docker.sock
                                 // IDE-3069: Test calling docker, remove before merging to master!
+								whoami
+                                id -u build
+                                groups build
+                                id -G build
                                 docker ps
                            """
                 }

--- a/inhouse-ci.jenkinsfile
+++ b/inhouse-ci.jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
             dir 'docker-build/'
             // Reuse repository.volume container if one exists, to speed up subsequent builds.
             // Bind to host's docker sock to use host's docker daemon to be able to use docker inside n4js docker container
-            args '-u 1000 --group-add 994 -v /var/run/docker.sock:/var/run/docker.sock -v n4js-m2-repository:/usr/share/maven/ref/repository/'
+            args ' --group-add 994 --network=host -v /var/run/docker.sock:/var/run/docker.sock -v n4js-m2-repository:/usr/share/maven/ref/repository/'
             additionalBuildArgs '--build-arg MAVEN_CENTRAL_URL=' + env.MAVEN_CENTRAL_URL
             label 'm5xlarge'
         }

--- a/inhouse-ci.jenkinsfile
+++ b/inhouse-ci.jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         dockerfile {
             dir 'docker-build/'
             // Reuse repository.volume container if one exists, to speed up subsequent builds.
-            args ' -v n4js-m2-repository:/usr/share/maven/ref/repository/'
+            args '-v n4js-m2-repository:/usr/share/maven/ref/repository/'
             additionalBuildArgs '--build-arg MAVEN_CENTRAL_URL=' + env.MAVEN_CENTRAL_URL
             label 'm5xlarge'
         }

--- a/inhouse-ci.jenkinsfile
+++ b/inhouse-ci.jenkinsfile
@@ -54,7 +54,6 @@ pipeline {
                                 ls -la
                                 docker --help
                                 ls -la /var/run/docker.sock
-                                // IDE-3069: Test calling docker, remove before merging to master!
                                 docker ps
                            """
                 }

--- a/inhouse-ci.jenkinsfile
+++ b/inhouse-ci.jenkinsfile
@@ -13,7 +13,8 @@ pipeline {
         dockerfile {
             dir 'docker-build/'
             // Reuse repository.volume container if one exists, to speed up subsequent builds.
-            args '-v n4js-m2-repository:/usr/share/maven/ref/repository/'
+            // Bind to host's docker sock to use host's docker daemon to be able to use docker inside n4js docker container
+            args '--group-add 994 -v /var/run/docker.sock:/var/run/docker.sock -v n4js-m2-repository:/usr/share/maven/ref/repository/'
             additionalBuildArgs '--build-arg MAVEN_CENTRAL_URL=' + env.MAVEN_CENTRAL_URL
             label 'm5xlarge'
         }

--- a/inhouse-ci.jenkinsfile
+++ b/inhouse-ci.jenkinsfile
@@ -52,6 +52,8 @@ pipeline {
                                 pwd
                                 git status
                                 ls -la
+                                // IDE-3069: Test calling docker, remove before merging to master!
+                                docker ps
                            """
                 }
             }

--- a/inhouse-ci.jenkinsfile
+++ b/inhouse-ci.jenkinsfile
@@ -13,8 +13,7 @@ pipeline {
         dockerfile {
             dir 'docker-build/'
             // Reuse repository.volume container if one exists, to speed up subsequent builds.
-            // Bind to host's docker sock to use host's docker daemon to be able to use docker inside n4js docker container
-            args ' --group-add 994 -v /var/run/docker.sock:/var/run/docker.sock -v n4js-m2-repository:/usr/share/maven/ref/repository/'
+            args ' -v n4js-m2-repository:/usr/share/maven/ref/repository/'
             additionalBuildArgs '--build-arg MAVEN_CENTRAL_URL=' + env.MAVEN_CENTRAL_URL
             label 'm5xlarge'
         }
@@ -52,7 +51,6 @@ pipeline {
                                 pwd
                                 git status
                                 ls -la
-                                docker ps
                            """
                 }
             }

--- a/inhouse-ci.jenkinsfile
+++ b/inhouse-ci.jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
             dir 'docker-build/'
             // Reuse repository.volume container if one exists, to speed up subsequent builds.
             // Bind to host's docker sock to use host's docker daemon to be able to use docker inside n4js docker container
-            args '-u:1000 --group-add 994 -v /var/run/docker.sock:/var/run/docker.sock -v n4js-m2-repository:/usr/share/maven/ref/repository/'
+            args '-u 1000 --group-add 994 -v /var/run/docker.sock:/var/run/docker.sock -v n4js-m2-repository:/usr/share/maven/ref/repository/'
             additionalBuildArgs '--build-arg MAVEN_CENTRAL_URL=' + env.MAVEN_CENTRAL_URL
             label 'm5xlarge'
         }

--- a/inhouse-ci.jenkinsfile
+++ b/inhouse-ci.jenkinsfile
@@ -53,6 +53,7 @@ pipeline {
                                 git status
                                 ls -la
                                 docker --help
+                                ls -la /var/run/docker.sock
                                 // IDE-3069: Test calling docker, remove before merging to master!
                                 docker ps
                            """

--- a/inhouse-ci.jenkinsfile
+++ b/inhouse-ci.jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
             dir 'docker-build/'
             // Reuse repository.volume container if one exists, to speed up subsequent builds.
             // Bind to host's docker sock to use host's docker daemon to be able to use docker inside n4js docker container
-            args ' --group-add 994 --network=host -v /var/run/docker.sock:/var/run/docker.sock -v n4js-m2-repository:/usr/share/maven/ref/repository/'
+            args ' --group-add 994 -v /var/run/docker.sock:/var/run/docker.sock -v n4js-m2-repository:/usr/share/maven/ref/repository/'
             additionalBuildArgs '--build-arg MAVEN_CENTRAL_URL=' + env.MAVEN_CENTRAL_URL
             label 'm5xlarge'
         }
@@ -55,10 +55,6 @@ pipeline {
                                 docker --help
                                 ls -la /var/run/docker.sock
                                 // IDE-3069: Test calling docker, remove before merging to master!
-								whoami
-                                id -u build
-                                groups build
-                                id -G build
                                 docker ps
                            """
                 }

--- a/inhouse-ci.jenkinsfile
+++ b/inhouse-ci.jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
             dir 'docker-build/'
             // Reuse repository.volume container if one exists, to speed up subsequent builds.
             // Bind to host's docker sock to use host's docker daemon to be able to use docker inside n4js docker container
-            args '--group-add 994 -v /var/run/docker.sock:/var/run/docker.sock -v n4js-m2-repository:/usr/share/maven/ref/repository/'
+            args '-u:1000 --group-add 994 -v /var/run/docker.sock:/var/run/docker.sock -v n4js-m2-repository:/usr/share/maven/ref/repository/'
             additionalBuildArgs '--build-arg MAVEN_CENTRAL_URL=' + env.MAVEN_CENTRAL_URL
             label 'm5xlarge'
         }

--- a/inhouse-ci.jenkinsfile
+++ b/inhouse-ci.jenkinsfile
@@ -52,8 +52,6 @@ pipeline {
                                 pwd
                                 git status
                                 ls -la
-                                docker --help
-                                ls -la /var/run/docker.sock
                                 docker ps
                            """
                 }


### PR DESCRIPTION
In the build log, search for `docker ps` to verify that a call to docker, which requires docker daemon, works.