### PR TITLE
GH-968: NPE when running code in IDE with runtime code installed from npm

### DIFF
--- a/n4js-libs/packages/n4js-es5/package.json
+++ b/n4js-libs/packages/n4js-es5/package.json
@@ -15,6 +15,7 @@
     "node": ">= 5.0.0"
   },
   "files": [
+    "src",
     "src-gen"
   ],
   "n4js": {

--- a/n4js-libs/packages/n4js-node-mangelhaft/package.json
+++ b/n4js-libs/packages/n4js-node-mangelhaft/package.json
@@ -26,6 +26,7 @@
     "org.eclipse.n4js.mangelhaft.reporter.ide": "^0.1.0"
   },
   "files": [
+    "src",
     "src-gen"
   ],
   "n4js": {

--- a/n4js-libs/packages/n4js-node/package.json
+++ b/n4js-libs/packages/n4js-node/package.json
@@ -35,6 +35,7 @@
     "n4js-es5": "^0.1.0"
   },
   "files": [
+    "src",
     "src-gen"
   ],
   "n4js": {


### PR DESCRIPTION
Issue: https://github.com/eclipse/n4js/issues/968

This PR adjusts the package.json files of the shipped n4js runtime environment projects to include the "src/" directories in the published version. Furthermore, the IDE runner was adjusted to not rely on the existence of source containers anymore, when computing the path of the execModule to be executed.