### PR TITLE
GH-993: asciidoc exporter now handles tests in other project than testee

### DIFF
--- a/plugins/org.eclipse.n4js.jsdoc2spec/src/org/eclipse/n4js/jsdoc2spec/KeyUtils.java
+++ b/plugins/org.eclipse.n4js.jsdoc2spec/src/org/eclipse/n4js/jsdoc2spec/KeyUtils.java
@@ -86,10 +86,15 @@ public class KeyUtils {
 	/** @return a unique key for elements in the given {@link RepoRelativePath} and element name. */
 	public static String getSpecKeyWithoutProjectFolder(RepoRelativePath rrp, String elementName) {
 		String key = "";
-		key += rrp.repositoryName;
-		key += "." + rrp.pathInRepository;
-		key += "." + rrp.projectName;
-		key += "." + elementName;
+		if (rrp != null) { // this happens in an error case only, we created a warning before
+			key += rrp.repositoryName;
+			if (!rrp.pathInRepository.isEmpty()) {
+				key += "." + rrp.pathInRepository;
+			}
+			key += "." + rrp.projectName;
+			key += ".";
+		}
+		key += elementName;
 		return key;
 	}
 

--- a/plugins/org.eclipse.n4js.jsdoc2spec/src/org/eclipse/n4js/jsdoc2spec/RepoRelativePath.java
+++ b/plugins/org.eclipse.n4js.jsdoc2spec/src/org/eclipse/n4js/jsdoc2spec/RepoRelativePath.java
@@ -52,7 +52,7 @@ public class RepoRelativePath {
 		String uriFileString = uri.toString();
 		String uriProjString = project.getLocation().toString();
 		String fileRelString = uriFileString.substring(uriProjString.length());
-		// strip anchor part, i.e. path to type with in the resource
+		// strip anchor part if present, i.e. path to type within the resource
 		int anchorIndex = fileRelString.indexOf("#");
 		if (anchorIndex >= 0)
 			fileRelString = fileRelString.substring(0, anchorIndex);

--- a/plugins/org.eclipse.n4js.jsdoc2spec/src/org/eclipse/n4js/jsdoc2spec/RepoRelativePath.java
+++ b/plugins/org.eclipse.n4js.jsdoc2spec/src/org/eclipse/n4js/jsdoc2spec/RepoRelativePath.java
@@ -15,7 +15,6 @@ import java.nio.file.Path;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
-import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.jgit.errors.ConfigInvalidException;
 import org.eclipse.jgit.lib.Config;
 import org.eclipse.n4js.projectModel.IN4JSCore;
@@ -41,8 +40,7 @@ public class RepoRelativePath {
 	 * Creates the RepoRelativePath from a given resource. Returns null, if resource is not contained in a repository.
 	 * If a repository is found, the simple name of the origin is used.
 	 */
-	public static RepoRelativePath compute(Resource resource, IN4JSCore n4jsCore) {
-		URI uri = resource.getURI();
+	public static RepoRelativePath compute(URI uri, IN4JSCore n4jsCore) {
 		Optional<? extends IN4JSProject> optProj = n4jsCore.findProject(uri);
 		if (!optProj.isPresent()) {
 			return null;
@@ -54,6 +52,10 @@ public class RepoRelativePath {
 		String uriFileString = uri.toString();
 		String uriProjString = project.getLocation().toString();
 		String fileRelString = uriFileString.substring(uriProjString.length());
+		// strip anchor part, i.e. path to type with in the resource
+		int anchorIndex = fileRelString.indexOf("#");
+		if (anchorIndex >= 0)
+			fileRelString = fileRelString.substring(0, anchorIndex);
 
 		String absFileName = path.toAbsolutePath() + fileRelString;
 		File file = new File(absFileName);
@@ -92,7 +94,7 @@ public class RepoRelativePath {
 	 * {@code currendDir/.git/config}
 	 * <p>
 	 * Git clone folder name might be different from git repository name
-	 * 
+	 *
 	 * @return string with repo name or {@code null}
 	 */
 	private static String getRepoName(File currentDir) {
@@ -144,7 +146,7 @@ public class RepoRelativePath {
 		String projNameSlashes = "/" + projName + "/";
 		startIdx = absFileName.indexOf(repoNameSlashes) + repoNameSlashes.length();
 		int endIdx = absFileName.indexOf(projNameSlashes);
-		if (startIdx == -1 || endIdx == -1) {
+		if (startIdx == -1 || endIdx == -1 || endIdx < startIdx) {
 			return "";
 		}
 		String repoPath = absFileName.substring(startIdx, endIdx);
@@ -156,7 +158,8 @@ public class RepoRelativePath {
 	 */
 	public final String repositoryName;
 	/**
-	 * Absolute path in repository (with leading slash).
+	 * Absolute path in repository (with leading slash). This may be empty; this happens if the project folder is a top
+	 * level folder of the project.
 	 */
 	public final String pathInRepository;
 	/**
@@ -243,6 +246,12 @@ public class RepoRelativePath {
 	 */
 	public String getFullPath() {
 		return repositoryName + pathInRepository + projectName + pathInProject;
+	}
+
+	@Override
+	public String toString() {
+		return "repo: " + repositoryName + ", pir: " + pathInRepository + ", proj: " + projectName + ", pip: "
+				+ pathInProject + ":" + lineNumber;
 	}
 
 	/**

--- a/plugins/org.eclipse.n4js.jsdoc2spec/src/org/eclipse/n4js/jsdoc2spec/SpecInfosByName.java
+++ b/plugins/org.eclipse.n4js.jsdoc2spec/src/org/eclipse/n4js/jsdoc2spec/SpecInfosByName.java
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) 2018 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+package org.eclipse.n4js.jsdoc2spec;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.n4js.jsdoc.dom.Doclet;
+import org.eclipse.n4js.jsdoc.dom.FullMemberReference;
+import org.eclipse.n4js.jsdoc2spec.adoc.RepoRelativePathHolder;
+import org.eclipse.n4js.n4JS.N4JSPackage;
+import org.eclipse.n4js.projectModel.IN4JSCore;
+import org.eclipse.n4js.scoping.N4JSGlobalScopeProvider;
+import org.eclipse.n4js.ts.types.ContainerType;
+import org.eclipse.n4js.ts.types.TMember;
+import org.eclipse.n4js.ts.types.TModule;
+import org.eclipse.n4js.ts.types.TVariable;
+import org.eclipse.n4js.ts.types.Type;
+import org.eclipse.n4js.utils.ContainerTypesHelper;
+import org.eclipse.n4js.utils.ContainerTypesHelper.MemberCollector;
+import org.eclipse.xtext.naming.QualifiedName;
+import org.eclipse.xtext.resource.IEObjectDescription;
+import org.eclipse.xtext.scoping.IScope;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+
+/**
+ * Basically a multi map from names to spec infos. Instead of directly using a map we introduced this helper class to
+ * controll access to the map.
+ */
+public class SpecInfosByName {
+
+	private final Multimap<String, SpecInfo> specInfoByName = HashMultimap.create();
+	private final IJSDoc2SpecIssueAcceptor issueAcceptor;
+	private final ContainerTypesHelper containerTypesHelper;
+	private final N4JSGlobalScopeProvider globalScopeProvider;
+	private final IN4JSCore n4jsCore;
+
+	/**
+	 * @param issueAcceptor
+	 *            injected in or added to creator and passed here to avoid DI for this helper type
+	 * @param globalScopeProvider
+	 *            injected in creator and passed here to avoid DI for this helper type
+	 * @param containerTypesHelper
+	 *            injected in creator and passed here to avoid DI for this helper type
+	 * @param n4jsCore
+	 *            injected in creator and passed here to avoid DI for this helper type
+	 */
+	SpecInfosByName(IJSDoc2SpecIssueAcceptor issueAcceptor, N4JSGlobalScopeProvider globalScopeProvider,
+			ContainerTypesHelper containerTypesHelper, IN4JSCore n4jsCore) {
+		this.issueAcceptor = issueAcceptor;
+		this.globalScopeProvider = globalScopeProvider;
+		this.containerTypesHelper = containerTypesHelper;
+		this.n4jsCore = n4jsCore;
+	}
+
+	void createTypeSpecInfo(Type type, RepoRelativePathHolder rrph) {
+		SpecInfo typeInfo = new SpecInfo(type);
+		String regionName = KeyUtils.getSpecKeyWithoutProjectFolder(rrph, type);
+		specInfoByName.put(regionName, typeInfo);
+
+		Collection<SpecInfo> identicalSpecInfo = specInfoByName.get(regionName);
+		if (identicalSpecInfo.size() > 1) {
+			SpecInfo polyfillAware = null;
+			List<SpecInfo> polyfilling = new LinkedList<>();
+			for (SpecInfo si : identicalSpecInfo) {
+				Type moduleType = si.specElementRef.getElementAsType();
+
+				if (moduleType != null) {
+					TModule typeModule = moduleType.getContainingModule();
+					if (typeModule.isStaticPolyfillModule()) {
+						polyfilling.add(si);
+					} else if (typeModule.isStaticPolyfillAware()) {
+						polyfillAware = si;
+					}
+				}
+			}
+
+			if (polyfillAware != null) {
+				Type polyfillAwareType = polyfillAware.specElementRef.getElementAsType();
+				for (SpecInfo si : polyfilling) {
+					si.specElementRef.polyfillAware = polyfillAwareType;
+				}
+			}
+		}
+	}
+
+	void createTVarSpecInfo(TVariable tvar, RepoRelativePathHolder rrph) {
+		String name = KeyUtils.getSpecKeyWithoutProjectFolder(rrph, tvar);
+		specInfoByName.put(name, new SpecInfo(tvar));
+	}
+
+	/**
+	 * Adds test info to an identified element.
+	 */
+	void addTestInfoForCodeElement(RepoRelativePath rrpOfTest, Doclet testMethodDoclet, FullMemberReference ref,
+			TMember testMember) {
+
+		RepoRelativePath rrpOfTestee = computeRRP(ref, testMember);
+
+		String fullTypeName = ref.fullTypeName();
+		String regionName = KeyUtils.getSpecKeyWithoutProjectFolder(rrpOfTestee, fullTypeName);
+		Collection<SpecInfo> specInfos = specInfoByName.get(regionName);
+
+		boolean testeeMemberFound = false;
+		for (SpecInfo specInfo : specInfos) {
+			for (Type testee : specInfo.specElementRef.getTypes()) {
+				if (testee instanceof ContainerType<?> && ref.memberNameSet()) {
+					TMember testeeMember = getRefMember((ContainerType<?>) testee, ref);
+					if (testeeMember != null) {
+						String testeeName = testeeMember.getName();
+						SpecTestInfo testSpecInfo = createTestSpecInfo(testeeName, testMethodDoclet, testMember,
+								rrpOfTest);
+						specInfo.addMemberTestInfo(testeeMember, testSpecInfo);
+					}
+					testeeMemberFound = true;
+				}
+			}
+		}
+
+		if (!testeeMemberFound) {
+			for (SpecInfo specInfo : specInfos) {
+				// Type, TFunction of TVariable
+				String elementName = specInfo.specElementRef.identifiableElement.getName();
+				SpecTestInfo testSpecInfo = createTestSpecInfo(elementName, testMethodDoclet, testMember, rrpOfTest);
+				specInfo.addTypeTestInfo(testSpecInfo);
+			}
+
+			if (specInfos.isEmpty()) {
+				issueAcceptor.addWarning("Testee " + fullTypeName + " not found", testMember);
+			}
+		}
+	}
+
+	private RepoRelativePath computeRRP(FullMemberReference ref, TMember testMember) {
+		IScope scope = globalScopeProvider.getScope(testMember.eResource(),
+				N4JSPackage.Literals.IMPORT_DECLARATION__MODULE);
+		QualifiedName qn = QualifiedName.create(ref.getModuleName().split("/"));
+		IEObjectDescription eod = scope.getSingleElement(qn);
+		if (eod != null) {
+			URI uri = eod.getEObjectURI();
+			RepoRelativePath rrp = RepoRelativePath.compute(uri, n4jsCore);
+			return rrp;
+		} else {
+			issueAcceptor.addWarning("Cannot resolve testee " + ref, testMember);
+			return null;
+		}
+
+	}
+
+	private SpecTestInfo createTestSpecInfo(String testeeName, Doclet doclet, TMember testMember,
+			RepoRelativePath rrpOfTest) {
+
+		String moduleName = testMember.getContainingModule().getModuleSpecifier();
+		String typeName = testMember.getContainingType().getName();
+		String memberName = testMember.getName();
+		QualifiedName qualifiedName = QualifiedName.create(moduleName, typeName, memberName);
+		RepoRelativePath repoRelPath = rrpOfTest != null ? rrpOfTest.withLine(testMember) : null;
+		return new SpecTestInfo(testeeName, qualifiedName, doclet, repoRelPath);
+	}
+
+	// TODO fqn of getter vs setter, fqn of static vs instance
+	private TMember getRefMember(ContainerType<?> ct, FullMemberReference ref) {
+		TMember member = null;
+		String memberName = ref.getMemberName();
+		boolean _static = ref.isStaticMember();
+		MemberCollector memberCollector = containerTypesHelper.fromContext(ct);
+		member = memberCollector.findMember(ct, memberName, false, _static);
+
+		if (member == null) {
+			member = memberCollector.findMember(ct, memberName, false, !_static);
+			if (member == null) {
+				member = memberCollector.findMember(ct, memberName, true, _static);
+				if (member == null) {
+					member = memberCollector.findMember(ct, memberName, true, !_static);
+				}
+			}
+		}
+		return member;
+
+	}
+
+	void addTestInfoForRequirement(RepoRelativePath rrp, Doclet testMethodDoclet, String reqid,
+			TMember testMember) {
+
+		Collection<SpecInfo> specInfos = specInfoByName.get(SpecElementRef.reqidKey(reqid));
+		if (specInfos.isEmpty()) {
+			SpecInfo specInfo = new SpecInfo(reqid);
+			specInfoByName.put(SpecElementRef.reqidKey(reqid), specInfo);
+		}
+		for (SpecInfo specInfo : specInfos) {
+			specInfo.addTypeTestInfo(createTestSpecInfo(reqid, testMethodDoclet, testMember, rrp));
+		}
+	}
+
+	/**
+	 * @return all spec infos, may contain duplicates, i.e. multiple spec infos for the same name.
+	 */
+	Collection<SpecInfo> values() {
+		return specInfoByName.values();
+	}
+}

--- a/plugins/org.eclipse.n4js.jsdoc2spec/src/org/eclipse/n4js/jsdoc2spec/adoc/ADocSerializer.xtend
+++ b/plugins/org.eclipse.n4js.jsdoc2spec/src/org/eclipse/n4js/jsdoc2spec/adoc/ADocSerializer.xtend
@@ -506,7 +506,13 @@ class ADocSerializer {
 			strb.append(testInfo.testMethodTypeName() + "." + testInfo.testMethodName());
 		} else {
 			val pc = SourceEntryFactory.create(testInfo);
-			val strCase = if (testInfo.testCase === null) "Test" else pass(removePrecedingNumber(testInfo.testCase));
+			val strCase = if (testInfo.testCase.nullOrEmpty) "Test" else {
+				var formattedCase = removePrecedingNumber(testInfo.testCase);
+				if (formattedCase.nullOrEmpty) {
+					formattedCase = testInfo.testCase;
+				} 
+				pass(formattedCase);
+			}
 			val strbTmp = new StringBuilder();
 			strbTmp.appendSourceLink(pc, strCase);
 			strb.append(small(strbTmp));

--- a/plugins/org.eclipse.n4js.jsdoc2spec/src/org/eclipse/n4js/jsdoc2spec/adoc/RepoRelativePathHolder.java
+++ b/plugins/org.eclipse.n4js.jsdoc2spec/src/org/eclipse/n4js/jsdoc2spec/adoc/RepoRelativePathHolder.java
@@ -43,7 +43,7 @@ public class RepoRelativePathHolder {
 
 		if (res != null) {
 			if (!modulesToRepoCache.containsKey(res)) {
-				RepoRelativePath rrpRes = RepoRelativePath.compute(res, n4jscore);
+				RepoRelativePath rrpRes = RepoRelativePath.compute(res.getURI(), n4jscore);
 				if (rrpRes != null) {
 					modulesToRepoCache.put(res, rrpRes);
 				}


### PR DESCRIPTION
#993 

Fixes:
- tests can be in other project then testee, use scoping to detect correct testee
- projects found in root of repository are handled correctly now
- if test case has no name, the number of the test case is used instead (otherwise html output would be broken)

- [x] http://n4ide1-jenkins.service.cd-dev.consul/job/N4JS-Inhouse-CI/job/GH-993/4/

Related:
- needs to be fixed in asciidoc macro srclnk: https://github.numberfour.eu/NumberFour/asciispec/issues/111