### PR TITLE
GH-979: Documentation not shown when hovering mouse over elements

### DIFF
--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/labeling/N4JSHoverProvider.xtend
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/labeling/N4JSHoverProvider.xtend
@@ -55,6 +55,7 @@ class N4JSHoverProvider extends DefaultEObjectHoverProvider {
 	@Inject
 	private OperationCanceledManager cancelManager;
 
+	@Inject
 	private N4JSDocletParser docletParser;
 
 	override protected getFirstLine(EObject o) {


### PR DESCRIPTION
Fixes GH-979

The fix is simply to add a missing `@Inject` annotation. I suspect this to be the outcome of a merge that did not go well.