### PR TITLE
Revert "GH-1036: Investigate recent failures of nightly builds"

### DIFF
--- a/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/typedefinitions/TypeDefinitionsShadowingPluginTest.java
+++ b/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/typedefinitions/TypeDefinitionsShadowingPluginTest.java
@@ -28,6 +28,7 @@ public class TypeDefinitionsShadowingPluginTest extends AbstractBuilderParticipa
 	private static final String NEGATIVE_FIXTURE_FOLDER = "simple-negative";
 
 	/**
+	 *
 	 * Positive test case.
 	 *
 	 * Imports client, definition and implementation project and expects none of the projects to raise any compilation
@@ -45,7 +46,7 @@ public class TypeDefinitionsShadowingPluginTest extends AbstractBuilderParticipa
 		final IProject definitionProject = ProjectTestsUtils.importProject(testdataLocation, "Def");
 		final IProject implProject = ProjectTestsUtils.importProject(testdataLocation, "Impl");
 
-		IResourcesSetupUtil.fullBuild();
+		IResourcesSetupUtil.cleanBuild();
 		waitForAutoBuild();
 
 		assertMarkers("Client project should not have any markers (no compilation issues)", clientProject, 0);
@@ -54,6 +55,7 @@ public class TypeDefinitionsShadowingPluginTest extends AbstractBuilderParticipa
 	}
 
 	/**
+	 *
 	 * Negative test case.
 	 *
 	 * Imports client, definition and implementation project that declare an invalid type definitions configuration.
@@ -70,7 +72,7 @@ public class TypeDefinitionsShadowingPluginTest extends AbstractBuilderParticipa
 		final IProject definitionProject = ProjectTestsUtils.importProject(testdataLocation, "Broken_Def");
 		final IProject implProject = ProjectTestsUtils.importProject(testdataLocation, "Impl");
 
-		IResourcesSetupUtil.fullBuild();
+		IResourcesSetupUtil.cleanBuild();
 		waitForAutoBuild();
 
 		IResource clientModule = clientProject.findMember("src/Client.n4js");


### PR DESCRIPTION
Reverts eclipse/n4js#1037

Temporary roll-back. Changes will be re-applied soon.