### PR TITLE
GH-1120: Remove code indirectly copied from Java (part 2)

### DIFF
--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/conversion/AbstractN4JSStringValueConverter.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/conversion/AbstractN4JSStringValueConverter.java
@@ -74,7 +74,8 @@ public abstract class AbstractN4JSStringValueConverter extends STRINGValueConver
 	 * Made public only for testing.
 	 */
 	public static String convertFromN4JSString(String n4jsString, INode node, boolean validate) {
-		StringConverterResult result = ValueConverterUtils.convertFromEscapedString(n4jsString, true, false, null);
+		StringConverterResult result = ValueConverterUtils.convertFromEscapedString(n4jsString, true, false, false,
+				null);
 		if (validate) {
 			if (result.hasError()) {
 				throw new BadEscapementException(IssueCodes.getMessageForVCO_STRING_BAD_ESCAP_ERROR(),

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/conversion/IdentifierValueConverter.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/conversion/IdentifierValueConverter.java
@@ -58,7 +58,7 @@ public class IdentifierValueConverter extends IDValueConverter {
 			}
 			return true;
 		};
-		StringConverterResult result = ValueConverterUtils.convertFromEscapedString(jsString, false, false,
+		StringConverterResult result = ValueConverterUtils.convertFromEscapedString(jsString, false, false, true,
 				validityChecker);
 		if (result.hasError()) {
 			throw new N4JSValueConverterWithValueException(

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/conversion/RegExLiteralConverter.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/conversion/RegExLiteralConverter.java
@@ -138,7 +138,7 @@ public class RegExLiteralConverter extends AbstractValueConverter<String> {
 	}
 
 	private static String convertFromJS(String jsString, INode node) {
-		StringConverterResult result = ValueConverterUtils.convertFromEscapedString(jsString, false, true, null);
+		StringConverterResult result = ValueConverterUtils.convertFromEscapedString(jsString, false, true, false, null);
 		if (result.hasError()) {
 			throw new N4JSValueConverterWithValueException(
 					IssueCodes.getMessageForVCO_REGEX_ILLEGAL_ESCAP(jsString),

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/conversion/ValueConverterUtils.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/conversion/ValueConverterUtils.java
@@ -101,6 +101,8 @@ public final class ValueConverterUtils {
 	 * @param keepBackSlashForUnknownEscSeq
 	 *            if <code>true</code>, then the backslash will be copied over to the destination string in case of
 	 *            unknown escape sequences.
+	 * @param errorForUnknownEscSeq
+	 *            if <code>true</code>, then an error will be reported for unknown escape sequences.
 	 * @param validityChecker
 	 *            if non-<code>null</code>, validity of each character added to the destination string (after decoding
 	 *            escape sequences) will be checked with this predicate; otherwise no such validity checks will be
@@ -108,7 +110,8 @@ public final class ValueConverterUtils {
 	 * @return the unescaped string in form of a {@link StringConverterResult}, possibly including error information.
 	 */
 	public static StringConverterResult convertFromEscapedString(String sourceStr, boolean allowStringEscSeq,
-			boolean keepBackSlashForUnknownEscSeq, CharacterValidityChecker validityChecker) {
+			boolean keepBackSlashForUnknownEscSeq, boolean errorForUnknownEscSeq,
+			CharacterValidityChecker validityChecker) {
 		int len = sourceStr.length();
 		StringConverterResult result = new StringConverterResult(validityChecker, len);
 		int off = 0;
@@ -116,7 +119,8 @@ public final class ValueConverterUtils {
 			char ch = sourceStr.charAt(off++);
 			if (ch == '\\') {
 				if (off < len) {
-					off = unescape(sourceStr, off, allowStringEscSeq, keepBackSlashForUnknownEscSeq, result);
+					off = unescape(sourceStr, off, allowStringEscSeq, keepBackSlashForUnknownEscSeq,
+							errorForUnknownEscSeq, result);
 				} else {
 					// backslash at end of input string
 					result.errorAt(off);
@@ -145,7 +149,7 @@ public final class ValueConverterUtils {
 	 * @return the updated offset.
 	 */
 	private static int unescape(String str, int off, boolean allowStringEscSeq, boolean keepBackSlashForUnknownEscSeq,
-			StringConverterResult result) {
+			boolean errorForUnknownEscSeq, StringConverterResult result) {
 
 		int offNew;
 		char ch = str.charAt(off);
@@ -162,6 +166,9 @@ public final class ValueConverterUtils {
 		if (offNew == off) {
 			// offset unchanged => unknown/unhandled control character
 			offNew++; // consume 'ch'
+			if (errorForUnknownEscSeq) {
+				result.errorAt(off);
+			}
 			if (keepBackSlashForUnknownEscSeq) {
 				result.append('\\', off);
 			}

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/ASTStructureValidator.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/ASTStructureValidator.xtend
@@ -17,16 +17,19 @@ import org.eclipse.emf.ecore.EAttribute
 import org.eclipse.emf.ecore.EObject
 import org.eclipse.emf.ecore.EStructuralFeature
 import org.eclipse.n4js.n4JS.AbstractCaseClause
+import org.eclipse.n4js.n4JS.Annotation
 import org.eclipse.n4js.n4JS.ArrayBindingPattern
 import org.eclipse.n4js.n4JS.ArrayElement
 import org.eclipse.n4js.n4JS.ArrayLiteral
 import org.eclipse.n4js.n4JS.AssignmentExpression
 import org.eclipse.n4js.n4JS.AssignmentOperator
+import org.eclipse.n4js.n4JS.BinaryLogicalExpression
 import org.eclipse.n4js.n4JS.BindingElement
 import org.eclipse.n4js.n4JS.Block
 import org.eclipse.n4js.n4JS.BreakStatement
 import org.eclipse.n4js.n4JS.CatchBlock
 import org.eclipse.n4js.n4JS.ContinueStatement
+import org.eclipse.n4js.n4JS.DestructureUtils
 import org.eclipse.n4js.n4JS.ExportDeclaration
 import org.eclipse.n4js.n4JS.Expression
 import org.eclipse.n4js.n4JS.ExpressionStatement
@@ -43,6 +46,7 @@ import org.eclipse.n4js.n4JS.IterationStatement
 import org.eclipse.n4js.n4JS.LabelRef
 import org.eclipse.n4js.n4JS.LabelledStatement
 import org.eclipse.n4js.n4JS.LegacyOctalIntLiteral
+import org.eclipse.n4js.n4JS.Literal
 import org.eclipse.n4js.n4JS.LocalArgumentsVariable
 import org.eclipse.n4js.n4JS.MethodDeclaration
 import org.eclipse.n4js.n4JS.N4ClassDefinition
@@ -69,6 +73,7 @@ import org.eclipse.n4js.n4JS.Script
 import org.eclipse.n4js.n4JS.StrictModeRelevant
 import org.eclipse.n4js.n4JS.StringLiteral
 import org.eclipse.n4js.n4JS.SuperLiteral
+import org.eclipse.n4js.n4JS.TemplateSegment
 import org.eclipse.n4js.n4JS.UnaryExpression
 import org.eclipse.n4js.n4JS.UnaryOperator
 import org.eclipse.n4js.n4JS.Variable
@@ -91,15 +96,12 @@ import org.eclipse.xtext.diagnostics.IDiagnosticConsumer
 import org.eclipse.xtext.diagnostics.Severity
 import org.eclipse.xtext.nodemodel.util.NodeModelUtils
 
-import static org.eclipse.n4js.validation.helper.FunctionValidationHelper.*
 import static org.eclipse.n4js.N4JSLanguageConstants.*
+import static org.eclipse.n4js.validation.helper.FunctionValidationHelper.*
 
 import static extension org.eclipse.n4js.conversion.AbstractN4JSStringValueConverter.*
-import org.eclipse.n4js.n4JS.DestructureUtils
 import static extension org.eclipse.n4js.n4JS.DestructureUtils.isTopOfDestructuringAssignment
 import static extension org.eclipse.n4js.n4JS.DestructureUtils.isTopOfDestructuringForStatement
-import org.eclipse.n4js.n4JS.Annotation
-import org.eclipse.n4js.n4JS.BinaryLogicalExpression
 
 /**
  * A utility that validates the structure of the AST in one pass.
@@ -433,15 +435,7 @@ class ASTStructureValidator {
 		Constraints constraints
 	) {
 		if (constraints.isStrict) {
-			val nodes = NodeModelUtils.findNodesForFeature(model, N4JSPackage.Literals.STRING_LITERAL__VALUE)
-			val target = nodes.head
-			val syntaxError = target.syntaxErrorMessage
-			if ((syntaxError === null || syntaxError.issueCode == WARN_ISSUE_CODE || syntaxError.issueCode == InternalSemicolonInjectingParser.SEMICOLON_INSERTED) && target.text.hasOctalEscapeSequence) {
-				producer.node = target
-				producer.addDiagnostic(
-					new DiagnosticMessage(IssueCodes.messageForAST_STR_NO_OCTALS,
-						IssueCodes.getDefaultSeverity(IssueCodes.AST_STR_NO_OCTALS), IssueCodes.AST_STR_NO_OCTALS))
-			}
+			addErrorForOctalEscapeSequence(model, N4JSPackage.Literals.STRING_LITERAL__VALUE, producer);
 		}
 		recursiveValidateASTStructure(
 			model,
@@ -449,6 +443,34 @@ class ASTStructureValidator {
 			validLabels,
 			constraints
 		)
+	}
+
+	def private dispatch void validateASTStructure(
+		TemplateSegment model,
+		ASTStructureDiagnosticProducer producer,
+		Set<LabelledStatement> validLabels,
+		Constraints constraints
+	) {
+		addErrorForOctalEscapeSequence(model, N4JSPackage.Literals.TEMPLATE_SEGMENT__RAW_VALUE, producer);
+
+		recursiveValidateASTStructure(
+			model,
+			producer,
+			validLabels,
+			constraints
+		)
+	}
+
+	def private addErrorForOctalEscapeSequence(Literal model, EAttribute valueEAttribute, ASTStructureDiagnosticProducer producer) {
+		val nodes = NodeModelUtils.findNodesForFeature(model, valueEAttribute);
+		val target = nodes.head;
+		val syntaxError = target.syntaxErrorMessage;
+		if ((syntaxError === null || syntaxError.issueCode == WARN_ISSUE_CODE || syntaxError.issueCode == InternalSemicolonInjectingParser.SEMICOLON_INSERTED) && target.text.hasOctalEscapeSequence) {
+			producer.node = target;
+			producer.addDiagnostic(
+				new DiagnosticMessage(IssueCodes.messageForAST_STR_NO_OCTALS,
+					IssueCodes.getDefaultSeverity(IssueCodes.AST_STR_NO_OCTALS), IssueCodes.AST_STR_NO_OCTALS));
+		}
 	}
 
 	def private dispatch void validateASTStructure(

--- a/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/conversion/IdentifierValueConverterTest.java
+++ b/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/conversion/IdentifierValueConverterTest.java
@@ -10,12 +10,11 @@
  */
 package org.eclipse.n4js.tests.conversion;
 
+import org.eclipse.n4js.conversion.IdentifierValueConverter;
 import org.eclipse.xtext.conversion.ValueConverterException;
 import org.eclipse.xtext.conversion.ValueConverterWithValueException;
 import org.junit.Assert;
 import org.junit.Test;
-
-import org.eclipse.n4js.conversion.IdentifierValueConverter;
 
 /**
  */
@@ -101,5 +100,15 @@ public class IdentifierValueConverterTest extends Assert {
 	@Test
 	public void testDots() {
 		assertError("aa", "a\\.a");
+	}
+
+	@Test
+	public void testUnknownEscapeSequence1() {
+		assertError("aBc", "a\\Bc");
+	}
+
+	@Test
+	public void testUnknownEscapeSequence2() {
+		assertError("Abc", "\\Abc");
 	}
 }


### PR DESCRIPTION
See #1120.

This PR fixes 2 bugs in the previous PR for this task, that were revealed by the ECMA test suite (which runs only in the nightly):
1. in identifiers (but not string literals, etc.) unknown escape sequences produce an error
2. the AST validation that shows an error if octal escape sequences are used in strict mode did not cover template string literals (only ordinary string literals). In the old code, template string literals had this handling in their value converter instead of the ASTStructureValidator.