### PR TITLE
GH-1026: Project wizard support for scoped projects

### DIFF
--- a/plugins/org.eclipse.n4js.runner/src/org/eclipse/n4js/runner/RunnerHelper.java
+++ b/plugins/org.eclipse.n4js.runner/src/org/eclipse/n4js/runner/RunnerHelper.java
@@ -36,6 +36,7 @@ import org.eclipse.n4js.runner.extension.IRunnerDescriptor;
 import org.eclipse.n4js.runner.extension.RunnerRegistry;
 import org.eclipse.n4js.runner.extension.RuntimeEnvironment;
 import org.eclipse.n4js.utils.FindArtifactHelper;
+import org.eclipse.n4js.utils.ProjectDescriptionUtils;
 import org.eclipse.n4js.utils.RecursionGuard;
 import org.eclipse.n4js.utils.ResourceNameComputer;
 import org.eclipse.xtext.xbase.lib.Pair;
@@ -280,7 +281,11 @@ public class RunnerHelper {
 	public String computeConfigurationName(String runnerId, URI moduleToRun) {
 		String modulePath = moduleToRun.path();
 		modulePath = stripStart(modulePath, "/", "resource/", "plugin/");
-		final String moduleName = modulePath.replace('/', '-');
+		// strip '@' character from project scopes
+		if (modulePath.startsWith(ProjectDescriptionUtils.NPM_SCOPE_PREFIX)) {
+			modulePath = modulePath.substring(1);
+		}
+		final String moduleName = modulePath.replace('/', '-').replace(':', '-');
 		final String runnerName = runnerRegistry.getDescriptor(runnerId).getName();
 		return moduleName + " (" + runnerName + ")";
 	}

--- a/plugins/org.eclipse.n4js.ui/plugin.xml
+++ b/plugins/org.eclipse.n4js.ui/plugin.xml
@@ -43,7 +43,7 @@ Contributors:
          point="org.eclipse.ui.newWizards">
      <category
        id="org.eclipse.wizards"
-       name="NumberFour">
+       name="N4JS">
      </category>
      <wizard
            category="org.eclipse.wizards"

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/wizard/project/N4JSNewProjectFileTemplates.xtend
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/wizard/project/N4JSNewProjectFileTemplates.xtend
@@ -15,6 +15,7 @@ import org.eclipse.n4js.projectDescription.SourceContainerType
 import org.eclipse.n4js.packagejson.PackageJsonBuilder
 
 import static org.eclipse.n4js.packagejson.PackageJsonProperties.VERSION
+import org.eclipse.n4js.utils.ProjectDescriptionUtils
 
 /**
  * Basic Xtend templates for new project wizard.
@@ -71,9 +72,12 @@ class N4JSNewProjectFileTemplates {
 	 * Returns the project description file contents for the given project info (package.json).
 	 */
 	static def getProjectDescriptionContents(N4JSProjectInfo projectInfo) {
+		val projectName = 
+			ProjectDescriptionUtils.convertEclipseProjectNameToN4JSProjectName(projectInfo.projectName);
+		
 		// configure basic properties
 		val builder = PackageJsonBuilder.newBuilder()
-			.withName(projectInfo.projectName)
+			.withName(projectName)
 			.withVersion(VERSION.defaultValue)
 			.withType(projectInfo.projectType)
 			.withOutput(projectInfo.outputFolder)

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/wizard/project/N4JSNewProjectWizardCreationPage.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/wizard/project/N4JSNewProjectWizardCreationPage.java
@@ -349,7 +349,7 @@ public class N4JSNewProjectWizardCreationPage extends ExtensibleWizardNewProject
 		final String plainProjectName = getProjectName();
 		final String scopeName = ProjectDescriptionUtils.getScopeName(projectName);
 
-		if (!ProjectDescriptionUtils.isValidScopeName(scopeName)) {
+		if (scopeName != null && !ProjectDescriptionUtils.isValidScopeName(scopeName)) {
 			setErrorMessage(
 					"Invalid project name: \"" + scopeName + "\" is not a valid scope segment.");
 			return false;

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/wizard/project/N4JSProjectCreator.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/wizard/project/N4JSProjectCreator.java
@@ -34,6 +34,7 @@ import org.eclipse.n4js.N4JSGlobals;
 import org.eclipse.n4js.N4JSLanguageConstants;
 import org.eclipse.n4js.projectDescription.ProjectType;
 import org.eclipse.n4js.projectModel.IN4JSProject;
+import org.eclipse.n4js.utils.ProjectDescriptionUtils;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.xtext.ui.util.ProjectFactory;
@@ -181,8 +182,7 @@ public class N4JSProjectCreator extends AbstractProjectCreator {
 		}
 
 		// create files
-
-		String safeProjectName = projectName.replaceAll("\\.", "_").replaceAll("-", "_").trim();
+		final String derivedProjectNameIdentifier = deriveN4JSIdentifierFromProjectName(projectName);
 		Charset charset = getWorkspaceCharsetOrUtf8();
 
 		// Path-Content map of the files to create
@@ -190,14 +190,15 @@ public class N4JSProjectCreator extends AbstractProjectCreator {
 
 		// For test projects create a test project greeter if wanted
 		if (ProjectType.TEST.equals(pi.getProjectType()) && pi.getCreateGreeterFile()) {
-			pathContentMap.put(modelFolderName + "/" + "Test_" + safeProjectName + ".n4js",
-					N4JSNewProjectFileTemplates.getSourceFileWithTestGreeter(safeProjectName));
+			pathContentMap.put(modelFolderName + "/" + "Test_" + derivedProjectNameIdentifier + ".n4js",
+					N4JSNewProjectFileTemplates.getSourceFileWithTestGreeter(derivedProjectNameIdentifier));
 		}
 
 		// For other projects create the default greeter file
 		if (!ProjectType.TEST.equals(pi.getProjectType()) && pi.getCreateGreeterFile()) {
-			pathContentMap.put(modelFolderName + "/" + "GreeterModule_" + safeProjectName + ".n4js",
-					N4JSNewProjectFileTemplates.getSourceFileWithGreeterClass(projectName, safeProjectName));
+			pathContentMap.put(modelFolderName + "/" + "GreeterModule_" + derivedProjectNameIdentifier + ".n4js",
+					N4JSNewProjectFileTemplates.getSourceFileWithGreeterClass(projectName,
+							derivedProjectNameIdentifier));
 		}
 
 		// create initial files
@@ -233,6 +234,20 @@ public class N4JSProjectCreator extends AbstractProjectCreator {
 		createIfNotExists(project, IN4JSProject.PACKAGE_JSON, projectDescriptionContent, charset, monitor);
 
 		project.refreshLocal(DEPTH_INFINITE, monitor);
+	}
+
+	/**
+	 * Derives a new N4JS (sub-)identifier from the given Eclipse N4JS project name.
+	 *
+	 * Makes sure the returned identifier does not include any characters that are not allowed in N4JS identifiers.
+	 *
+	 * Note that this method does not provide a bijective mapping between project names and N4JS identifier (e.g. scope
+	 * name are not considered).
+	 */
+	private String deriveN4JSIdentifierFromProjectName(String projectName) {
+		final String n4jsProjectName = ProjectDescriptionUtils.convertEclipseProjectNameToN4JSProjectName(projectName);
+		final String plainProjectName = ProjectDescriptionUtils.getPlainProjectName(n4jsProjectName);
+		return plainProjectName.replaceAll("\\.", "_").replaceAll("-", "_").trim();
 	}
 
 	/**

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/ui/dialogs/ExtensibleWizardNewProjectCreationPage.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/ui/dialogs/ExtensibleWizardNewProjectCreationPage.java
@@ -1,0 +1,378 @@
+/**
+ * Copyright (c) 2018 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+package org.eclipse.ui.dialogs;
+
+import java.net.URI;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Path;
+import org.eclipse.jface.dialogs.Dialog;
+import org.eclipse.jface.util.BidiUtils;
+import org.eclipse.jface.viewers.IStructuredSelection;
+import org.eclipse.jface.wizard.WizardPage;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Listener;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.IWorkingSet;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.internal.ide.IDEWorkbenchMessages;
+import org.eclipse.ui.internal.ide.IDEWorkbenchPlugin;
+import org.eclipse.ui.internal.ide.IIDEHelpContextIds;
+import org.eclipse.ui.internal.ide.dialogs.ProjectContentsLocationArea;
+import org.eclipse.ui.internal.ide.dialogs.ProjectContentsLocationArea.IErrorMessageReporter;
+
+/**
+ * This class is mostly copied from {@link WizardNewProjectCreationPage} with minor adjustments to allow subclasses to
+ * control the wizard page behavior more thoroughly.
+ *
+ * See comments with "CHANGED:" for documentation on the concrete changes.
+ */
+@SuppressWarnings({ "javadoc", "restriction" })
+public class ExtensibleWizardNewProjectCreationPage extends WizardPage {
+
+	// initial value stores
+	private String initialProjectFieldValue;
+
+	// widgets
+	Text projectNameField;
+
+	private final Listener nameModifyListener = e -> {
+		setLocationForSelection();
+		boolean valid = validatePage();
+		setPageComplete(valid);
+
+	};
+
+	// CHANGED: expose locationArea to subclasses
+	protected ProjectContentsLocationArea locationArea;
+
+	private WorkingSetGroup workingSetGroup;
+
+	// constants
+	private static final int SIZING_TEXT_FIELD_WIDTH = 250;
+
+	/**
+	 * Creates a new project creation wizard page.
+	 *
+	 * @param pageName
+	 *            the name of this page
+	 */
+	public ExtensibleWizardNewProjectCreationPage(String pageName) {
+		super(pageName);
+		setPageComplete(false);
+	}
+
+	/**
+	 * Creates a new project creation wizard page.
+	 *
+	 * @param pageName
+	 * @param selection
+	 * @param workingSetTypes
+	 *
+	 * @deprecated default placement of the working set group has been removed. If you wish to use the working set block
+	 *             please call {@link #createWorkingSetGroup(Composite, IStructuredSelection, String[])} in your
+	 *             overridden {@link #createControl(Composite)} implementation.
+	 * @since 3.4
+	 */
+	@Deprecated
+	public ExtensibleWizardNewProjectCreationPage(String pageName,
+			IStructuredSelection selection, String[] workingSetTypes) {
+		this(pageName);
+	}
+
+	@Override
+	public void createControl(Composite parent) {
+		Composite composite = new Composite(parent, SWT.NULL);
+
+		initializeDialogUnits(parent);
+
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(composite,
+				IIDEHelpContextIds.NEW_PROJECT_WIZARD_PAGE);
+
+		composite.setLayout(new GridLayout());
+		composite.setLayoutData(new GridData(GridData.FILL_BOTH));
+
+		createProjectNameGroup(composite);
+		locationArea = new ProjectContentsLocationArea(getErrorReporter(), composite);
+		if (initialProjectFieldValue != null) {
+			locationArea.updateProjectName(initialProjectFieldValue);
+		}
+
+		// Scale the button based on the rest of the dialog
+		setButtonLayoutData(locationArea.getBrowseButton());
+
+		setPageComplete(validatePage());
+		// Show description on opening
+		setErrorMessage(null);
+		setMessage(null);
+		setControl(composite);
+		Dialog.applyDialogFont(composite);
+	}
+
+	/**
+	 * Create a working set group for this page. This method can only be called once.
+	 *
+	 * @param composite
+	 *            the composite in which to create the group
+	 * @param selection
+	 *            the current workbench selection
+	 * @param supportedWorkingSetTypes
+	 *            an array of working set type IDs that will restrict what types of working sets can be chosen in this
+	 *            group
+	 * @return the created group. If this method has been called previously the original group will be returned.
+	 * @since 3.4
+	 */
+	public WorkingSetGroup createWorkingSetGroup(Composite composite,
+			IStructuredSelection selection, String[] supportedWorkingSetTypes) {
+		if (workingSetGroup != null)
+			return workingSetGroup;
+		workingSetGroup = new WorkingSetGroup(composite, selection,
+				supportedWorkingSetTypes);
+		return workingSetGroup;
+	}
+
+	/**
+	 * Get an error reporter for the receiver.
+	 *
+	 * @return IErrorMessageReporter
+	 */
+	private IErrorMessageReporter getErrorReporter() {
+		return (errorMessage, infoOnly) -> {
+			if (infoOnly) {
+				setMessage(errorMessage, IStatus.INFO);
+				setErrorMessage(null);
+			} else
+				setErrorMessage(errorMessage);
+			boolean valid = errorMessage == null;
+			if (valid) {
+				valid = validatePage();
+			}
+
+			setPageComplete(valid);
+		};
+	}
+
+	/**
+	 * Creates the project name specification controls.
+	 *
+	 * @param parent
+	 *            the parent composite
+	 */
+	private final void createProjectNameGroup(Composite parent) {
+		// project specification group
+		Composite projectGroup = new Composite(parent, SWT.NONE);
+		GridLayout layout = new GridLayout();
+		layout.numColumns = 2;
+		projectGroup.setLayout(layout);
+		projectGroup.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+		// new project label
+		Label projectLabel = new Label(projectGroup, SWT.NONE);
+		projectLabel.setText(IDEWorkbenchMessages.WizardNewProjectCreationPage_nameLabel);
+		projectLabel.setFont(parent.getFont());
+
+		// new project name entry field
+		projectNameField = new Text(projectGroup, SWT.BORDER);
+		GridData data = new GridData(GridData.FILL_HORIZONTAL);
+		data.widthHint = SIZING_TEXT_FIELD_WIDTH;
+		projectNameField.setLayoutData(data);
+		projectNameField.setFont(parent.getFont());
+
+		// Set the initial value first before listener
+		// to avoid handling an event during the creation.
+		if (initialProjectFieldValue != null) {
+			projectNameField.setText(initialProjectFieldValue);
+		}
+		projectNameField.addListener(SWT.Modify, nameModifyListener);
+		BidiUtils.applyBidiProcessing(projectNameField, BidiUtils.BTD_DEFAULT);
+	}
+
+	/**
+	 * Returns the current project location path as entered by the user, or its anticipated initial value. Note that if
+	 * the default has been returned the path in a project description used to create a project should not be set.
+	 *
+	 * @return the project location path or its anticipated initial value.
+	 */
+	public IPath getLocationPath() {
+		return new Path(locationArea.getProjectLocation());
+	}
+
+	/**
+	 * /** Returns the current project location URI as entered by the user, or <code>null</code> if a valid project
+	 * location has not been entered.
+	 *
+	 * @return the project location URI, or <code>null</code>
+	 * @since 3.2
+	 */
+	public URI getLocationURI() {
+		return locationArea.getProjectLocationURI();
+	}
+
+	/**
+	 * Creates a project resource handle for the current project name field value. The project handle is created
+	 * relative to the workspace root.
+	 * <p>
+	 * This method does not create the project resource; this is the responsibility of <code>IProject::create</code>
+	 * invoked by the new project resource wizard.
+	 * </p>
+	 *
+	 * @return the new project resource handle
+	 */
+	public IProject getProjectHandle() {
+		return ResourcesPlugin.getWorkspace().getRoot().getProject(
+				getProjectName());
+	}
+
+	/**
+	 * Returns the current project name as entered by the user, or its anticipated initial value.
+	 *
+	 * @return the project name, its anticipated initial value, or <code>null</code> if no project name is known
+	 */
+	public String getProjectName() {
+		if (projectNameField == null) {
+			return initialProjectFieldValue;
+		}
+
+		return getProjectNameFieldValue();
+	}
+
+	/**
+	 * Returns the value of the project name field with leading and trailing spaces removed.
+	 *
+	 * @return the project name in the field
+	 */
+	private String getProjectNameFieldValue() {
+		if (projectNameField == null) {
+			return ""; //$NON-NLS-1$
+		}
+
+		return projectNameField.getText().trim();
+	}
+
+	/**
+	 * Sets the initial project name that this page will use when created. The name is ignored if the
+	 * createControl(Composite) method has already been called. Leading and trailing spaces in the name are ignored.
+	 * Providing the name of an existing project will not necessarily cause the wizard to warn the user. Callers of this
+	 * method should first check if the project name passed already exists in the workspace.
+	 *
+	 * @param name
+	 *            initial project name for this page
+	 *
+	 * @see IWorkspace#validateName(String, int)
+	 *
+	 */
+	public void setInitialProjectName(String name) {
+		if (name == null) {
+			initialProjectFieldValue = null;
+		} else {
+			initialProjectFieldValue = name.trim();
+			if (locationArea != null) {
+				locationArea.updateProjectName(name.trim());
+			}
+		}
+	}
+
+	/**
+	 * Set the location to the default location if we are set to useDefaults.
+	 *
+	 * CHANGED: set to protected to allow overriding
+	 */
+
+	protected void setLocationForSelection() {
+		locationArea.updateProjectName(getProjectNameFieldValue());
+	}
+
+	/**
+	 * Returns whether this page's controls currently all contain valid values.
+	 *
+	 * @return <code>true</code> if all controls are valid, and <code>false</code> if at least one is invalid
+	 */
+	protected boolean validatePage() {
+		IWorkspace workspace = IDEWorkbenchPlugin.getPluginWorkspace();
+
+		// CHANGED: use getProjectName to allow subclasses to control what concrete project name value is validated
+		String projectFieldContents = getProjectName();
+		if (projectFieldContents.equals("")) { //$NON-NLS-1$
+			setErrorMessage(null);
+			setMessage(IDEWorkbenchMessages.WizardNewProjectCreationPage_projectNameEmpty);
+			return false;
+		}
+
+		IStatus nameStatus = workspace.validateName(projectFieldContents,
+				IResource.PROJECT);
+		if (!nameStatus.isOK()) {
+			setErrorMessage(nameStatus.getMessage());
+			return false;
+		}
+
+		IProject handle = getProjectHandle();
+		if (handle.exists()) {
+			setErrorMessage(IDEWorkbenchMessages.WizardNewProjectCreationPage_projectExistsMessage);
+			return false;
+		}
+
+		// CHANGED: allow getProjectHandle to control the IProject instance used here
+		locationArea.setExistingProject(handle);
+
+		String validLocationMessage = locationArea.checkValidLocation();
+		if (validLocationMessage != null) { // there is no destination location given
+			setErrorMessage(validLocationMessage);
+			return false;
+		}
+
+		setErrorMessage(null);
+		setMessage(null);
+		return true;
+	}
+
+	/*
+	 * see @DialogPage.setVisible(boolean)
+	 */
+	@Override
+	public void setVisible(boolean visible) {
+		super.setVisible(visible);
+		if (visible) {
+			projectNameField.setFocus();
+		}
+	}
+
+	/**
+	 * Returns the useDefaults.
+	 *
+	 * @return boolean
+	 */
+	public boolean useDefaults() {
+		return locationArea.isDefault();
+	}
+
+	/**
+	 * Return the selected working sets, if any. If this page is not configured to interact with working sets this will
+	 * be an empty array.
+	 *
+	 * @return the selected working sets
+	 * @since 3.4
+	 */
+	public IWorkingSet[] getSelectedWorkingSets() {
+		return workingSetGroup == null ? new IWorkingSet[0]
+				: workingSetGroup
+						.getSelectedWorkingSets();
+	}
+}

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/utils/ProjectDescriptionUtils.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/utils/ProjectDescriptionUtils.java
@@ -14,6 +14,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.eclipse.core.resources.IProject;
@@ -30,6 +32,8 @@ import org.eclipse.xtext.naming.QualifiedName;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import com.google.common.collect.Sets;
 
 /**
  * Miscellaneous utilities for dealing with {@link ProjectDescription}s and values stored within them. In particular,
@@ -43,6 +47,21 @@ public class ProjectDescriptionUtils {
 	public static final char NPM_SCOPE_SEPARATOR = '/';
 	/** Like {@link #NPM_SCOPE_SEPARATOR}, but used in Eclipse project names. */
 	public static final char NPM_SCOPE_SEPARATOR_ECLIPSE = ':';
+
+	/**
+	 * Regular expression for valid package.json identifier (e.g. package name, vendor ID).
+	 * <p>
+	 * NOTE: for legacy reasons, upper case letters are accepted, even though they are not allowed by npm.
+	 */
+	private static final Pattern IDENTIFIER_PATTERN = Pattern.compile("(^)?[A-Za-z][A-Za-z_\\-\\.0-9]*");
+
+	private static final Set<String> NPM_RESERVED_PACKAGE_NAMES = Sets.newHashSet(
+			// npm core modules (as of 2018/08/06)
+			"assert", "buffer", "child_process", "cluster", "console", "constants", "crypto", "dgram", "dns", "domain",
+			"events", "fs", "http", "https", "module", "net", "os", "path", "punycode", "querystring", "readline",
+			"repl", "stream", "string_decoder", "sys", "timers", "tls", "tty", "url", "util", "vm", "zlib",
+			// other reserved names
+			"node_modules", "favicon.ico");
 
 	/**
 	 * Tells if the given N4JS project name includes an npm scope, i.e. if it is of the form
@@ -151,6 +170,40 @@ public class ProjectDescriptionUtils {
 		return isProjectNameWithScope(projectName)
 				? projectName.substring(projectName.indexOf(NPM_SCOPE_SEPARATOR) + 1)
 				: projectName;
+	}
+
+	/**
+	 * Tells if the given N4JS project name is valid, i.e. the name may include an npm scope as described
+	 * {@link #isProjectNameWithScope(String) here}.
+	 */
+	public static boolean isValidProjectName(String name) {
+		String scopeName = getScopeName(name);
+		if (scopeName != null) {
+			String plainProjectName = getPlainProjectName(name);
+			return isValidScopeName(scopeName) && isValidPlainProjectName(plainProjectName);
+		}
+		return isValidPlainProjectName(name);
+	}
+
+	/**
+	 * Tells if the given plain project name is valid.
+	 */
+	public static boolean isValidPlainProjectName(String name) {
+		return isValidNpmPackageName(name);
+	}
+
+	/**
+	 * Tells if the given NPM scope name is valid.
+	 */
+	public static boolean isValidScopeName(String name) {
+		return isValidNpmPackageName(name);
+	}
+
+	private static boolean isValidNpmPackageName(String name) {
+		return !Strings.isNullOrEmpty(name)
+				&& name.length() <= 214
+				&& !NPM_RESERVED_PACKAGE_NAMES.contains(name)
+				&& IDENTIFIER_PATTERN.matcher(name).matches();
 	}
 
 	/**

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/utils/ProjectDescriptionUtils.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/utils/ProjectDescriptionUtils.java
@@ -196,6 +196,11 @@ public class ProjectDescriptionUtils {
 	 * Tells if the given NPM scope name is valid.
 	 */
 	public static boolean isValidScopeName(String name) {
+		// if present, remove scope prefix character
+		if (name.startsWith(NPM_SCOPE_PREFIX)) {
+			return isValidNpmPackageName(name.substring(1));
+		}
+
 		return isValidNpmPackageName(name);
 	}
 


### PR DESCRIPTION
Ticket #1026 

With this PR, I have introduced support for scoped projects in the N4JS Project Wizard. The usage is as simple as using a project name like `@scope/project`.

@mor-n4 Please have a look.