### PR TITLE
GH-809: use master branch for type definitions in n4jsd repository

### DIFF
--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/external/TypeDefinitionGitLocationProvider.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/external/TypeDefinitionGitLocationProvider.java
@@ -101,9 +101,7 @@ public interface TypeDefinitionGitLocationProvider {
 		/**
 		 * The default location for the type definition file. Used in the production code.
 		 */
-		PUBLIC_DEFINITION_LOCATION("n4jsd", "https://github.com/NumberFour/n4jsd.git",
-				// GitUtils.getMasterBranch()
-				"GH-809-pkgjson"),
+		PUBLIC_DEFINITION_LOCATION("n4jsd", "https://github.com/NumberFour/n4jsd.git", GitUtils.getMasterBranch()),
 
 		/**
 		 * Type definition location for testing purposes.


### PR DESCRIPTION
See #809.

Corresponding PR in n4jsd repository has to be merged first:
https://github.com/NumberFour/n4jsd/pull/16