### PR TITLE
GH-1119: As a smith I want to restructure the integration tests of N4JS

### DIFF
--- a/docker-build/Dockerfile
+++ b/docker-build/Dockerfile
@@ -79,7 +79,7 @@ RUN set -ex && \
 #
 # Node install
 #
-ENV NODE_VERSION 8.11.2
+ENV NODE_VERSION 10.13.0
 
 RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
     case "${dpkgArch##*-}" in \
@@ -98,7 +98,7 @@ RUN ARCH= && dpkgArch="$(dpkg --print-architecture)" && \
 #
 # Yarn install
 #
-ENV YARN_VERSION 1.5.1
+ENV YARN_VERSION 1.12.3
 
 RUN set -ex && \
     for key in \

--- a/plugins/org.eclipse.n4js.utils/src/org/eclipse/n4js/utils/io/FileCopier.java
+++ b/plugins/org.eclipse.n4js.utils/src/org/eclipse/n4js/utils/io/FileCopier.java
@@ -108,8 +108,9 @@ public class FileCopier implements FileVisitor<Path> {
 
 	@Override
 	public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-		if (this.shouldCopyFile.apply(file))
+		if (this.shouldCopyFile.apply(file)) {
 			Files.copy(file, target.resolve(source.relativize(file)), StandardCopyOption.REPLACE_EXISTING);
+		}
 		return CONTINUE;
 	}
 

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/binaries/nodejs/NodeJsBinary.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/binaries/nodejs/NodeJsBinary.java
@@ -145,7 +145,7 @@ public class NodeJsBinary implements Binary {
 	 *
 	 * @return the user configured absolute path to the binary or the default one.
 	 */
-	String getUserNodePathOrDefault() {
+	public String getUserNodePathOrDefault() {
 		final URI userConfiguredLocation = getUserConfiguredLocation();
 		return null == userConfiguredLocation ? getDefaultNodePath()
 				: new File(userConfiguredLocation).getAbsolutePath();

--- a/releng/org.eclipse.n4js.parent/pom.xml
+++ b/releng/org.eclipse.n4js.parent/pom.xml
@@ -90,7 +90,6 @@ Contributors:
 		
 		<!-- some memory -->
 		<memoryArgs>-Xms256M -Xmx1324M -XX:+HeapDumpOnOutOfMemoryError</memoryArgs>
-		<lowMemoryArgs>-Xms64M -Xmx320M -XX:+HeapDumpOnOutOfMemoryError</lowMemoryArgs>
 		<encodingArgs>-Dfile.encoding=${file.encoding}</encodingArgs>
 
 		<!-- Test related dependency path tragets. -->

--- a/testhelpers/org.eclipse.n4js.ui.tests.helper/src/org/eclipse/n4js/tests/builder/AbstractBuilderTest.java
+++ b/testhelpers/org.eclipse.n4js.ui.tests.helper/src/org/eclipse/n4js/tests/builder/AbstractBuilderTest.java
@@ -9,18 +9,15 @@ package org.eclipse.n4js.tests.builder;
 
 import static org.apache.log4j.Logger.getLogger;
 import static org.eclipse.core.resources.IContainer.INCLUDE_HIDDEN;
-import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
 import static org.eclipse.n4js.tests.builder.BuilderUtil.countResourcesInIndex;
 import static org.eclipse.n4js.tests.builder.BuilderUtil.getAllResourceDescriptionsAsString;
 import static org.eclipse.n4js.tests.builder.BuilderUtil.getBuilderState;
-import static org.eclipse.ui.PlatformUI.isWorkbenchRunning;
 import static org.eclipse.xtext.ui.testing.util.IResourcesSetupUtil.root;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IProject;
-import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
@@ -145,21 +142,7 @@ public abstract class AbstractBuilderTest {
 	}
 
 	private void toggleAutobuild(final boolean enable) {
-		if (isWorkbenchRunning()) {
-			final IWorkspaceDescription workspaceDescription = getWorkspace().getDescription();
-			if (null != workspaceDescription) {
-				if (workspaceDescription.isAutoBuilding() != enable) {
-					workspaceDescription.setAutoBuilding(enable);
-					try {
-						getWorkspace().setDescription(workspaceDescription);
-					} catch (final CoreException e) {
-						throw new IllegalStateException("Error while trying to turn workspace autobuild "
-								+ (enable ? "on" : "off") + ".", e);
-					}
-				}
-			}
-
-		}
+		EclipseUIUtils.toggleAutobuild(enable);
 	}
 
 	private static void deleteProjects(final IProject[] projects, StringBuilder error) {

--- a/testhelpers/org.eclipse.n4js.ui.tests.helper/src/org/eclipse/n4js/tests/builder/AbstractBuilderTest.java
+++ b/testhelpers/org.eclipse.n4js.ui.tests.helper/src/org/eclipse/n4js/tests/builder/AbstractBuilderTest.java
@@ -33,6 +33,7 @@ import org.eclipse.n4js.ui.building.CloseProjectTaskScheduler;
 import org.eclipse.n4js.ui.building.ResourceDescriptionWithoutModuleUserData;
 import org.eclipse.n4js.ui.external.ExternalLibraryBuildScheduler;
 import org.eclipse.n4js.ui.internal.N4JSActivator;
+import org.eclipse.n4js.ui.utils.AutobuildUtils;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.PlatformUI;
@@ -141,8 +142,13 @@ public abstract class AbstractBuilderTest {
 		toggleAutobuild(true);
 	}
 
+	/**
+	 * Turns auto build on/off. Delegating to {@link AutobuildUtils#set(boolean)}.
+	 *
+	 * Consider using {@link AutobuildUtils#suppressAutobuild()} if you want to disable auto build only temporarily.
+	 */
 	private void toggleAutobuild(final boolean enable) {
-		EclipseUIUtils.toggleAutobuild(enable);
+		AutobuildUtils.set(enable);
 	}
 
 	private static void deleteProjects(final IProject[] projects, StringBuilder error) {

--- a/testhelpers/org.eclipse.n4js.ui.tests.helper/src/org/eclipse/n4js/tests/util/EclipseUIUtils.java
+++ b/testhelpers/org.eclipse.n4js.ui.tests.helper/src/org/eclipse/n4js/tests/util/EclipseUIUtils.java
@@ -11,17 +11,13 @@
 package org.eclipse.n4js.tests.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
-import static org.eclipse.ui.PlatformUI.isWorkbenchRunning;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IWorkspace;
-import org.eclipse.core.resources.IWorkspaceDescription;
-import org.eclipse.core.runtime.CoreException;
+import org.eclipse.n4js.ui.utils.AutobuildUtils;
 import org.eclipse.n4js.ui.utils.TimeoutRuntimeException;
 import org.eclipse.n4js.ui.utils.UIUtils;
 import org.eclipse.ui.IEditorPart;
@@ -144,23 +140,12 @@ public class EclipseUIUtils {
 		return refFileEditor.get();
 	}
 
-	/** Turns auto build on/off. */
-	// moved here from class AbstractBuilderTest
+	/**
+	 * Turns auto build on/off. Delegating to {@link AutobuildUtils#set(boolean)}.
+	 *
+	 * Consider using {@link AutobuildUtils#suppressAutobuild()} if you want to disable auto build only temporarily.
+	 */
 	public static void toggleAutobuild(final boolean enable) {
-		if (isWorkbenchRunning()) {
-			final IWorkspace workspace = getWorkspace();
-			final IWorkspaceDescription workspaceDescription = workspace.getDescription();
-			if (null != workspaceDescription) {
-				if (workspaceDescription.isAutoBuilding() != enable) {
-					workspaceDescription.setAutoBuilding(enable);
-					try {
-						workspace.setDescription(workspaceDescription);
-					} catch (final CoreException e) {
-						throw new IllegalStateException("Error while trying to turn auto build "
-								+ (enable ? "on" : "off") + ".", e);
-					}
-				}
-			}
-		}
+		AutobuildUtils.set(enable);
 	}
 }

--- a/testhelpers/org.eclipse.n4js.ui.tests.helper/src/org/eclipse/n4js/tests/util/EclipseUIUtils.java
+++ b/testhelpers/org.eclipse.n4js.ui.tests.helper/src/org/eclipse/n4js/tests/util/EclipseUIUtils.java
@@ -11,12 +11,17 @@
 package org.eclipse.n4js.tests.util;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static org.eclipse.core.resources.ResourcesPlugin.getWorkspace;
+import static org.eclipse.ui.PlatformUI.isWorkbenchRunning;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.IWorkspaceDescription;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.n4js.ui.utils.TimeoutRuntimeException;
 import org.eclipse.n4js.ui.utils.UIUtils;
 import org.eclipse.ui.IEditorPart;
@@ -139,4 +144,23 @@ public class EclipseUIUtils {
 		return refFileEditor.get();
 	}
 
+	/** Turns auto build on/off. */
+	// moved here from class AbstractBuilderTest
+	public static void toggleAutobuild(final boolean enable) {
+		if (isWorkbenchRunning()) {
+			final IWorkspace workspace = getWorkspace();
+			final IWorkspaceDescription workspaceDescription = workspace.getDescription();
+			if (null != workspaceDescription) {
+				if (workspaceDescription.isAutoBuilding() != enable) {
+					workspaceDescription.setAutoBuilding(enable);
+					try {
+						workspace.setDescription(workspaceDescription);
+					} catch (final CoreException e) {
+						throw new IllegalStateException("Error while trying to turn auto build "
+								+ (enable ? "on" : "off") + ".", e);
+					}
+				}
+			}
+		}
+	}
 }

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -406,6 +406,9 @@ Contributors:
 								<includes>
 									<include>**/*PluginUITest.java</include>
 								</includes>
+								<excludes>
+									<exclude>**/*IntegrationPluginUITest.java</exclude>
+								</excludes>
 							</configuration>
 							<goals>
 								<goal>test</goal>


### PR DESCRIPTION
See #1119.

This PR contains some minor adjustments of several utility methods used mainly by tests plus some related refactorings (e.g. moving some code from library manager into re-usable utility methods).

Also, the version of `node` and `yarn` used during Jenkins builds is increased.