### PR TITLE
GH-926: As a user I want content assist to be faster and better sorted

### DIFF
--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/proposals/imports/N4JSReplacementTextApplier.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/proposals/imports/N4JSReplacementTextApplier.java
@@ -36,6 +36,7 @@ import org.eclipse.n4js.ts.types.ModuleNamespaceVirtualType;
 import org.eclipse.n4js.ui.proposals.linkedEditing.IdentifierExitPolicy;
 import org.eclipse.n4js.ui.proposals.linkedEditing.N4JSCompletionProposal;
 import org.eclipse.n4js.ui.utils.ConfigurableCompletionProposalExtensions;
+import org.eclipse.n4js.utils.UtilN4;
 import org.eclipse.swt.custom.StyledText;
 import org.eclipse.text.edits.MultiTextEdit;
 import org.eclipse.text.edits.ReplaceEdit;
@@ -289,7 +290,7 @@ public class N4JSReplacementTextApplier extends ReplacementTextApplier {
 
 			// the simple name is already reachable, i.e. already in use - another import is present
 			// try to use an alias
-			alias = "Alias" + shortQName;
+			alias = "Alias" + UtilN4.toUpperCaseFirst(shortQName);
 		}
 
 		applyWithImport(qualifiedName, alias, document, proposal);
@@ -434,6 +435,10 @@ public class N4JSReplacementTextApplier extends ReplacementTextApplier {
 	private void adjustCursorPositionIfRequested(ConfigurableCompletionProposal proposal) {
 		final int offset = ConfigurableCompletionProposalExtensions.getCursorOffset(proposal);
 		if (offset != 0) {
+			if (viewer.getTextWidget() == null || viewer.getTextWidget().isDisposed()) {
+				return; // do not attempt to set up linked mode in a disposed UI
+			}
+
 			final int pos = proposal.getCursorPosition() + offset;
 
 			proposal.setSelectionStart(pos);

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/utils/ConfigurableCompletionProposalExtensions.xtend
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/utils/ConfigurableCompletionProposalExtensions.xtend
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2018 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+package org.eclipse.n4js.ui.utils
+
+import org.eclipse.n4js.ui.proposals.imports.N4JSReplacementTextApplier
+import org.eclipse.xtext.ui.editor.contentassist.ConfigurableCompletionProposal
+
+/**
+ * Type-safe access to some user data entries of completion proposals.
+ */
+class ConfigurableCompletionProposalExtensions {
+
+	private static final String KEY_REPLACEMENT_SUFFIX = "REPLACEMENT_SUFFIX";
+	private static final String KEY_CURSOR_OFFSET = "CURSOR_OFFSET";
+
+
+	/** See {@link #setReplacementSuffix(ConfigurableCompletionProposal, String)}. */
+	def public static String getReplacementSuffix(ConfigurableCompletionProposal proposal) {
+		val suffix = proposal.getAdditionalData(KEY_REPLACEMENT_SUFFIX);
+		return if (suffix instanceof String) suffix else "";
+	}
+
+	/**
+	 * If set, an additional string will be appended by {@link N4JSReplacementTextApplier} after ordinary
+	 * replacement text when the given proposal is applied. The cursor will be placed after this suffix,
+	 * unless a {@link #setCursorOffset(ConfigurableCompletionProposal, int) cursor offset} is set to
+	 * change this default behavior.
+	 */
+	def public static void setReplacementSuffix(ConfigurableCompletionProposal proposal, String suffix) {
+		proposal.setAdditionalData(KEY_REPLACEMENT_SUFFIX, suffix);
+	}
+
+	/** See {@link #setCursorOffset(ConfigurableCompletionProposal, int)}. */
+	def public static int getCursorOffset(ConfigurableCompletionProposal proposal) {
+		val offset = proposal.getAdditionalData(KEY_CURSOR_OFFSET);
+		return if (offset instanceof Integer) offset.intValue else 0;
+	}
+
+	/**
+	 * If set to a non-zero value, the cursor won't appear at the default location after the given proposal
+	 * is applied but instead be shifted by the given offset (handled by {@link N4JSReplacementTextApplier}).
+	 */
+	def public static void setCursorOffset(ConfigurableCompletionProposal proposal, int offset) {
+		proposal.setAdditionalData(KEY_CURSOR_OFFSET, Integer.valueOf(offset));
+	}
+}

--- a/plugins/org.eclipse.n4js.utils/src/org/eclipse/n4js/utils/UtilN4.java
+++ b/plugins/org.eclipse.n4js.utils/src/org/eclipse/n4js/utils/UtilN4.java
@@ -166,6 +166,32 @@ public class UtilN4 {
 	}
 
 	/**
+	 * Like {@link String#toUpperCase()}, but converts the first character only.
+	 */
+	public static final String toUpperCaseFirst(String str) {
+		if (str != null && str.length() > 0) {
+			final char first = str.charAt(0);
+			if (Character.isLowerCase(first)) {
+				return Character.toUpperCase(first) + str.substring(1);
+			}
+		}
+		return str;
+	}
+
+	/**
+	 * Like {@link String#toLowerCase()}, but converts the first character only.
+	 */
+	public static final String toLowerCaseFirst(String str) {
+		if (str != null && str.length() > 0) {
+			final char first = str.charAt(0);
+			if (Character.isUpperCase(first)) {
+				return Character.toLowerCase(first) + str.substring(1);
+			}
+		}
+		return str;
+	}
+
+	/**
 	 * If 'str' starts with one or more of the given prefixes, the prefixes will be removed.
 	 */
 	public static final String trimPrefix(String str, String... prefix) {

--- a/tests/org.eclipse.n4js.n4ide.spec.tests/xpect-test/Ch05_01_01_03__CA_Complete_Identifier_Reference/ContentAssist_addParensForFunctions.n4js.xt
+++ b/tests/org.eclipse.n4js.n4ide.spec.tests/xpect-test/Ch05_01_01_03__CA_Complete_Identifier_Reference/ContentAssist_addParensForFunctions.n4js.xt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2018 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.n4ide.spec.tests.N4JSXpectPluginUITest
+
+	Workspace {
+		Project "ProjectCA" {
+			SrcFolder {
+				File "ModuleA.n4js" {}
+				File "ModuleB.n4js" {}
+				ThisFile {}
+			}
+			File { from="package.json" }
+		}
+	}
+
+	END_SETUP
+*/
+
+
+function funcLocal() {}
+
+const funcRemoteInB = 42; // this will introduce a name conflict when importing "funcRemoteInB" and thus trigger the import with alias mode
+
+class ClassLocal {
+	instanceMethod() {}
+	static staticMethod() {}
+}
+
+let varWithFunc = funcLocal;
+
+
+// XPECT contentAssist at 'funcL<|>;' apply 'funcLocal' --> funcLocal();
+funcL;
+
+
+/* XPECT contentAssist at 'funcR<|>;' apply 'funcRemoteInA - ModuleA' ---
+<...>
+import {funcRemoteInA} from "ModuleA";
+<...>
+funcRemoteInA();
+<...>
+--- */
+funcR;
+
+
+// import with alias mode
+/* XPECT contentAssist at 'funcR<|>;' apply 'funcRemoteInB - ModuleB' ---
+<...>
+import {funcRemoteInB as AliasFuncRemoteInB} from "ModuleB";
+<...>
+AliasFuncRemoteInB();
+<...>
+--- */
+funcR;
+
+
+// XPECT contentAssist at 'new ClassLocal().in<|>;' apply 'instanceMethod' --> new ClassLocal().instanceMethod();
+new ClassLocal().in;
+
+
+// XPECT contentAssist at 'ClassLocal.stat<|>;' apply 'staticMethod' --> ClassLocal.staticMethod();
+ClassLocal.stat;
+
+
+// a variable with a type that is a subtype of function should not get the parentheses (could be changed in the future):
+
+// XPECT contentAssist at 'varWF<|>;' apply 'varWithFunc' --> varWithFunc;
+varWF;

--- a/tests/org.eclipse.n4js.n4ide.spec.tests/xpect-test/Ch05_01_01_03__CA_Complete_Identifier_Reference/ModuleA.n4js
+++ b/tests/org.eclipse.n4js.n4ide.spec.tests/xpect-test/Ch05_01_01_03__CA_Complete_Identifier_Reference/ModuleA.n4js
@@ -13,3 +13,4 @@
 
 export public class ClassRemoteInA {}
 
+export public function funcRemoteInA() {}

--- a/tests/org.eclipse.n4js.n4ide.spec.tests/xpect-test/Ch05_01_01_03__CA_Complete_Identifier_Reference/ModuleB.n4js
+++ b/tests/org.eclipse.n4js.n4ide.spec.tests/xpect-test/Ch05_01_01_03__CA_Complete_Identifier_Reference/ModuleB.n4js
@@ -13,3 +13,4 @@
 
 export public class ClassRemoteInB {}
 
+export public function funcRemoteInB() {}

--- a/tests/org.eclipse.n4js.n4ide.spec.tests/xpect-test/Ch05_01_01_03__CA_Complete_Identifier_Reference/ModuleC.n4js
+++ b/tests/org.eclipse.n4js.n4ide.spec.tests/xpect-test/Ch05_01_01_03__CA_Complete_Identifier_Reference/ModuleC.n4js
@@ -13,3 +13,4 @@
 
 export public class ClassRemoteInC {}
 
+export public function funcRemoteInC() {}


### PR DESCRIPTION
See #926.

This adds parentheses when inserting function/method references via content assist. Cursor is placed between the parentheses.