### PR TITLE
GH-821: Make sure target definition package.json is re-created properly

### DIFF
--- a/plugins/org.eclipse.n4js.external.libraries/src/org/eclipse/n4js/external/libraries/ExternalLibrariesActivator.java
+++ b/plugins/org.eclipse.n4js.external.libraries/src/org/eclipse/n4js/external/libraries/ExternalLibrariesActivator.java
@@ -20,11 +20,9 @@ import static java.lang.Boolean.parseBoolean;
 import static org.eclipse.core.runtime.Platform.inDebugMode;
 import static org.eclipse.core.runtime.Platform.inDevelopmentMode;
 import static org.eclipse.n4js.external.libraries.ExternalLibraryFolderUtils.NPM_ROOT;
-import static org.eclipse.n4js.external.libraries.ExternalLibraryFolderUtils.PACKAGE_JSON;
 import static org.eclipse.xtext.util.Tuples.pair;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
@@ -198,7 +196,7 @@ public class ExternalLibrariesActivator implements BundleActivator {
 			() -> getExternalLibraries());
 
 	/**
-	 * Supplies the {@code .n4npm/node_modules} folder location form the worksapce's {@code .metadata} folder. This
+	 * Supplies the {@code .n4npm/node_modules} folder location form the workspace's {@code .metadata} folder. This
 	 * could be missing if the {@link Platform platform} is not running.
 	 */
 	public static final Supplier<File> N4_NPM_FOLDER_SUPPLIER = memoize(() -> getOrCreateNpmFolder());
@@ -343,20 +341,7 @@ public class ExternalLibrariesActivator implements BundleActivator {
 		checkState(typeDefinitionsFolder.isDirectory(),
 				"Expecting directory but was a file: " + typeDefinitionsFolder + ".");
 
-		final File targetPlatformFile = new File(targetPlatform, PACKAGE_JSON);
-		if (!targetPlatformFile.exists()) {
-			try {
-				checkState(targetPlatformFile.createNewFile(), "Error while creating default target platform file.");
-				try (final FileWriter fw = new FileWriter(targetPlatformFile)) {
-					fw.write(ExternalLibraryFolderUtils.createTargetPlatformPackageJson());
-					fw.flush();
-				}
-			} catch (final IOException e) {
-				final String message = "Error while initializing default target platform file.";
-				LOGGER.error(message, e);
-				throw new RuntimeException(message, e);
-			}
-		}
+		final File targetPlatformFile = ExternalLibraryFolderUtils.createTargetPlatformDefinitionFile(targetPlatform);
 		checkState(targetPlatformFile.isFile(),
 				"Expecting file as the target platform file: " + targetPlatformFile + ".");
 

--- a/plugins/org.eclipse.n4js.external.libraries/src/org/eclipse/n4js/external/libraries/ExternalLibraryFolderUtils.xtend
+++ b/plugins/org.eclipse.n4js.external.libraries/src/org/eclipse/n4js/external/libraries/ExternalLibraryFolderUtils.xtend
@@ -10,6 +10,11 @@
  */
 package org.eclipse.n4js.external.libraries
 
+import java.io.FileWriter
+import java.io.IOException
+import java.io.File
+import static com.google.common.base.Preconditions.checkState
+
 /**
  * Utilities for dealing with the folder containing the external libraries.
  */
@@ -35,5 +40,30 @@ class ExternalLibraryFolderUtils {
 				"name": "targetplatform"
 			}
 		''';
+	}
+	
+	/**
+	 * Creates a fresh target platform definition file ({@code package.json} file) in the given
+	 * target platform location.
+	 */
+	public static def File createTargetPlatformDefinitionFile(File targetPlatformLocationFile) {
+		val File targetPlatformFile = new File(targetPlatformLocationFile, PACKAGE_JSON);
+		if (!targetPlatformFile.exists()) {
+			try {
+				checkState(targetPlatformFile.createNewFile(), "Error while creating default target platform file.");
+				var FileWriter fw;
+				try {
+					fw = new FileWriter(targetPlatformFile);
+					fw.write(ExternalLibraryFolderUtils.createTargetPlatformPackageJson());
+					fw.flush();
+				} finally {
+					fw.close();
+				}
+			} catch (IOException e) {
+				val String message = "Error while initializing default target platform file.";
+				throw new RuntimeException(message, e);
+			}
+		}
+		return targetPlatformFile;
 	}
 }

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/external/ExternalLibrariesActionsHelper.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/external/ExternalLibrariesActionsHelper.java
@@ -99,9 +99,10 @@ public class ExternalLibrariesActionsHelper {
 	 *            the status used accumulate issues
 	 */
 	public void maintenanceDeleteNpms(final MultiStatus multistatus) {
-		// get folder
+		// get target platform folder (contains node_modules, package.json, etc.)
 		File npmFolder = locationProvider.getTargetPlatformInstallFolder();
 
+		// delete whole target platform folder
 		if (npmFolder.exists()) {
 			FileDeleter.delete(npmFolder, (IOException ioe) -> multistatus.merge(
 					statusHelper.createError("Exception during deletion of the npm folder.", ioe)));
@@ -111,7 +112,7 @@ public class ExternalLibrariesActionsHelper {
 			// recreate npm folder
 			if (!locationProvider.repairNpmFolderState()) {
 				multistatus.merge(statusHelper
-						.createError("The npm folder was not recreated correctly."));
+						.createError("The target platform location folder was not recreated correctly."));
 			}
 		} else {// should never happen
 			multistatus

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/external/TargetPlatformInstallLocationProvider.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/external/TargetPlatformInstallLocationProvider.java
@@ -18,6 +18,7 @@ import java.net.URI;
 
 import org.apache.log4j.Logger;
 import org.eclipse.n4js.external.libraries.ExternalLibrariesActivator;
+import org.eclipse.n4js.external.libraries.ExternalLibraryFolderUtils;
 
 /**
  * Provides information about the target platform install location and about the location of the actual target platform
@@ -163,9 +164,10 @@ public interface TargetPlatformInstallLocationProvider {
 	}
 
 	/**
-	 * Recreates the folders node_modules and type_definitions.
+	 * Recreates the folders node_modules and type_definitions folders and the the target platform definition
+	 * {@code package.json} file.
 	 *
-	 * @return true if folder were recreated and exist
+	 * @return true if the required file system structure was recreated and now exists
 	 */
 	default boolean repairNpmFolderState() {
 		boolean success = true;
@@ -173,9 +175,13 @@ public interface TargetPlatformInstallLocationProvider {
 		if (!installLocation.isDirectory()) {
 			success &= installLocation.mkdir();
 		}
+
 		if (success) {
-			File npmFile = getNodeModulesFolder();
-			File tdFile = getTypeDefinitionsFolder();
+			final File targetPlatformDefinitionFile = ExternalLibraryFolderUtils
+					.createTargetPlatformDefinitionFile(installLocation);
+			final File npmFile = getNodeModulesFolder();
+			final File tdFile = getTypeDefinitionsFolder();
+			success &= targetPlatformDefinitionFile != null && targetPlatformDefinitionFile.isFile();
 			success &= npmFile != null && npmFile.isDirectory();
 			success &= tdFile != null && tdFile.isDirectory();
 		}


### PR DESCRIPTION
This PR fixes a bug that was introduced by one of the subtasks of #821. 

On the current master, an invocation of the "big button" will delete the target definition `package.json` file but never re-create it. As a consequence, all following `npm install`-calls will output the following warnings:

```
npm WARN saveError ENOENT: no such file or directory, open '/.../workspace/.metadata/.plugins/org.eclipse.n4js.external.libraries/.n4npm/package.json'
npm notice created a lockfile as package-lock.json. You should commit this file.
npm WARN enoent ENOENT: no such file or directory, open '/.../workspace/.metadata/.plugins/org.eclipse.n4js.external.libraries/.n4npm/package.json'
```

More importantly however, the external `node_modules` folder managed by the IDE, will no longer have a corresponding `package.json` file. This can lead to unpredictable behaviour of npm when it tries to prune the `node_modules` folder and remove "unused" dependencies, as in "not listed in the package.json".

The following changes were applied to fix the bug:

* The method `TargetPlatformInstallLocationProvider#repairNpmFolderState` will now also re-create the target definition `package.json` file.
* Increase re-use of the `maintenance*` methods from `ExternalLibraryPreferencePage.java`. As a consequence, the maintenance action implementations that are used by the "big button" and by the library manager UI now overlap more (they still use slightly different versions of some actions, but I did not want to touch that too much)