### PR TITLE
GH-821: Filter type dependencies in dependency collection of the "big button"

### DIFF
--- a/plugins/org.eclipse.n4js.model/emf-gen/org/eclipse/n4js/projectDescription/DependencyType.java
+++ b/plugins/org.eclipse.n4js.model/emf-gen/org/eclipse/n4js/projectDescription/DependencyType.java
@@ -1,0 +1,249 @@
+/**
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+package org.eclipse.n4js.projectDescription;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.eclipse.emf.common.util.Enumerator;
+
+/**
+ * <!-- begin-user-doc -->
+ * A representation of the literals of the enumeration '<em><b>Dependency Type</b></em>',
+ * and utility methods for working with them.
+ * <!-- end-user-doc -->
+ * <!-- begin-model-doc -->
+ * * Different types of dependencies.
+ * <!-- end-model-doc -->
+ * @see org.eclipse.n4js.projectDescription.ProjectDescriptionPackage#getDependencyType()
+ * @model
+ * @generated
+ */
+public enum DependencyType implements Enumerator {
+	/**
+	 * The '<em><b>RUNTIME</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #RUNTIME_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	RUNTIME(0, "RUNTIME", "RUNTIME"),
+
+	/**
+	 * The '<em><b>DEVELOPMENT</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #DEVELOPMENT_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	DEVELOPMENT(0, "DEVELOPMENT", "DEVELOPMENT"),
+
+	/**
+	 * The '<em><b>TYPE</b></em>' literal object.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #TYPE_VALUE
+	 * @generated
+	 * @ordered
+	 */
+	TYPE(0, "TYPE", "TYPE");
+
+	/**
+	 * The '<em><b>RUNTIME</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * * Dependencies of this type must always be present.
+	 * <!-- end-model-doc -->
+	 * @see #RUNTIME
+	 * @model
+	 * @generated
+	 * @ordered
+	 */
+	public static final int RUNTIME_VALUE = 0;
+
+	/**
+	 * The '<em><b>DEVELOPMENT</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * * Dependencies of this type must be present at development-time.
+	 * <!-- end-model-doc -->
+	 * @see #DEVELOPMENT
+	 * @model
+	 * @generated
+	 * @ordered
+	 */
+	public static final int DEVELOPMENT_VALUE = 0;
+
+	/**
+	 * The '<em><b>TYPE</b></em>' literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * *
+	 * Dependencies of this type must be present when using a package
+	 * from a typed language or when developing the package itself.
+	 * <!-- end-model-doc -->
+	 * @see #TYPE
+	 * @model
+	 * @generated
+	 * @ordered
+	 */
+	public static final int TYPE_VALUE = 0;
+
+	/**
+	 * An array of all the '<em><b>Dependency Type</b></em>' enumerators.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private static final DependencyType[] VALUES_ARRAY =
+		new DependencyType[] {
+			RUNTIME,
+			DEVELOPMENT,
+			TYPE,
+		};
+
+	/**
+	 * A public read-only list of all the '<em><b>Dependency Type</b></em>' enumerators.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public static final List<DependencyType> VALUES = Collections.unmodifiableList(Arrays.asList(VALUES_ARRAY));
+
+	/**
+	 * Returns the '<em><b>Dependency Type</b></em>' literal with the specified literal value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param literal the literal.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
+	public static DependencyType get(String literal) {
+		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
+			DependencyType result = VALUES_ARRAY[i];
+			if (result.toString().equals(literal)) {
+				return result;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the '<em><b>Dependency Type</b></em>' literal with the specified name.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param name the name.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
+	public static DependencyType getByName(String name) {
+		for (int i = 0; i < VALUES_ARRAY.length; ++i) {
+			DependencyType result = VALUES_ARRAY[i];
+			if (result.getName().equals(name)) {
+				return result;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the '<em><b>Dependency Type</b></em>' literal with the specified integer value.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the integer value.
+	 * @return the matching enumerator or <code>null</code>.
+	 * @generated
+	 */
+	public static DependencyType get(int value) {
+		switch (value) {
+			case RUNTIME_VALUE: return RUNTIME;
+		}
+		return null;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final int value;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final String name;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private final String literal;
+
+	/**
+	 * Only this class can construct instances.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private DependencyType(int value, String name, String literal) {
+		this.value = value;
+		this.name = name;
+		this.literal = literal;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public int getValue() {
+	  return value;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public String getName() {
+	  return name;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public String getLiteral() {
+	  return literal;
+	}
+
+	/**
+	 * Returns the literal value of the enumerator, which is its string representation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public String toString() {
+		return literal;
+	}
+	
+} //DependencyType

--- a/plugins/org.eclipse.n4js.model/emf-gen/org/eclipse/n4js/projectDescription/ProjectDependency.java
+++ b/plugins/org.eclipse.n4js.model/emf-gen/org/eclipse/n4js/projectDescription/ProjectDependency.java
@@ -25,6 +25,7 @@ import org.eclipse.n4js.semver.Semver.NPMVersionRequirement;
  * The following features are supported:
  * </p>
  * <ul>
+ *   <li>{@link org.eclipse.n4js.projectDescription.ProjectDependency#getType <em>Type</em>}</li>
  *   <li>{@link org.eclipse.n4js.projectDescription.ProjectDependency#getVersionRequirementString <em>Version Requirement String</em>}</li>
  *   <li>{@link org.eclipse.n4js.projectDescription.ProjectDependency#getVersionRequirement <em>Version Requirement</em>}</li>
  * </ul>
@@ -34,6 +35,35 @@ import org.eclipse.n4js.semver.Semver.NPMVersionRequirement;
  * @generated
  */
 public interface ProjectDependency extends ProjectReference {
+	/**
+	 * Returns the value of the '<em><b>Type</b></em>' attribute.
+	 * The literals are from the enumeration {@link org.eclipse.n4js.projectDescription.DependencyType}.
+	 * <!-- begin-user-doc -->
+	 * <p>
+	 * If the meaning of the '<em>Type</em>' attribute isn't clear,
+	 * there really should be more of a description here...
+	 * </p>
+	 * <!-- end-user-doc -->
+	 * @return the value of the '<em>Type</em>' attribute.
+	 * @see org.eclipse.n4js.projectDescription.DependencyType
+	 * @see #setType(DependencyType)
+	 * @see org.eclipse.n4js.projectDescription.ProjectDescriptionPackage#getProjectDependency_Type()
+	 * @model unique="false"
+	 * @generated
+	 */
+	DependencyType getType();
+
+	/**
+	 * Sets the value of the '{@link org.eclipse.n4js.projectDescription.ProjectDependency#getType <em>Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @param value the new value of the '<em>Type</em>' attribute.
+	 * @see org.eclipse.n4js.projectDescription.DependencyType
+	 * @see #getType()
+	 * @generated
+	 */
+	void setType(DependencyType value);
+
 	/**
 	 * Returns the value of the '<em><b>Version Requirement String</b></em>' attribute.
 	 * <!-- begin-user-doc -->

--- a/plugins/org.eclipse.n4js.model/emf-gen/org/eclipse/n4js/projectDescription/ProjectDescriptionPackage.java
+++ b/plugins/org.eclipse.n4js.model/emf-gen/org/eclipse/n4js/projectDescription/ProjectDescriptionPackage.java
@@ -405,13 +405,22 @@ public interface ProjectDescriptionPackage extends EPackage {
 	int PROJECT_DEPENDENCY__PROJECT_ID = PROJECT_REFERENCE__PROJECT_ID;
 
 	/**
+	 * The feature id for the '<em><b>Type</b></em>' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int PROJECT_DEPENDENCY__TYPE = PROJECT_REFERENCE_FEATURE_COUNT + 0;
+
+	/**
 	 * The feature id for the '<em><b>Version Requirement String</b></em>' attribute.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int PROJECT_DEPENDENCY__VERSION_REQUIREMENT_STRING = PROJECT_REFERENCE_FEATURE_COUNT + 0;
+	int PROJECT_DEPENDENCY__VERSION_REQUIREMENT_STRING = PROJECT_REFERENCE_FEATURE_COUNT + 1;
 
 	/**
 	 * The feature id for the '<em><b>Version Requirement</b></em>' containment reference.
@@ -420,7 +429,7 @@ public interface ProjectDescriptionPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int PROJECT_DEPENDENCY__VERSION_REQUIREMENT = PROJECT_REFERENCE_FEATURE_COUNT + 1;
+	int PROJECT_DEPENDENCY__VERSION_REQUIREMENT = PROJECT_REFERENCE_FEATURE_COUNT + 2;
 
 	/**
 	 * The number of structural features of the '<em>Project Dependency</em>' class.
@@ -429,7 +438,7 @@ public interface ProjectDescriptionPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int PROJECT_DEPENDENCY_FEATURE_COUNT = PROJECT_REFERENCE_FEATURE_COUNT + 2;
+	int PROJECT_DEPENDENCY_FEATURE_COUNT = PROJECT_REFERENCE_FEATURE_COUNT + 3;
 
 	/**
 	 * The number of operations of the '<em>Project Dependency</em>' class.
@@ -608,6 +617,16 @@ public interface ProjectDescriptionPackage extends EPackage {
 	 * @generated
 	 */
 	int MODULE_LOADER = 10;
+
+	/**
+	 * The meta object id for the '{@link org.eclipse.n4js.projectDescription.DependencyType <em>Dependency Type</em>}' enum.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see org.eclipse.n4js.projectDescription.DependencyType
+	 * @see org.eclipse.n4js.projectDescription.impl.ProjectDescriptionPackageImpl#getDependencyType()
+	 * @generated
+	 */
+	int DEPENDENCY_TYPE = 11;
 
 
 	/**
@@ -926,6 +945,17 @@ public interface ProjectDescriptionPackage extends EPackage {
 	EClass getProjectDependency();
 
 	/**
+	 * Returns the meta object for the attribute '{@link org.eclipse.n4js.projectDescription.ProjectDependency#getType <em>Type</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the attribute '<em>Type</em>'.
+	 * @see org.eclipse.n4js.projectDescription.ProjectDependency#getType()
+	 * @see #getProjectDependency()
+	 * @generated
+	 */
+	EAttribute getProjectDependency_Type();
+
+	/**
 	 * Returns the meta object for the attribute '{@link org.eclipse.n4js.projectDescription.ProjectDependency#getVersionRequirementString <em>Version Requirement String</em>}'.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -1071,6 +1101,16 @@ public interface ProjectDescriptionPackage extends EPackage {
 	 * @generated
 	 */
 	EEnum getModuleLoader();
+
+	/**
+	 * Returns the meta object for enum '{@link org.eclipse.n4js.projectDescription.DependencyType <em>Dependency Type</em>}'.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for enum '<em>Dependency Type</em>'.
+	 * @see org.eclipse.n4js.projectDescription.DependencyType
+	 * @generated
+	 */
+	EEnum getDependencyType();
 
 	/**
 	 * Returns the factory that creates the instances of the model.
@@ -1336,6 +1376,14 @@ public interface ProjectDescriptionPackage extends EPackage {
 		EClass PROJECT_DEPENDENCY = eINSTANCE.getProjectDependency();
 
 		/**
+		 * The meta object literal for the '<em><b>Type</b></em>' attribute feature.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EAttribute PROJECT_DEPENDENCY__TYPE = eINSTANCE.getProjectDependency_Type();
+
+		/**
 		 * The meta object literal for the '<em><b>Version Requirement String</b></em>' attribute feature.
 		 * <!-- begin-user-doc -->
 		 * <!-- end-user-doc -->
@@ -1460,6 +1508,16 @@ public interface ProjectDescriptionPackage extends EPackage {
 		 * @generated
 		 */
 		EEnum MODULE_LOADER = eINSTANCE.getModuleLoader();
+
+		/**
+		 * The meta object literal for the '{@link org.eclipse.n4js.projectDescription.DependencyType <em>Dependency Type</em>}' enum.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @see org.eclipse.n4js.projectDescription.DependencyType
+		 * @see org.eclipse.n4js.projectDescription.impl.ProjectDescriptionPackageImpl#getDependencyType()
+		 * @generated
+		 */
+		EEnum DEPENDENCY_TYPE = eINSTANCE.getDependencyType();
 
 	}
 

--- a/plugins/org.eclipse.n4js.model/emf-gen/org/eclipse/n4js/projectDescription/impl/ProjectDependencyImpl.java
+++ b/plugins/org.eclipse.n4js.model/emf-gen/org/eclipse/n4js/projectDescription/impl/ProjectDependencyImpl.java
@@ -18,6 +18,7 @@ import org.eclipse.emf.ecore.InternalEObject;
 
 import org.eclipse.emf.ecore.impl.ENotificationImpl;
 
+import org.eclipse.n4js.projectDescription.DependencyType;
 import org.eclipse.n4js.projectDescription.ProjectDependency;
 import org.eclipse.n4js.projectDescription.ProjectDescriptionPackage;
 
@@ -31,6 +32,7 @@ import org.eclipse.n4js.semver.Semver.NPMVersionRequirement;
  * The following features are implemented:
  * </p>
  * <ul>
+ *   <li>{@link org.eclipse.n4js.projectDescription.impl.ProjectDependencyImpl#getType <em>Type</em>}</li>
  *   <li>{@link org.eclipse.n4js.projectDescription.impl.ProjectDependencyImpl#getVersionRequirementString <em>Version Requirement String</em>}</li>
  *   <li>{@link org.eclipse.n4js.projectDescription.impl.ProjectDependencyImpl#getVersionRequirement <em>Version Requirement</em>}</li>
  * </ul>
@@ -38,6 +40,26 @@ import org.eclipse.n4js.semver.Semver.NPMVersionRequirement;
  * @generated
  */
 public class ProjectDependencyImpl extends ProjectReferenceImpl implements ProjectDependency {
+	/**
+	 * The default value of the '{@link #getType() <em>Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getType()
+	 * @generated
+	 * @ordered
+	 */
+	protected static final DependencyType TYPE_EDEFAULT = DependencyType.RUNTIME;
+
+	/**
+	 * The cached value of the '{@link #getType() <em>Type</em>}' attribute.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @see #getType()
+	 * @generated
+	 * @ordered
+	 */
+	protected DependencyType type = TYPE_EDEFAULT;
+
 	/**
 	 * The default value of the '{@link #getVersionRequirementString() <em>Version Requirement String</em>}' attribute.
 	 * <!-- begin-user-doc -->
@@ -85,6 +107,27 @@ public class ProjectDependencyImpl extends ProjectReferenceImpl implements Proje
 	@Override
 	protected EClass eStaticClass() {
 		return ProjectDescriptionPackage.Literals.PROJECT_DEPENDENCY;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public DependencyType getType() {
+		return type;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public void setType(DependencyType newType) {
+		DependencyType oldType = type;
+		type = newType == null ? TYPE_EDEFAULT : newType;
+		if (eNotificationRequired())
+			eNotify(new ENotificationImpl(this, Notification.SET, ProjectDescriptionPackage.PROJECT_DEPENDENCY__TYPE, oldType, type));
 	}
 
 	/**
@@ -173,6 +216,8 @@ public class ProjectDependencyImpl extends ProjectReferenceImpl implements Proje
 	@Override
 	public Object eGet(int featureID, boolean resolve, boolean coreType) {
 		switch (featureID) {
+			case ProjectDescriptionPackage.PROJECT_DEPENDENCY__TYPE:
+				return getType();
 			case ProjectDescriptionPackage.PROJECT_DEPENDENCY__VERSION_REQUIREMENT_STRING:
 				return getVersionRequirementString();
 			case ProjectDescriptionPackage.PROJECT_DEPENDENCY__VERSION_REQUIREMENT:
@@ -189,6 +234,9 @@ public class ProjectDependencyImpl extends ProjectReferenceImpl implements Proje
 	@Override
 	public void eSet(int featureID, Object newValue) {
 		switch (featureID) {
+			case ProjectDescriptionPackage.PROJECT_DEPENDENCY__TYPE:
+				setType((DependencyType)newValue);
+				return;
 			case ProjectDescriptionPackage.PROJECT_DEPENDENCY__VERSION_REQUIREMENT_STRING:
 				setVersionRequirementString((String)newValue);
 				return;
@@ -207,6 +255,9 @@ public class ProjectDependencyImpl extends ProjectReferenceImpl implements Proje
 	@Override
 	public void eUnset(int featureID) {
 		switch (featureID) {
+			case ProjectDescriptionPackage.PROJECT_DEPENDENCY__TYPE:
+				setType(TYPE_EDEFAULT);
+				return;
 			case ProjectDescriptionPackage.PROJECT_DEPENDENCY__VERSION_REQUIREMENT_STRING:
 				setVersionRequirementString(VERSION_REQUIREMENT_STRING_EDEFAULT);
 				return;
@@ -225,6 +276,8 @@ public class ProjectDependencyImpl extends ProjectReferenceImpl implements Proje
 	@Override
 	public boolean eIsSet(int featureID) {
 		switch (featureID) {
+			case ProjectDescriptionPackage.PROJECT_DEPENDENCY__TYPE:
+				return type != TYPE_EDEFAULT;
 			case ProjectDescriptionPackage.PROJECT_DEPENDENCY__VERSION_REQUIREMENT_STRING:
 				return VERSION_REQUIREMENT_STRING_EDEFAULT == null ? versionRequirementString != null : !VERSION_REQUIREMENT_STRING_EDEFAULT.equals(versionRequirementString);
 			case ProjectDescriptionPackage.PROJECT_DEPENDENCY__VERSION_REQUIREMENT:
@@ -243,7 +296,9 @@ public class ProjectDependencyImpl extends ProjectReferenceImpl implements Proje
 		if (eIsProxy()) return super.toString();
 
 		StringBuffer result = new StringBuffer(super.toString());
-		result.append(" (versionRequirementString: ");
+		result.append(" (type: ");
+		result.append(type);
+		result.append(", versionRequirementString: ");
 		result.append(versionRequirementString);
 		result.append(')');
 		return result.toString();

--- a/plugins/org.eclipse.n4js.model/emf-gen/org/eclipse/n4js/projectDescription/impl/ProjectDescriptionFactoryImpl.java
+++ b/plugins/org.eclipse.n4js.model/emf-gen/org/eclipse/n4js/projectDescription/impl/ProjectDescriptionFactoryImpl.java
@@ -93,6 +93,8 @@ public class ProjectDescriptionFactoryImpl extends EFactoryImpl implements Proje
 				return createModuleFilterTypeFromString(eDataType, initialValue);
 			case ProjectDescriptionPackage.MODULE_LOADER:
 				return createModuleLoaderFromString(eDataType, initialValue);
+			case ProjectDescriptionPackage.DEPENDENCY_TYPE:
+				return createDependencyTypeFromString(eDataType, initialValue);
 			default:
 				throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
 		}
@@ -114,6 +116,8 @@ public class ProjectDescriptionFactoryImpl extends EFactoryImpl implements Proje
 				return convertModuleFilterTypeToString(eDataType, instanceValue);
 			case ProjectDescriptionPackage.MODULE_LOADER:
 				return convertModuleLoaderToString(eDataType, instanceValue);
+			case ProjectDescriptionPackage.DEPENDENCY_TYPE:
+				return convertDependencyTypeToString(eDataType, instanceValue);
 			default:
 				throw new IllegalArgumentException("The datatype '" + eDataType.getName() + "' is not a valid classifier");
 		}
@@ -266,6 +270,26 @@ public class ProjectDescriptionFactoryImpl extends EFactoryImpl implements Proje
 	 * @generated
 	 */
 	public String convertModuleLoaderToString(EDataType eDataType, Object instanceValue) {
+		return instanceValue == null ? null : instanceValue.toString();
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public DependencyType createDependencyTypeFromString(EDataType eDataType, String initialValue) {
+		DependencyType result = DependencyType.get(initialValue);
+		if (result == null) throw new IllegalArgumentException("The value '" + initialValue + "' is not a valid enumerator of '" + eDataType.getName() + "'");
+		return result;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	public String convertDependencyTypeToString(EDataType eDataType, Object instanceValue) {
 		return instanceValue == null ? null : instanceValue.toString();
 	}
 

--- a/plugins/org.eclipse.n4js.model/emf-gen/org/eclipse/n4js/projectDescription/impl/ProjectDescriptionPackageImpl.java
+++ b/plugins/org.eclipse.n4js.model/emf-gen/org/eclipse/n4js/projectDescription/impl/ProjectDescriptionPackageImpl.java
@@ -20,6 +20,7 @@ import org.eclipse.emf.ecore.EcorePackage;
 import org.eclipse.emf.ecore.impl.EPackageImpl;
 
 import org.eclipse.n4js.projectDescription.BootstrapModule;
+import org.eclipse.n4js.projectDescription.DependencyType;
 import org.eclipse.n4js.projectDescription.ModuleFilter;
 import org.eclipse.n4js.projectDescription.ModuleFilterSpecifier;
 import org.eclipse.n4js.projectDescription.ModuleFilterType;
@@ -118,6 +119,13 @@ public class ProjectDescriptionPackageImpl extends EPackageImpl implements Proje
 	 * @generated
 	 */
 	private EEnum moduleLoaderEEnum = null;
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	private EEnum dependencyTypeEEnum = null;
 
 	/**
 	 * Creates an instance of the model <b>Package</b>, registered with
@@ -450,7 +458,7 @@ public class ProjectDescriptionPackageImpl extends EPackageImpl implements Proje
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
-	public EAttribute getProjectDependency_VersionRequirementString() {
+	public EAttribute getProjectDependency_Type() {
 		return (EAttribute)projectDependencyEClass.getEStructuralFeatures().get(0);
 	}
 
@@ -459,8 +467,17 @@ public class ProjectDescriptionPackageImpl extends EPackageImpl implements Proje
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public EAttribute getProjectDependency_VersionRequirementString() {
+		return (EAttribute)projectDependencyEClass.getEStructuralFeatures().get(1);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public EReference getProjectDependency_VersionRequirement() {
-		return (EReference)projectDependencyEClass.getEStructuralFeatures().get(1);
+		return (EReference)projectDependencyEClass.getEStructuralFeatures().get(2);
 	}
 
 	/**
@@ -576,6 +593,15 @@ public class ProjectDescriptionPackageImpl extends EPackageImpl implements Proje
 	 * <!-- end-user-doc -->
 	 * @generated
 	 */
+	public EEnum getDependencyType() {
+		return dependencyTypeEEnum;
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
 	public ProjectDescriptionFactory getProjectDescriptionFactory() {
 		return (ProjectDescriptionFactory)getEFactoryInstance();
 	}
@@ -631,6 +657,7 @@ public class ProjectDescriptionPackageImpl extends EPackageImpl implements Proje
 		createEAttribute(projectReferenceEClass, PROJECT_REFERENCE__PROJECT_ID);
 
 		projectDependencyEClass = createEClass(PROJECT_DEPENDENCY);
+		createEAttribute(projectDependencyEClass, PROJECT_DEPENDENCY__TYPE);
 		createEAttribute(projectDependencyEClass, PROJECT_DEPENDENCY__VERSION_REQUIREMENT_STRING);
 		createEReference(projectDependencyEClass, PROJECT_DEPENDENCY__VERSION_REQUIREMENT);
 
@@ -650,6 +677,7 @@ public class ProjectDescriptionPackageImpl extends EPackageImpl implements Proje
 		sourceContainerTypeEEnum = createEEnum(SOURCE_CONTAINER_TYPE);
 		moduleFilterTypeEEnum = createEEnum(MODULE_FILTER_TYPE);
 		moduleLoaderEEnum = createEEnum(MODULE_LOADER);
+		dependencyTypeEEnum = createEEnum(DEPENDENCY_TYPE);
 	}
 
 	/**
@@ -719,6 +747,7 @@ public class ProjectDescriptionPackageImpl extends EPackageImpl implements Proje
 		initEAttribute(getProjectReference_ProjectId(), theEcorePackage.getEString(), "projectId", null, 0, 1, ProjectReference.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
 		initEClass(projectDependencyEClass, ProjectDependency.class, "ProjectDependency", !IS_ABSTRACT, !IS_INTERFACE, IS_GENERATED_INSTANCE_CLASS);
+		initEAttribute(getProjectDependency_Type(), this.getDependencyType(), "type", null, 0, 1, ProjectDependency.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEAttribute(getProjectDependency_VersionRequirementString(), theEcorePackage.getEString(), "versionRequirementString", null, 0, 1, ProjectDependency.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, !IS_UNSETTABLE, !IS_ID, !IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 		initEReference(getProjectDependency_VersionRequirement(), theSemverPackage.getNPMVersionRequirement(), null, "versionRequirement", null, 0, 1, ProjectDependency.class, !IS_TRANSIENT, !IS_VOLATILE, IS_CHANGEABLE, IS_COMPOSITE, !IS_RESOLVE_PROXIES, !IS_UNSETTABLE, IS_UNIQUE, !IS_DERIVED, IS_ORDERED);
 
@@ -758,6 +787,11 @@ public class ProjectDescriptionPackageImpl extends EPackageImpl implements Proje
 		addEEnumLiteral(moduleLoaderEEnum, ModuleLoader.N4JS);
 		addEEnumLiteral(moduleLoaderEEnum, ModuleLoader.COMMONJS);
 		addEEnumLiteral(moduleLoaderEEnum, ModuleLoader.NODE_BUILTIN);
+
+		initEEnum(dependencyTypeEEnum, DependencyType.class, "DependencyType");
+		addEEnumLiteral(dependencyTypeEEnum, DependencyType.RUNTIME);
+		addEEnumLiteral(dependencyTypeEEnum, DependencyType.DEVELOPMENT);
+		addEEnumLiteral(dependencyTypeEEnum, DependencyType.TYPE);
 
 		// Create resource
 		createResource(eNS_URI);

--- a/plugins/org.eclipse.n4js.model/model/ProjectDescription.xcore
+++ b/plugins/org.eclipse.n4js.model/model/ProjectDescription.xcore
@@ -90,6 +90,7 @@ class ProjectReference {
 
 /* Reference to another project, including a version requirement. */
 class ProjectDependency extends ProjectReference {
+	DependencyType ^type
 	String versionRequirementString
 	contains NPMVersionRequirement versionRequirement
 }
@@ -143,4 +144,17 @@ enum ModuleLoader {
 	N4JS = 0,
 	COMMONJS = 1,
 	NODE_BUILTIN = 2
+}
+
+/** Different types of dependencies. */
+enum DependencyType {
+	/** Dependencies of this type must always be present. */
+	RUNTIME,
+	/** Dependencies of this type must be present at development-time. */
+	DEVELOPMENT,
+	/** 
+	 * Dependencies of this type must be present when using a package 
+	 * from a typed language or when developing the package itself.
+	 */
+	TYPE
 }

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/packagejson/PackageJsonHelper.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/packagejson/PackageJsonHelper.java
@@ -38,6 +38,7 @@ import org.eclipse.n4js.json.JSON.JSONDocument;
 import org.eclipse.n4js.json.JSON.JSONObject;
 import org.eclipse.n4js.json.JSON.JSONValue;
 import org.eclipse.n4js.json.JSON.NameValuePair;
+import org.eclipse.n4js.projectDescription.DependencyType;
 import org.eclipse.n4js.projectDescription.ProjectDependency;
 import org.eclipse.n4js.projectDescription.ProjectDescription;
 import org.eclipse.n4js.projectDescription.ProjectDescriptionFactory;
@@ -108,11 +109,11 @@ public class PackageJsonHelper {
 				target.setProjectVersion(parseVersion(asNonEmptyStringOrNull(value)));
 				break;
 			case DEPENDENCIES:
-				convertDependencies(target, asNameValuePairsOrEmpty(value), true);
+				convertDependencies(target, asNameValuePairsOrEmpty(value), true, DependencyType.RUNTIME);
 				break;
 			case DEV_DEPENDENCIES:
 				// for the moment, we do not separate devDependencies from ordinary dependencies in ProjectDescription
-				convertDependencies(target, asNameValuePairsOrEmpty(value), true);
+				convertDependencies(target, asNameValuePairsOrEmpty(value), true, DependencyType.DEVELOPMENT);
 				break;
 			case MAIN:
 				// need to handle this value later after all source containers have been read
@@ -194,7 +195,7 @@ public class PackageJsonHelper {
 				break;
 			case TYPE_DEPENDENCIES:
 				// in the context of N4JS, type dependencies are considered regular project dependencies
-				convertDependencies(target, asNameValuePairsOrEmpty(value), true);
+				convertDependencies(target, asNameValuePairsOrEmpty(value), true, DependencyType.TYPE);
 				break;
 
 			default:
@@ -203,7 +204,8 @@ public class PackageJsonHelper {
 		}
 	}
 
-	private void convertDependencies(ProjectDescription target, List<NameValuePair> depPairs, boolean avoidDuplicates) {
+	private void convertDependencies(ProjectDescription target, List<NameValuePair> depPairs, boolean avoidDuplicates,
+			DependencyType type) {
 		Set<String> existingProjectIds = new HashSet<>();
 		if (avoidDuplicates) {
 			for (ProjectDependency pd : target.getProjectDependencies()) {
@@ -225,6 +227,7 @@ public class PackageJsonHelper {
 				ProjectDependency dep = ProjectDescriptionFactory.eINSTANCE.createProjectDependency();
 				dep.setProjectId(projectId);
 				dep.setVersionRequirementString(valueStr);
+				dep.setType(type);
 
 				NPMVersionRequirement vreq = parseVersionRequirement(valueStr);
 				dep.setVersionRequirement(vreq);

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/projectModel/dependencies/DependenciesCollectingUtil.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/projectModel/dependencies/DependenciesCollectingUtil.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.eclipse.n4js.projectDescription.DependencyType;
 import org.eclipse.n4js.projectDescription.ProjectDescription;
 import org.eclipse.n4js.projectDescription.ProjectReference;
 
@@ -63,6 +64,7 @@ public class DependenciesCollectingUtil {
 					pd.getImplementedProjects().stream().map(DependencyInfo::create))
 					.reduce(Stream::concat)
 					.orElseGet(Stream::empty)
+					.filter(info -> info.type != DependencyType.TYPE) // do not install missing type dependencies
 					.forEach(info -> dependencies.merge(info.name, info.version, DependenciesCollectingUtil::resolve));
 		}
 	}

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/projectModel/dependencies/DependencyInfo.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/projectModel/dependencies/DependencyInfo.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.n4js.projectModel.dependencies;
 
+import org.eclipse.n4js.projectDescription.DependencyType;
 import org.eclipse.n4js.projectDescription.ProjectDependency;
 import org.eclipse.n4js.projectDescription.ProjectReference;
 import org.eclipse.n4js.semver.model.SemverSerializer;
@@ -21,16 +22,24 @@ public class DependencyInfo {
 	final public String name;
 	/** version of the dependency */
 	final public String version;
+	/** type of the dependency */
+	final public DependencyType type;
 
 	/** Simple constructor, client might need to use {@link #create(ProjectReference)} */
-	public DependencyInfo(String id, String version) {
+	public DependencyInfo(String id, String version, DependencyType type) {
 		this.name = id;
 		this.version = version;
+		this.type = type;
 	}
 
-	/** factory method to create instances form {@code ProjectReference} */
+	/** factory method to create instances from {@code ProjectReference}s. */
 	public static DependencyInfo create(ProjectReference projectReference) {
-		return new DependencyInfo(toName(projectReference), toVersion(projectReference));
+		return new DependencyInfo(toName(projectReference), toVersion(projectReference), DependencyType.RUNTIME);
+	}
+
+	/** factory method to create instances from {@code ProjectDependency}s. */
+	public static DependencyInfo create(ProjectDependency projectDependency) {
+		return new DependencyInfo(toName(projectDependency), toVersion(projectDependency), projectDependency.getType());
 	}
 
 	private static String toName(ProjectReference projectReference) {


### PR DESCRIPTION
Ticket: #821 

In this PR I made the following changes:

* I exposed the origin/type of a dependency (runtime, development or type as declared in the "dependencies", "devDependencies" and "typeDependencies" sections) in the ProjectDescription model via a new `DependencyType` enum type. Upon removal of type dependencies, this can be reduced to runtime and development.

* In the collection logic of the "big button", I filter the missing dependencies by their type (only collect non-type dependencies)

This PR is a preparation for merging the last subtask of #821, as it restores the backward compatibility of the introduced "typeDependencies". On the current master, the "big button" logic will attempt to install missing type dependencies. However, this fails since we do not publish type definitions yet.