### PR TITLE
GH-1209: Bogus error messages in n4idl when invoking generic migrations

### DIFF
--- a/plugins/org.eclipse.n4js.ts/src/org/eclipse/n4js/ts/utils/TypeUtils.java
+++ b/plugins/org.eclipse.n4js.ts/src/org/eclipse/n4js/ts/utils/TypeUtils.java
@@ -56,6 +56,7 @@ import org.eclipse.n4js.ts.typeRefs.TypeRefsPackage;
 import org.eclipse.n4js.ts.typeRefs.TypeTypeRef;
 import org.eclipse.n4js.ts.typeRefs.TypeVariableMapping;
 import org.eclipse.n4js.ts.typeRefs.UnionTypeExpression;
+import org.eclipse.n4js.ts.typeRefs.VersionedParameterizedTypeRef;
 import org.eclipse.n4js.ts.typeRefs.Wildcard;
 import org.eclipse.n4js.ts.types.AnyType;
 import org.eclipse.n4js.ts.types.InferenceVariable;
@@ -1207,12 +1208,16 @@ public class TypeUtils {
 	}
 
 	/**
-	 * Same as {@link EcoreUtil2#cloneWithProxies(EObject)}, but takes care of special copy semantics for TypeRefs. See
-	 * {@link #copy(EObject)}.
+	 * Converts the given {@link ParameterizedTypeRef} into a {@link ParameterizedTypeRefStructural}. Creates a copy and
+	 * does not modify the passed-in type reference.
+	 * <p>
+	 * Returns <code>null</code> if given a {@link FunctionTypeRef}.
 	 */
 	public static final ParameterizedTypeRefStructural copyToParameterizedTypeRefStructural(
 			ParameterizedTypeRef source) {
-		EClass ptrsEClass = TypeRefsPackage.eINSTANCE.getParameterizedTypeRefStructural();
+		EClass ptrsEClass = source instanceof VersionedParameterizedTypeRef
+				? TypeRefsPackage.eINSTANCE.getVersionedParameterizedTypeRefStructural()
+				: TypeRefsPackage.eINSTANCE.getParameterizedTypeRefStructural();
 		return (ParameterizedTypeRefStructural) copy(source, false, false, ptrsEClass);
 	}
 

--- a/plugins/org.eclipse.n4js.ts/src/org/eclipse/n4js/ts/utils/TypeUtils.java
+++ b/plugins/org.eclipse.n4js.ts/src/org/eclipse/n4js/ts/utils/TypeUtils.java
@@ -565,7 +565,7 @@ public class TypeUtils {
 	private static TypeRef mergeTypingStrategies(TypeRef target, TypingStrategy source) {
 		final TypingStrategy combined = concatTypingStrategies(target.getTypingStrategy(), source);
 		if (combined != target.getTypingStrategy()) {
-			if (target instanceof ParameterizedTypeRef) {
+			if (target instanceof ParameterizedTypeRef && !(target instanceof FunctionTypeRef)) {
 				final ParameterizedTypeRefStructural ptrs = copyToParameterizedTypeRefStructural(
 						(ParameterizedTypeRef) target);
 				ptrs.setTypingStrategy(combined);
@@ -1210,11 +1210,16 @@ public class TypeUtils {
 	/**
 	 * Converts the given {@link ParameterizedTypeRef} into a {@link ParameterizedTypeRefStructural}. Creates a copy and
 	 * does not modify the passed-in type reference.
-	 * <p>
-	 * Returns <code>null</code> if given a {@link FunctionTypeRef}.
+	 *
+	 * @throws IllegalArgumentException
+	 *             if given a {@link FunctionTypeRef}, because {@code FunctionTypeRef}s do not have a corresponding
+	 *             subclass that implements {@link ParameterizedTypeRefStructural}.
 	 */
 	public static final ParameterizedTypeRefStructural copyToParameterizedTypeRefStructural(
 			ParameterizedTypeRef source) {
+		if (source instanceof FunctionTypeRef) {
+			throw new IllegalArgumentException("FunctionTypeRefs do not have a corresponding structural variant");
+		}
 		EClass ptrsEClass = source instanceof VersionedParameterizedTypeRef
 				? TypeRefsPackage.eINSTANCE.getVersionedParameterizedTypeRefStructural()
 				: TypeRefsPackage.eINSTANCE.getParameterizedTypeRefStructural();

--- a/tests/org.eclipse.n4js.bugreports.tests/bugreports-tests/GH_1209_BogusErrorInN4idlWhenInvokingGenericMigrations.n4idl.xt
+++ b/tests/org.eclipse.n4js.bugreports.tests/bugreports-tests/GH_1209_BogusErrorInN4idlWhenInvokingGenericMigrations.n4idl.xt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2019 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.bugreports.tests.N4JSBugreportTest END_SETUP  */
+
+class Element#1 {
+	public value : string
+}
+class Element#2 {
+	public value : string
+}
+
+@Migration
+export function migrateElement(e1 : Element#1) : Element#2 {
+	let e2 = new Element#2();
+	// XPECT noerrors --> "constructor{Element#2} is not a subtype of constructor{ToT}." and "Element#2 is not a subtype of FromT+."
+	copy(Element#2, e2);
+	return null;
+}
+
+@Migration
+export public function <FromT extends Object, ToT extends ~FromT&Object> copy(
+	ctor : constructor{ToT},  from: FromT+
+) : ToT {
+	return null;
+}


### PR DESCRIPTION
See #1209.