### PR TITLE
GH-957: Fix issues when a workspace project depends on one of the published runtime NPMs (part 2)

### DIFF
--- a/plugins/org.eclipse.n4js.runner/src/org/eclipse/n4js/runner/RuntimeEnvironmentsHelper.java
+++ b/plugins/org.eclipse.n4js.runner/src/org/eclipse/n4js/runner/RuntimeEnvironmentsHelper.java
@@ -34,7 +34,7 @@ import org.eclipse.n4js.projectModel.IN4JSSourceContainerAware;
 import org.eclipse.n4js.runner.exceptions.DependencyCycleDetectedException;
 import org.eclipse.n4js.runner.exceptions.InsolvableRuntimeEnvironmentException;
 import org.eclipse.n4js.runner.extension.RuntimeEnvironment;
-import org.eclipse.n4js.validation.helper.SoureContainerAwareDependencyTraverser;
+import org.eclipse.n4js.validation.helper.SourceContainerAwareDependencyTraverser;
 
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
@@ -145,7 +145,7 @@ public class RuntimeEnvironmentsHelper {
 	 * @return list of transitive dependencies of type runtime library, no duplicates
 	 */
 	private List<IN4JSProject> collectRequiredRuntimeLibraries(IN4JSProject project) {
-		if (new SoureContainerAwareDependencyTraverser(project).getResult().hasCycle()) {
+		if (new SourceContainerAwareDependencyTraverser(project).getResult().hasCycle()) {
 			throw new DependencyCycleDetectedException(project);
 		}
 		Set<IN4JSProject> depsRuntimeLibraries = new HashSet<>();

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/wizard/dependencies/ExternalLibrariesInstallHelper.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/wizard/dependencies/ExternalLibrariesInstallHelper.java
@@ -11,14 +11,15 @@
 package org.eclipse.n4js.ui.wizard.dependencies;
 
 import java.util.HashSet;
-import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.n4js.n4mf.DeclaredVersion;
 import org.eclipse.n4js.ui.external.ExternalLibrariesActionsHelper;
 
 import com.google.inject.Inject;
@@ -53,14 +54,14 @@ public class ExternalLibrariesInstallHelper {
 		// remove npms
 		externals.maintenanceDeleteNpms(multistatus);
 
-		Set<String> projectIdsOfShippedCode = StreamSupport
+		Map<String, DeclaredVersion> projectIdsOfShippedCode = StreamSupport
 				.stream(dependenciesHelper.getAvailableProjectsDescriptions(true).spliterator(), false)
-				.map(pd -> pd.getProjectId())
-				.collect(Collectors.toCollection(LinkedHashSet::new));
+				.collect(Collectors.toMap(pd -> pd.getProjectId(), pd -> pd.getProjectVersion()));
 
 		// install npms from target platform
 		Map<String, String> dependenciesToInstall = dependenciesHelper.calculateDependenciesToInstall();
-		addDependenciesForRemainingShippedCode(dependenciesToInstall, projectIdsOfShippedCode);
+		removeDependenciesToShippedCodeIfVersionMatches(dependenciesToInstall, projectIdsOfShippedCode);
+		addDependenciesForRemainingShippedCode(dependenciesToInstall, projectIdsOfShippedCode.keySet());
 		final SubMonitor subMonitor3 = monitor.split(45);
 
 		externals.installNoUpdate(dependenciesToInstall, multistatus, subMonitor3);
@@ -68,6 +69,29 @@ public class ExternalLibrariesInstallHelper {
 		// rebuild externals & schedule full rebuild
 		final SubMonitor subMonitor4 = monitor.split(35);
 		externals.maintenanceUpateState(multistatus, subMonitor4);
+	}
+
+	/**
+	 * Removes from map 'dependenciesToInstall' all entries for projects that are in the shipped code, if and only if
+	 * the requested version is the "fake" version of the shipped code.
+	 *
+	 * FIXME GH-957 / GH-809 change implementation to use a proper SemVer version-range-check instead of the string
+	 * compare!
+	 */
+	private void removeDependenciesToShippedCodeIfVersionMatches(Map<String, String> dependenciesToInstall,
+			Map<String, DeclaredVersion> projectIdsOfShippedCode) {
+		for (Entry<String, String> depToInstall : dependenciesToInstall.entrySet()) {
+			String projectId = depToInstall.getKey();
+			DeclaredVersion availableVersionInShippedCode = projectIdsOfShippedCode.get(projectId);
+			if (availableVersionInShippedCode != null) {
+				String versionConstraintStr = depToInstall.getValue();
+				if (versionConstraintStr != null && versionConstraintStr.trim().equals("@\">=0.1.0 <=0.1.0\"")) {
+					// the "fake" version of the project in the shipped code is requested,
+					// so remove from list of dependencies to be installed:
+					dependenciesToInstall.remove(projectId);
+				}
+			}
+		}
 	}
 
 	/**

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/helper/SourceContainerAwareDependencyTraverser.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/helper/SourceContainerAwareDependencyTraverser.xtend
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */
@@ -24,16 +24,16 @@ import org.eclipse.n4js.utils.DependencyTraverser
  * Class for traversing {@link IN4JSSourceContainerAware source container aware} dependencies and
  * indicating cycles in the dependency graph.
  */
-class SoureContainerAwareDependencyTraverser extends DependencyTraverser<IN4JSSourceContainerAware> {
+class SourceContainerAwareDependencyTraverser extends DependencyTraverser<IN4JSSourceContainerAware> {
 
-	static val DEPENDENCIES_FUNC = [IN4JSSourceContainerAware p |
+	// this is used by default:
+	static val DEPENDENCIES_FUNC = [ IN4JSSourceContainerAware p |
 		p.allDirectDependencies
 	];
-	static val DEPENDENCIES_FUNC_IGNORE_EXTERNAL_VALIDATION = [IN4JSSourceContainerAware p |
-		ImmutableList.copyOf(p.allDirectDependencies.filter[dep | !isExternalValidation(dep)]);
+	// this is used if external projects of project type VALIDATION are requested to be ignored:
+	static val DEPENDENCIES_FUNC_IGNORE_EXTERNAL_VALIDATION = [ IN4JSSourceContainerAware p |
+		ImmutableList.copyOf(p.allDirectDependencies.filter[dep|!isExternalValidation(dep)]);
 	] as Function<IN4JSSourceContainerAware, Collection<? extends IN4JSSourceContainerAware>>;
-
-	private boolean ignoreExternalValidationProjects;
 
 	/** Creates a new traverser instance with the given root node. */
 	new(IN4JSSourceContainerAware rootNode) {
@@ -42,8 +42,14 @@ class SoureContainerAwareDependencyTraverser extends DependencyTraverser<IN4JSSo
 
 	/** Creates a new traverser instance with the given root node. */
 	new(IN4JSSourceContainerAware rootNode, boolean ignoreExternalValidationProjects) {
-		super(rootNode, SourceContainerAwareEquivalence.INSTANCE, if (ignoreExternalValidationProjects) DEPENDENCIES_FUNC_IGNORE_EXTERNAL_VALIDATION else DEPENDENCIES_FUNC)
-		this.ignoreExternalValidationProjects = ignoreExternalValidationProjects;
+		super(
+			rootNode,
+			SourceContainerAwareEquivalence.INSTANCE,
+			if (ignoreExternalValidationProjects)
+				DEPENDENCIES_FUNC_IGNORE_EXTERNAL_VALIDATION
+			else
+				DEPENDENCIES_FUNC
+		)
 	}
 
 	def private static boolean isExternalValidation(IN4JSSourceContainerAware project) {

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/packagejson/N4JSProjectSetupJsonValidatorExtension.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/packagejson/N4JSProjectSetupJsonValidatorExtension.xtend
@@ -68,7 +68,6 @@ import org.eclipse.n4js.utils.Version
 import org.eclipse.n4js.utils.WildcardPathFilterHelper
 import org.eclipse.n4js.validation.IssueCodes
 import org.eclipse.n4js.validation.N4JSElementKeywordProvider
-import org.eclipse.n4js.validation.helper.SoureContainerAwareDependencyTraverser
 import org.eclipse.xtend.lib.annotations.Data
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils
 import org.eclipse.xtext.resource.IContainer
@@ -84,6 +83,7 @@ import static org.eclipse.n4js.validation.IssueCodes.*
 import static org.eclipse.n4js.validation.validators.packagejson.ProjectTypePredicate.*
 
 import static extension com.google.common.base.Strings.nullToEmpty
+import org.eclipse.n4js.validation.helper.SourceContainerAwareDependencyTraverser
 
 /**
  * A JSON validator extension that validates {@code package.json} resources in the context
@@ -337,7 +337,7 @@ public class N4JSProjectSetupJsonValidatorExtension extends AbstractJSONValidato
 	def checkCyclicDependencies(JSONDocument document) {
 		val project = findProject(document.eResource.URI).orNull;
 		if (null !== project) {
-			val result = new SoureContainerAwareDependencyTraverser(project, true).result;
+			val result = new SourceContainerAwareDependencyTraverser(project, true).result;
 			if (result.hasCycle) {
 				// add issue to 'name' property or alternatively to the whole document
 				val nameValue = getSingleDocumentValue(ProjectDescriptionHelper.PROP__NAME);


### PR DESCRIPTION
See #957.
Do not install shipped code project if "fake" version requested.