### PR TITLE
GH-1018-sub3169: As a user I want the LibraryManager to use new n4jsd npms

### DIFF
--- a/n4js-libs/packages/n4js-mangelhaft-cli/.project
+++ b/n4js-libs/packages/n4js-mangelhaft-cli/.project
@@ -14,15 +14,4 @@
 	<natures>
 		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
 	</natures>
-	<filteredResources>
-		<filter>
-			<id>1535380273953</id>
-			<name></name>
-			<type>26</type>
-			<matcher>
-				<id>org.eclipse.ui.ide.multiFilter</id>
-				<arguments>1.0-name-matches-false-false-build</arguments>
-			</matcher>
-		</filter>
-	</filteredResources>
 </projectDescription>

--- a/n4js-libs/packages/n4js-mangelhaft-cli/package.json
+++ b/n4js-libs/packages/n4js-mangelhaft-cli/package.json
@@ -19,6 +19,9 @@
   },
   "dependencies": {
     "n4js.lang": "^0.1.0",
+    "n4js-runtime-fetch": "^0.1.0",
+    "n4js-runtime-es2015": "^0.1.0",
+    "n4js-runtime-node": "^0.1.0",
     "org.eclipse.n4js.mangelhaft": "^0.1.0",
     "org.eclipse.n4js.mangelhaft.reporter.console": "^0.1.0",
     "org.eclipse.n4js.mangelhaft.reporter.xunit": "^0.1.0",
@@ -43,10 +46,5 @@
       "n4js-runtime-node"
     ],
     "moduleLoader": "n4js"
-  },
-  "devDependencies": {
-    "n4js-runtime-fetch": "^0.1.0",
-    "n4js-runtime-es2015": "^0.1.0",
-    "n4js-runtime-node": "^0.1.0"
   }
 }

--- a/n4js-libs/packages/n4js-mangelhaft-cli/tests/TestPrj/package.json
+++ b/n4js-libs/packages/n4js-mangelhaft-cli/tests/TestPrj/package.json
@@ -2,13 +2,12 @@
   "name": "TestPrj",
   "version": "0.0.1",
   "dependencies": {
+    "n4js-runtime-node": "*",
     "org.eclipse.n4js.mangelhaft": "*",
     "org.eclipse.n4js.mangelhaft.assert": "*",
     "express": "*"
   },
-  "devDependencies": {
-    "n4js-runtime-node": "*"
-  },
+  "devDependencies": {},
   "n4js": {
     "projectType": "test",
     "vendorId": "org.eclipse.n4js",

--- a/n4js-libs/packages/n4js-runtime-fetch/package.json
+++ b/n4js-libs/packages/n4js-runtime-fetch/package.json
@@ -33,8 +33,8 @@
     ],
     "moduleLoader": "n4js"
   },
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "n4js-runtime-es2015": "^0.1.0"
-  }
+  },
+  "devDependencies": {}
 }

--- a/n4js-libs/packages/n4js-runtime-html5/package.json
+++ b/n4js-libs/packages/n4js-runtime-html5/package.json
@@ -25,10 +25,10 @@
     ],
     "moduleLoader": "n4js"
   },
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "n4js-runtime-fetch": "^0.1.0",
     "n4js-runtime-es2015": "^0.1.0",
     "n4js-runtime-esnext": "^0.1.0"
-  }
+  },
+  "devDependencies": {}
 }

--- a/n4js-libs/packages/n4js-runtime-n4-tests/package.json
+++ b/n4js-libs/packages/n4js-runtime-n4-tests/package.json
@@ -53,11 +53,10 @@
   "dependencies": {
     "n4js.lang": "^0.1.0",
     "org.eclipse.n4js.mangelhaft.assert": "^0.1.0",
-    "n4js-node": "^0.1.0"
-  },
-  "devDependencies": {
+    "n4js-node": "^0.1.0",
     "n4js-runtime-n4": "^0.1.0",
     "n4js-runtime-es2015": "^0.1.0",
     "n4js-runtime-v8": "^0.1.0"
-  }
+  },
+  "devDependencies": {}
 }

--- a/n4js-libs/packages/n4js-runtime-node-tests/package.json
+++ b/n4js-libs/packages/n4js-runtime-node-tests/package.json
@@ -16,9 +16,6 @@
     "build": "./npm-build.sh"
   },
   "devDependencies": {
-    "n4js-runtime-n4": "^0.1.0",
-    "n4js-runtime-es2015": "^0.1.0",
-    "n4js-runtime-node": "^0.1.0",
     "babel-cli": "^6.6.5",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.7.4",
     "babel-preset-es2015": "^6.6.0"
@@ -53,6 +50,9 @@
   },
   "dependencies": {
     "org.eclipse.n4js.mangelhaft.assert": "^0.1.0",
-    "n4js-node": "^0.1.0"
+    "n4js-node": "^0.1.0",
+    "n4js-runtime-n4": "^0.1.0",
+    "n4js-runtime-es2015": "^0.1.0",
+    "n4js-runtime-node": "^0.1.0",
   }
 }

--- a/n4js-libs/packages/n4js-runtime-node-tests/package.json
+++ b/n4js-libs/packages/n4js-runtime-node-tests/package.json
@@ -53,6 +53,6 @@
     "n4js-node": "^0.1.0",
     "n4js-runtime-n4": "^0.1.0",
     "n4js-runtime-es2015": "^0.1.0",
-    "n4js-runtime-node": "^0.1.0",
+    "n4js-runtime-node": "^0.1.0"
   }
 }

--- a/n4js-libs/packages/n4js-runtime-node/package.json
+++ b/n4js-libs/packages/n4js-runtime-node/package.json
@@ -30,9 +30,9 @@
     },
     "moduleLoader": "node_builtin"
   },
-  "dependencies": {},
-  "devDependencies": {
+  "dependencies": {
     "n4js-runtime-esnext": "^0.1.0",
     "n4js-runtime-es2015": "^0.1.0"
-  }
+  },
+  "devDependencies": {}
 }

--- a/n4js-libs/packages/n4js.lang/package.json
+++ b/n4js-libs/packages/n4js.lang/package.json
@@ -33,9 +33,8 @@
     "moduleLoader": "n4js"
   },
   "dependencies": {
-    "n4js-node": "^0.1.0"
-  },
-  "devDependencies": {
+    "n4js-node": "^0.1.0",
     "n4js-runtime-es2015": "^0.1.0"
-  }
+  },
+  "devDependencies": {}
 }

--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft.assert.test/package.json
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft.assert.test/package.json
@@ -40,11 +40,10 @@
   "dependencies": {
     "org.eclipse.n4js.mangelhaft": "^0.1.0",
     "org.eclipse.n4js.mangelhaft.assert": "^0.1.0",
-    "n4js-node": "^0.1.0"
-  },
-  "devDependencies": {
+    "n4js-node": "^0.1.0",
     "n4js-runtime-n4": "^0.1.0",
     "n4js-runtime-v8": "^0.1.0",
     "n4js-runtime-es2015": "^0.1.0"
-  }
+  },
+  "devDependencies": {}
 }

--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft.assert/package.json
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft.assert/package.json
@@ -37,11 +37,10 @@
     "moduleLoader": "n4js"
   },
   "dependencies": {
-    "n4js-node": "^0.1.0"
-  },
-  "devDependencies": {
+    "n4js-node": "^0.1.0",
     "n4js-runtime-n4": "^0.1.0",
     "n4js-runtime-v8": "^0.1.0",
     "n4js-runtime-es2015": "^0.1.0"
-  }
+  },
+  "devDependencies": {}
 }

--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft.reporter.console/package.json
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft.reporter.console/package.json
@@ -21,13 +21,12 @@
   },
   "dependencies": {
     "org.eclipse.n4js.mangelhaft": "^0.1.0",
-    "n4js-node": "^0.1.0"
-  },
-  "devDependencies": {
+    "n4js-node": "^0.1.0",
     "n4js-runtime-n4": "^0.1.0",
     "n4js-runtime-v8": "^0.1.0",
     "n4js-runtime-es2015": "^0.1.0"
   },
+  "devDependencies": {},
   "n4js": {
     "projectType": "library",
     "vendorId": "org.eclipse.n4js",

--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft.reporter.ide.test/package.json
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft.reporter.ide.test/package.json
@@ -43,10 +43,9 @@
     "org.eclipse.n4js.mangelhaft.reporter.ide": "^0.1.0",
     "org.eclipse.n4js.mangelhaft.assert": "^0.1.0",
     "org.eclipse.n4js.mangelhaft": "^0.1.0",
-    "n4js-node": "^0.1.0"
-  },
-  "devDependencies": {
+    "n4js-node": "^0.1.0",
     "n4js-runtime-fetch": "^0.1.0",
     "n4js-runtime-mangelhaft": "^0.1.0"
-  }
+  },
+  "devDependencies": {}
 }

--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft.reporter.ide/package.json
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft.reporter.ide/package.json
@@ -36,9 +36,8 @@
   },
   "dependencies": {
     "org.eclipse.n4js.mangelhaft": "^0.1.0",
-    "n4js-node": "^0.1.0"
-  },
-  "devDependencies": {
+    "n4js-node": "^0.1.0",
     "n4js-runtime-fetch": "^0.1.0"
-  }
+  },
+  "devDependencies": {}
 }

--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft.reporter.xunit/package.json
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft.reporter.xunit/package.json
@@ -22,12 +22,11 @@
   "dependencies": {
     "org.eclipse.n4js.mangelhaft": "^0.1.0",
     "xmlbuilder": "^10.0.0",
-    "n4js-node": "^0.1.0"
-  },
-  "devDependencies": {
+    "n4js-node": "^0.1.0",
     "n4js-runtime-node": "^0.1.0",
     "n4js-runtime-es2015": "^0.1.0"
   },
+  "devDependencies": {},
   "n4js": {
     "projectType": "library",
     "vendorId": "org.eclipse.n4js",

--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft.runner.ide/package.json
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft.runner.ide/package.json
@@ -40,11 +40,10 @@
     "n4js.lang": "^0.1.0",
     "org.eclipse.n4js.mangelhaft": "^0.1.0",
     "org.eclipse.n4js.mangelhaft.reporter.ide": "^0.1.0",
-    "n4js-node": "^0.1.0"
-  },
-  "devDependencies": {
+    "n4js-node": "^0.1.0",
     "n4js-runtime-n4": "^0.1.0",
     "n4js-runtime-fetch": "^0.1.0",
     "n4js-runtime-v8": "^0.1.0"
-  }
+  },
+  "devDependencies": {}
 }

--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft.test/package.json
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft.test/package.json
@@ -44,11 +44,10 @@
     "n4js.lang": "^0.1.0",
     "org.eclipse.n4js.mangelhaft": "^0.1.0",
     "org.eclipse.n4js.mangelhaft.assert": "^0.1.0",
-    "n4js-node": "^0.1.0"
-  },
-  "devDependencies": {
+    "n4js-node": "^0.1.0",
     "n4js-runtime-n4": "^0.1.0",
     "n4js-runtime-es2015": "^0.1.0",
     "n4js-runtime-mangelhaft": "^0.1.0"
-  }
+  },
+  "devDependencies": {}
 }

--- a/n4js-libs/packages/org.eclipse.n4js.mangelhaft/package.json
+++ b/n4js-libs/packages/org.eclipse.n4js.mangelhaft/package.json
@@ -39,11 +39,10 @@
   "dependencies": {
     "n4js.lang": "^0.1.0",
     "org.eclipse.n4js.mangelhaft.assert": "^0.1.0",
-    "n4js-node": "^0.1.0"
-  },
-  "devDependencies": {
+    "n4js-node": "^0.1.0",
     "n4js-runtime-n4": "^0.1.0",
     "n4js-runtime-v8": "^0.1.0",
     "n4js-runtime-es2015": "^0.1.0"
-  }
+  },
+  "devDependencies": {}
 }


### PR DESCRIPTION
See #1018.

This fixes compilation problems in headless case in experienced some code bases.