### PR TITLE
GH-1171: UI of external library manager in Eclipse preferences dialog not showing up

### DIFF
--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/preferences/external/ExternalLibraryPreferencePage.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/preferences/external/ExternalLibraryPreferencePage.java
@@ -224,6 +224,8 @@ public class ExternalLibraryPreferencePage extends PreferencePage implements IWo
 			}
 		});
 
+		control.requestLayout();
+
 		return control;
 	}
 


### PR DESCRIPTION
See #1171.