### PR TITLE
GH-1238: clarify how much code was copied from other Eclipse projects

### DIFF
--- a/n4js-libs/packages/n4js-runtime-n4-tests/test/n4js/runtime/n4/di/N4JS_DI_Singleton_Example/DI_05_NestedInjectorSingletonUnbound.n4js
+++ b/n4js-libs/packages/n4js-runtime-n4-tests/test/n4js/runtime/n4/di/N4JS_DI_Singleton_Example/DI_05_NestedInjectorSingletonUnbound.n4js
@@ -58,8 +58,8 @@ class D { @Inject s: S;}
  *
  * Other approach would be if always root would create and hold instance of the singleton.
  * But that means that child injector can mutate parent injector, which in turn can affect
- * other child of the parent. (E.G. fabelhaft (parent) loads app (child), child mutates parent(!)
- * , fabelhaft loads other app (child), other has singleton created for previous app).
+ * other child of the parent. (E.g. a parent loads a child, child mutates parent(!),
+ * parent loads other child, other has singleton created for previous child).
  */
 export class TestNestedInjectorsNoSingletonBinding{
 

--- a/plugins/org.eclipse.n4js.json/src/org/eclipse/n4js/json/conversion/JSONSTRINGValueConverter.java
+++ b/plugins/org.eclipse.n4js.json/src/org/eclipse/n4js/json/conversion/JSONSTRINGValueConverter.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright (c) 2018 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Parts originally copied from org.eclipse.xtext.conversion.impl.STRINGValueConverter
+ *	in bundle org.eclipse.xtext
+ *	available under the terms of the Eclipse Public License 2.0
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
 package org.eclipse.n4js.json.conversion;
 
 import org.eclipse.xtext.conversion.ValueConverterWithValueException;

--- a/plugins/org.eclipse.n4js.semver/src/org/eclipse/n4js/semver/SemverResourceValidator.java
+++ b/plugins/org.eclipse.n4js.semver/src/org/eclipse/n4js/semver/SemverResourceValidator.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright (c) 2018 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Parts originally copied from .validation.ResourceValidatorImpl
+ *	in bundle org.eclipse.xtext
+ *	available under the terms of the Eclipse Public License 2.0
+ *  Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
 package org.eclipse.n4js.semver;
 
 import java.util.ArrayList;

--- a/plugins/org.eclipse.n4js.smith.ui/src/org/eclipse/n4js/smith/ui/graph/Rectangle.java
+++ b/plugins/org.eclipse.n4js.smith.ui/src/org/eclipse/n4js/smith/ui/graph/Rectangle.java
@@ -5,6 +5,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Parts originally copied from org.eclipse.draw2d.ChopboxAnchor
+ *	in bundle org.eclipse.draw2d
+ *	available under the terms of the Eclipse Public License 2.0
+ *  Copyright (c) 2000, 2010 IBM Corporation and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */

--- a/plugins/org.eclipse.n4js.tester.ui/src/org/eclipse/n4js/tester/ui/resultsview/TestResultsView.java
+++ b/plugins/org.eclipse.n4js.tester.ui/src/org/eclipse/n4js/tester/ui/resultsview/TestResultsView.java
@@ -5,6 +5,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Parts originally copied from org.eclipse.debug.internal.ui.views.console.ConsoleTerminateAction
+ *	in bundle org.eclipse.debug.ui
+ *	available under the terms of the Eclipse Public License 2.0
+ *  Copyright (c) 2000, 2013 IBM Corporation and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/MyReferenceSearchResultContentProviderCustomModule.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/MyReferenceSearchResultContentProviderCustomModule.java
@@ -5,6 +5,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Parts originally copied from org.eclipse.xtext.ui.shared.internal.SharedModule
+ *	in bundle org.eclipse.xtext.ui.shared
+ *	available under the terms of the Eclipse Public License 2.0
+ *  Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/N4JSDoubleClickStrategyProvider.xtend
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/N4JSDoubleClickStrategyProvider.xtend
@@ -5,6 +5,16 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Parts originally copied from org.eclipse.xtext.ui.editor.doubleClicking.AbstractPartitionDoubleClickSelector 
+ * 	in bundle  org.eclipse.xtext.ui
+ * 	available under the terms of the Eclipse Public License 2.0
+ * 	Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ * 
+ * and org.eclipse.jdt.internal.ui.text.java.JavadocDoubleClickStrategy
+ *	in bundle org.eclipse.jdt.ui
+ *	available under the terms of the Eclipse Public License 2.0
+ *  Copyright (c) 2000, 2011 IBM Corporation and others.
+ * 
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/N4JSHover.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/N4JSHover.java
@@ -5,6 +5,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Parts originally copied from org.eclipse.xtext.ui.editor.hover.DispatchingEObjectTextHover
+ *	in bundle org.eclipse.xtext.ui
+ *	available under the terms of the Eclipse Public License 2.0
+ * 	Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/N4JSHyperlinkDetector.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/N4JSHyperlinkDetector.java
@@ -5,6 +5,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Parts originally copied from org.eclipse.xtext.ui.editor.hyperlinking.DefaultHyperlinkDetector
+ *	in bundle org.eclipse.xtext.ui
+ *	available under the terms of the Eclipse Public License 2.0
+ *  Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/external/ComputeProjectOrder.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/external/ComputeProjectOrder.java
@@ -6,8 +6,9 @@
  * http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     IBM Corporation - initial API and implementation
- *     Broadcom Corporation - ongoing development
+ * - original code copied from org.eclipse.core.internal.resources.ComputeProjectOrder
+ * 	 available under the terms of the Eclipse Public License 2.0
+ * 	 Copyright (c) 2000, 2011 IBM Corporation and others.
  *******************************************************************************/
 package org.eclipse.n4js.ui.external;
 

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/logging/EclipseLogAppender.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/logging/EclipseLogAppender.java
@@ -5,8 +5,10 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
- * Originally copied from bundle-fragment "org.eclipse.xtext.logging;version=1.2.15.v201605250459"
- *
+ * Originally copied from org.eclipse.xtext.logging.EclipseLogAppender
+ * 		in bundle-fragment "org.eclipse.xtext.logging;version=1.2.15.v201605250459"
+ * 		available under the terms of the Eclipse Public License 2.0
+ * 		Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
  *******************************************************************************/
 package org.eclipse.n4js.ui.logging;
 

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/organize/imports/MultiElementListSelectionDialog.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/organize/imports/MultiElementListSelectionDialog.java
@@ -5,8 +5,10 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
- * Contributors:
- *     IBM Corporation - initial API and implementation
+ * Originally copied from org.eclipse.jdt.internal.ui.dialogs.MultiElementListSelectionDialog
+ * 		in bundle org.eclipse.jdt.internal.ui.dialogs
+ * 		available under the terms of the Eclipse Public License 2.0
+ * 		Copyright (c) 2000, 2011 IBM Corporation and others.
  *******************************************************************************/
 package org.eclipse.n4js.ui.organize.imports;
 // package org.eclipse.jdt.internal.ui.dialogs;

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/outline/N4JSShowInheritedMembersOutlineContribution.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/outline/N4JSShowInheritedMembersOutlineContribution.java
@@ -5,6 +5,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Parts originally copied from org.eclipse.xtend.ide.outline.ShowSyntheticMembersContribution
+ *	in bundle org.eclipse.xtend.ide
+ *	available under the terms of the Eclipse Public License 2.0
+ *  Copyright (c) 2012 itemis AG (http://www.itemis.eu) and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/preferences/AbstractN4JSPreferencePage.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/preferences/AbstractN4JSPreferencePage.java
@@ -5,8 +5,19 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Originally copied from org.eclipse.xtext.ui.preferences.PropertyAndPreferencePage
+ * 		in bundle org.eclipse.xtext.ui
+ * 		available under the terms of the Eclipse Public License 2.0
+ * 		Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ *
+ *  which has been itself copied from org.eclipse.jdt.internal.ui.preferences.PropertyAndPreferencePage
+ *      in bundle org.eclipse.jdt.ui
+ *      available under the terms of the Eclipse Public License 2.0
+ *      Copyright (c) 2000, 2011 IBM Corporation and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
+ *
  */
 package org.eclipse.n4js.ui.preferences;
 
@@ -34,6 +45,10 @@ import org.eclipse.jface.dialogs.IMessageProvider;
 import org.eclipse.jface.preference.IPersistentPreferenceStore;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.window.Window;
+import org.eclipse.n4js.generator.CompilerProperties;
+import org.eclipse.n4js.ui.internal.N4JSActivator;
+import org.eclipse.n4js.utils.ComponentDescriptor;
+import org.eclipse.n4js.utils.IComponentProperties;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.events.SelectionListener;
@@ -63,11 +78,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
-
-import org.eclipse.n4js.generator.CompilerProperties;
-import org.eclipse.n4js.ui.internal.N4JSActivator;
-import org.eclipse.n4js.utils.ComponentDescriptor;
-import org.eclipse.n4js.utils.IComponentProperties;
 
 /**
  */
@@ -189,7 +199,8 @@ public abstract class AbstractN4JSPreferencePage<DESCR_TYPE extends ComponentDes
 			useProjectSettings = new SelectionButtonDialogField(SWT.CHECK);
 			useProjectSettings.setDialogFieldListener(listener);
 			useProjectSettings
-					.setLabelText(org.eclipse.xtext.ui.preferences.Messages.PropertyAndPreferencePage_useprojectsettings_label);
+					.setLabelText(
+							org.eclipse.xtext.ui.preferences.Messages.PropertyAndPreferencePage_useprojectsettings_label);
 			useProjectSettings.doFillIntoGrid(composite, 1);
 			LayoutUtil.setHorizontalGrabbing(useProjectSettings.getSelectionButton(null));
 

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/preferences/N4JSBuilderPreferencePage.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/preferences/N4JSBuilderPreferencePage.java
@@ -5,6 +5,22 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Parts originally copied from
+ * 		org.eclipse.xtext.builder.preferences.BuilderPreferencePage,
+ * 		org.eclipse.xtext.builder.preferences.BuilderConfigurationBlock,
+ * 		org.eclipse.xtext.ui.editor.syntaxcoloring.SyntaxColoringPreferencePage,
+ * 		org.eclipse.xtext.ui.preferences.PropertyAndPreferencePage and
+ * 		org.eclipse.xtext.ui.preferences.OptionsConfigurationBlock
+ *  in bundles org.eclipse.xtext.builder and org.eclipse.xtext.ui
+ *	available under the terms of the Eclipse Public License 2.0
+ *  Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ *  Part of these have been itself copied from
+ *  		org.eclipse.jdt.internal.ui.preferences.PropertyAndPreferencePage and
+ *  		org.eclipse.jdt.internal.ui.preferences.OptionsConfigurationBlock
+ *      in bundle org.eclipse.jdt.ui
+ *      available under the terms of the Eclipse Public License 2.0
+ *      Copyright (c) 2000, 2011 IBM Corporation and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/quickfix/N4JSIssue.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/quickfix/N4JSIssue.java
@@ -5,6 +5,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Parts originally copied from org.eclipse.xtext.ui.util.IssueUtil
+ *	in bundle org.eclipse.xtext.ui
+ *	available under the terms of the Eclipse Public License 2.0
+ *  Copyright (c) 2010 itemis AG (http://www.itemis.eu) and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/ui/dialogs/ExtensibleWizardNewProjectCreationPage.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/ui/dialogs/ExtensibleWizardNewProjectCreationPage.java
@@ -5,6 +5,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Originally copied from org.eclipse.ui.dialogs.WizardNewProjectCreationPage
+ *	in bundle org.eclipse.ui.ide
+ *	available under the terms of the Eclipse Public License 2.0
+ *  Copyright (c) 2000, 2015 IBM Corporation and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */

--- a/plugins/org.eclipse.n4js.utils/src/org/eclipse/n4js/utils/RecursionGuard.java
+++ b/plugins/org.eclipse.n4js.utils/src/org/eclipse/n4js/utils/RecursionGuard.java
@@ -5,6 +5,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Parts originally copied from org.eclipse.xtext.xbase.typesystem.util.RecursionGuard<T>
+ *	in bundle org.eclipse.xtext.xbase
+ *	available under the terms of the Eclipse Public License 2.0
+ *  Copyright (c) 2013 itemis AG (http://www.itemis.eu) and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/N4JSStandaloneSetup.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/N4JSStandaloneSetup.java
@@ -29,7 +29,7 @@ import com.google.inject.Injector;
 
 /**
  * Initialization support for running Xtext languages without equinox extension registry. The content here is completely
- * copied from N4JSStandaloneSetup and its super classes.
+ * copied from N4JSStandaloneSetupGenerate.
  */
 public class N4JSStandaloneSetup implements ISetup {
 

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/conversion/ValueConverterUtils.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/conversion/ValueConverterUtils.java
@@ -5,6 +5,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Parts originally copied from org.eclipse.xtext.util.Strings
+ *	in bundle org.eclipse.xtext.util
+ *	available under the terms of the Eclipse Public License 2.0
+ *  Copyright (c) 2008, 2017 itemis AG (http://www.itemis.eu) and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSCache.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSCache.java
@@ -5,6 +5,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Parts originally copied from org.eclipse.xtext.util.OnChangeEvictingCache
+ *	in bundle org.eclipse.xtext.util
+ *	available under the terms of the Eclipse Public License 2.0
+ *  Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSExternalReferenceChecker.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSExternalReferenceChecker.java
@@ -5,6 +5,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Parts originally copied from org.eclipse.xtext.resource.impl.DefaultResourceDescriptionStrategy
+ *	in bundle org.eclipse.xtext
+ *	available under the terms of the Eclipse Public License 2.0
+ *  Copyright (c) 2011, 2017 itemis AG (http://www.itemis.eu) and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSResource.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSResource.java
@@ -5,6 +5,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Parts originally copied from org.eclipse.emf.ecore.resource.impl.ResourceImpl
+ *	in bundle org.eclipse.emf.ecore
+ *	available under the terms of the Eclipse Public License 2.0
+ *  Copyright (c) 2002-2013 IBM Corporation and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSResourceDescriptionDelta.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSResourceDescriptionDelta.java
@@ -5,6 +5,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Parts originally copied from org.eclipse.xtext.resource.impl.DefaultResourceDescriptionDelta
+ *	in bundle org.eclipse.xtext
+ *	available under the terms of the Eclipse Public License 2.0
+ *  Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */

--- a/releng/org.eclipse.n4js.targetplatform/N4JS.setup
+++ b/releng/org.eclipse.n4js.targetplatform/N4JS.setup
@@ -387,8 +387,6 @@
         <repository
             url="http://download.eclipse.org/tools/orbit/downloads/drops/R20180905201904/repository"/>
         <repository
-            url="http://boothen.github.io/Json-Eclipse-Plugin"/>
-        <repository
             url="https://ci.eclipse.org/xpect/job/Xpect-Integration-Release/lastSuccessfulBuild/artifact/org.eclipse.xpect.releng/p2-repository/target/repository/"/>
         <repository
             url="http://download.eclipse.org/cbi/updates/license/1.0.1.v20140414-1359"/>

--- a/releng/org.eclipse.n4js.targetplatform/n4js.dict
+++ b/releng/org.eclipse.n4js.targetplatform/n4js.dict
@@ -38,7 +38,6 @@ exec
 exec
 exportable
 extendable
-fabelhaft
 fallback
 fpar
 fpars

--- a/testhelpers/org.eclipse.n4js.tests.helper/src/org/eclipse/n4js/N4JSParseHelper.java
+++ b/testhelpers/org.eclipse.n4js.tests.helper/src/org/eclipse/n4js/N4JSParseHelper.java
@@ -5,6 +5,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Parts originally copied from org.eclipse.xtext.testing.util.ResourceHelper
+ *	in bundle org.eclipse.xtext.testing
+ *	available under the terms of the Eclipse Public License 2.0
+ *  Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */

--- a/testhelpers/org.eclipse.n4js.ui.tests.helper/src/org/eclipse/n4js/tests/outline/DisplaySafeSyncer.java
+++ b/testhelpers/org.eclipse.n4js.ui.tests.helper/src/org/eclipse/n4js/tests/outline/DisplaySafeSyncer.java
@@ -5,6 +5,11 @@
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
  *
+ * Originally copied from org.eclipse.xtext.ui.tests.editor.outline.DisplaySafeSyncer
+ *	in bundle org.eclipse.xtext.ui.tests
+ *	available under the terms of the Eclipse Public License 2.0
+ * 	Copyright (c) 2010, 2017 itemis AG (http://www.itemis.eu) and others.
+ *
  * Contributors:
  *   NumberFour AG - Initial API and implementation
  */
@@ -18,8 +23,7 @@ import org.eclipse.swt.widgets.Display;
 
 /**
  *
- *         Copied from
- *         /org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/DisplaySafeSyncer.java
+ * Copied from /org.eclipse.xtext.ui.tests/tests/org/eclipse/xtext/ui/tests/editor/outline/DisplaySafeSyncer.java
  */
 @SuppressWarnings("javadoc")
 public class DisplaySafeSyncer {

--- a/tests/org.eclipse.n4js.bugreports.tests/bugreports-tests/IDEBUG_0198_StackOverflowInStructuralTyping.n4js.xt
+++ b/tests/org.eclipse.n4js.bugreports.tests/bugreports-tests/IDEBUG_0198_StackOverflowInStructuralTyping.n4js.xt
@@ -14,9 +14,6 @@
 // IDEBUG-198
 
 
-// stripped-down version of some fabelhaft/stdlib code:
-
-
 interface ~Element {
     public querySelector(selector : string) : Element;
 }

--- a/tests/org.eclipse.n4js.flowgraphs.ui.tests/model/react/index.n4jsd
+++ b/tests/org.eclipse.n4js.flowgraphs.ui.tests/model/react/index.n4jsd
@@ -16,177 +16,36 @@ export external public abstract class Element {
 export external public interface ~ComponentProps {
     public children?: Array<Element>;
     public ref?: {function(Object /* node */): void};
-    // Attention: Beware that you can't read/rely on the key property when rendering, see https://facebook.github.io/react/docs/lists-and-keys.html
     public key?: string;
 }
 
 export external public abstract class Component<PropsT extends ComponentProps, StateT extends Object> {
     public get props(): PropsT;
     public state: StateT;
-
     public context: Object+;
     public get refs(): Object+;
     public static name: Object+;
-
     public abstract render(): Element;
-
-    /**
-     * Base class helpers for the updating state of a component.
-     */
     @CovariantConstructor
     public constructor(props: PropsT);
-
-    /**
-     * Values in the mapping will be set on this.props if that prop is not specified by the parent component (i.e. using an in check).
-     * Be aware that any complex objects will be shared across instances, not copied.
-     */
     protected static defaultProps: Object;
-
-    /**
-     * The propTypes object allows you to validate props being passed to your components.
-     *
-     * @see http://facebook.github.io/react/docs/reusable-components.html
-     */
     protected static propTypes: Object;
-
-    /**
-     * Forces an update. This should only be invoked when it is known with
-     * certainty that we are **not** in a DOM transaction.
-     *
-     * You may want to call this when you know that some deeper aspect of the
-     * component's state has changed but `setState` was not called.
-     *
-     * This will not invoke `shouldUpdateComponent`, but it will invoke
-     * `componentWillUpdate` and `componentDidUpdate`.
-     *
-     * @param callback - Called after update is complete.
-     */
     @Final protected forceUpdate(callback: Function =): void;
-
-    /**
-     * Sets a subset of the state. Always use this to mutate
-     * state. You should treat `this.state` as immutable.
-     *
-     * There is no guarantee that `this.state` will be immediately updated, so
-     * accessing `this.state` after calling this method may return the old value.
-     *
-     * There is no guarantee that calls to `setState` will run synchronously,
-     * as they may eventually be batched together.  You can provide an optional
-     * callback that will be executed when the call to setState is actually
-     * completed.
-     *
-     * When a function is provided to setState, it will be called at some point in
-     * the future (not synchronously). It will be called with the up to date
-     * component arguments (state, props, context). These values can be different
-     * from this.* because your function may be called after receiveProps but before
-     * shouldComponentUpdate, and this new state, props, and context will not yet be
-     * assigned to this.
-     *
-     * @param {object|function} partialState Next partial state or function to
-     *        produce next partial state to be merged with current state.
-     * @param {?function} callback Called after state is updated.
-     * @final
-     * @protected
-     */
     public setState(partialState: union{Object /* subset of StateT */, {function(state: Object /* subset of StateT */, props: PropsT, context: Object): void}}, callback: Function =): void;
-
-    /**
-     * Returns true if the component is rendered into the DOM, false otherwise.
-     * You can use this method to guard asynchronous calls to setState() or forceUpdate().
-     */
     public isMounted(): boolean;
-
-    //
-    // Lifecycle Methods:
-    //
-
-    /**
-     * Invoked once, both on the client and server, immediately before the initial rendering occurs.
-     * If you call setState within this method, render() will see the updated state and will be executed only once despite the state change.
-     */
     protected componentWillMount(): void;
-
-    /**
-     * Invoked once, only on the client (not on the server), immediately after the initial rendering occurs.
-     * At this point in the lifecycle, the component has a DOM representation which you can access via R.findDOMNode().
-     * If you want to integrate with other JavaScript frameworks, set timers using setTimeout or setInterval, or send AJAX requests, perform those operations in this method.
-     */
     protected componentDidMount(): void;
-
-    /**
-     * Invoked when a component is receiving new props.
-     * This method is not called for the initial render.
-     *
-     * Use this as an opportunity to react to a prop transition before render() is called by updating the state using this.setState().
-     * The old props can be accessed via this.props. Calling this.setState() within this function will not trigger an additional render.
-     *
-     * dbo TODO react deprecated?
-     */
     protected componentWillReceiveProps(nextProps: Object): void;
-
-    /**
-     * Invoked before rendering when new props or state are being received.
-     * This method is not called for the initial render or when forceUpdate is used.
-     *
-     * Use this as an opportunity to return false when you're certain that the transition to the new props and state will not require a component update.
-     *
-     * <pre>
-     * @Override boolean shouldComponentUpdate(Object nextProps, ObjectnextState) {
-     *     return nextProps.id !== this.props.id;
-     * }
-     *
-     * If shouldComponentUpdate returns false, then render() will be completely skipped until the next state change.
-     * (In addition, componentWillUpdate and componentDidUpdate will not be called.)
-     *
-     * By default, shouldComponentUpdate always returns true to prevent subtle bugs when state is mutated in place,
-     * but if you are careful to always treat state as immutable and to read only from props and state in render() then
-     * you can override shouldComponentUpdate with an implementation that compares the old props and state to their replacements.
-     *
-     * If performance is a bottleneck, especially with dozens or hundreds of components, use shouldComponentUpdate to speed up your app.
-     */
     protected shouldComponentUpdate(nextProps: PropsT, nextState: StateT): boolean;
-
-    /**
-     * Invoked immediately before rendering when new props or state are being received.
-     * This method is not called for the initial render.
-     *
-     * Use this as an opportunity to perform preparation before an update occurs.
-     *
-     * Note:
-     * You cannot use this.setState() in this method.
-     * If you need to update state in response to a prop change, use componentWillReceiveProps instead.
-     */
     protected componentWillUpdate(nextProps: PropsT, nextState: StateT): void;
-
-    /**
-     * Invoked immediately after the component's updates are flushed to the DOM.
-     * This method is not called for the initial render.
-     *
-     * Use this as an opportunity to operate on the DOM when the component has been updated.
-     */
     protected componentDidUpdate(prevProps: PropsT, prevState: StateT): void;
-
-    /**
-     * Invoked immediately before a component is unmounted from the DOM.
-     *
-     * Perform any necessary cleanup in this method, such as invalidating timers or
-     * cleaning up any DOM Elements that were created in componentDidMount.
-     */
     protected componentWillUnmount(): void;
 }
 
-/**
- * React.PureComponent is exactly like React.Component but implements shouldComponentUpdate() with a shallow prop and state comparison.
- */
 export external public abstract class PureComponent<PropsT extends ComponentProps, StateT extends Object>
         extends Component<PropsT, StateT> {
 }
 
-/**
- * Create and return a new Element of the given type.
- * The type argument can be either an html tag name string (eg. 'div', 'span', etc),
- * or a ReactClass.
- */
 // mor TODO IDE-2323
 //    public static <PropsT extends ComponentProps> createElement(
 //        type: union{string, {function(PropsT?): Element}, constructor{Component<PropsT, ?>}},
@@ -196,39 +55,13 @@ export external public function createElement(
     props: Object =,
     ...children: union{string, Element, Array<Element>}): Element;
 
-/**
- * Clone and return a new Element using Element as the starting point.
- * The resulting Element will have the original Element's props with the new props merged in shallowly.
- * New children will replace existing children.
- * Unlike R.addons.cloneWithProps, key and ref from the original Element will be preserved.
- * There is no special behavior for merging any props (unlike cloneWithProps).
- */
 export external public function cloneElement(
     Element: Element,
     props: Object =,
     ...children: union{string, Element, Array<Element>}): Element;
 
-/**
- * Verifies the object is an Element.
- */
 export external public function isValidElement(object: Object): boolean;
-
-/**
- * Render a Element to its initial HTML. This should only be used on the server.
- * React will return an HTML string.
- * You can use this method to generate HTML on the server and send the markup down on the initial
- * request for faster page loads and to allow search engines to crawl your pages for SEO purposes.
- * If you call R.render() on a node that already has this server-rendered markup,
- * React will preserve it and only attach event handlers, allowing you to have a very performant first-load experience.
- */
 export external public function renderToString(Element: Element): string;
-
-/**
- * Similar to renderToString, except this doesn't create extra DOM attributes such as data-react-id,
- * that React uses internally.
- * This is useful if you want to use React as a simple static page generator, as stripping away the
- * extra attributes can save lots of bytes.
- */
 export external public function renderToStaticMarkup(Element: Element): string;
 
 export external public interface ~PropConstraint {
@@ -236,46 +69,19 @@ export external public interface ~PropConstraint {
 }
 export external public interface ~PropType extends PropConstraint {}
 
-/**
- * R.PropTypes includes types that can be used with a component's propTypes object to validate
- * props being passed to your components.
- *
- * @see http://facebook.github.io/react/docs/reusable-components.html
- */
 export external public class ~PropTypes {
-    // You can declare that a prop is a specific JS primitive. By default, these
-    // are all optional.
     public const array: PropType;
     public const bool: PropType;
     public const func: PropType;
     public const number: PropType;
     public const object: PropType;
     public const string: PropType;
-
-    // Anything that can be rendered: numbers, strings, Elements or an array
-    // containing these types.
     public const node: PropType;
-
-    // A React Element.
     public const Element: PropType;
-
-    // You can also declare that a prop is an instance of a class. This uses
-    // JS's instanceof operator.
     public static instanceOf(comp: Object): PropConstraint;
-
-    // You can ensure that your prop is limited to specific values by treating
-    // it as an enum.
     public static oneOf(...values: any): PropConstraint;
-
-    // An object that could be one of many types
     public static oneOfType(...constraints: PropConstraint): PropConstraint;
-
-    // An array of a certain type
     public static arrayOf(elemType: PropType): PropConstraint;
-
-    // An object with property values of a certain type
     public static objectOf(valueType: PropType): PropConstraint;
-
-    // An object taking on a particular shape
     public static shape(Object): PropConstraint;
 }

--- a/tests/org.eclipse.n4js.hlc.tests/probands/n4jsx/P3/src/react/index.n4jsd
+++ b/tests/org.eclipse.n4js.hlc.tests/probands/n4jsx/P3/src/react/index.n4jsd
@@ -16,177 +16,36 @@ export external public abstract class Element {
 export external public interface ~ComponentProps {
     public children?: Array<Element>;
     public ref?: {function(Object /* node */): void};
-    // Attention: Beware that you can't read/rely on the key property when rendering, see https://facebook.github.io/react/docs/lists-and-keys.html
     public key?: string;
 }
 
 export external public abstract class Component<PropsT extends ComponentProps, StateT extends Object> {
     public get props(): PropsT;
     public state: StateT;
-
     public context: Object+;
     public get refs(): Object+;
     public static name: Object+;
-
     public abstract render(): Element;
-
-    /**
-     * Base class helpers for the updating state of a component.
-     */
     @CovariantConstructor
     public constructor(props: PropsT);
-
-    /**
-     * Values in the mapping will be set on this.props if that prop is not specified by the parent component (i.e. using an in check).
-     * Be aware that any complex objects will be shared across instances, not copied.
-     */
     protected static defaultProps: Object;
-
-    /**
-     * The propTypes object allows you to validate props being passed to your components.
-     *
-     * @see http://facebook.github.io/react/docs/reusable-components.html
-     */
     protected static propTypes: Object;
-
-    /**
-     * Forces an update. This should only be invoked when it is known with
-     * certainty that we are **not** in a DOM transaction.
-     *
-     * You may want to call this when you know that some deeper aspect of the
-     * component's state has changed but `setState` was not called.
-     *
-     * This will not invoke `shouldUpdateComponent`, but it will invoke
-     * `componentWillUpdate` and `componentDidUpdate`.
-     *
-     * @param callback - Called after update is complete.
-     */
     @Final protected forceUpdate(callback: Function =): void;
-
-    /**
-     * Sets a subset of the state. Always use this to mutate
-     * state. You should treat `this.state` as immutable.
-     *
-     * There is no guarantee that `this.state` will be immediately updated, so
-     * accessing `this.state` after calling this method may return the old value.
-     *
-     * There is no guarantee that calls to `setState` will run synchronously,
-     * as they may eventually be batched together.  You can provide an optional
-     * callback that will be executed when the call to setState is actually
-     * completed.
-     *
-     * When a function is provided to setState, it will be called at some point in
-     * the future (not synchronously). It will be called with the up to date
-     * component arguments (state, props, context). These values can be different
-     * from this.* because your function may be called after receiveProps but before
-     * shouldComponentUpdate, and this new state, props, and context will not yet be
-     * assigned to this.
-     *
-     * @param {object|function} partialState Next partial state or function to
-     *        produce next partial state to be merged with current state.
-     * @param {?function} callback Called after state is updated.
-     * @final
-     * @protected
-     */
     public setState(partialState: union{Object /* subset of StateT */, {function(state: Object /* subset of StateT */, props: PropsT, context: Object): void}}, callback: Function =): void;
-
-    /**
-     * Returns true if the component is rendered into the DOM, false otherwise.
-     * You can use this method to guard asynchronous calls to setState() or forceUpdate().
-     */
     public isMounted(): boolean;
-
-    //
-    // Lifecycle Methods:
-    //
-
-    /**
-     * Invoked once, both on the client and server, immediately before the initial rendering occurs.
-     * If you call setState within this method, render() will see the updated state and will be executed only once despite the state change.
-     */
     protected componentWillMount(): void;
-
-    /**
-     * Invoked once, only on the client (not on the server), immediately after the initial rendering occurs.
-     * At this point in the lifecycle, the component has a DOM representation which you can access via R.findDOMNode().
-     * If you want to integrate with other JavaScript frameworks, set timers using setTimeout or setInterval, or send AJAX requests, perform those operations in this method.
-     */
     protected componentDidMount(): void;
-
-    /**
-     * Invoked when a component is receiving new props.
-     * This method is not called for the initial render.
-     *
-     * Use this as an opportunity to react to a prop transition before render() is called by updating the state using this.setState().
-     * The old props can be accessed via this.props. Calling this.setState() within this function will not trigger an additional render.
-     *
-     * dbo TODO react deprecated?
-     */
     protected componentWillReceiveProps(nextProps: Object): void;
-
-    /**
-     * Invoked before rendering when new props or state are being received.
-     * This method is not called for the initial render or when forceUpdate is used.
-     *
-     * Use this as an opportunity to return false when you're certain that the transition to the new props and state will not require a component update.
-     *
-     * <pre>
-     * @Override boolean shouldComponentUpdate(Object nextProps, ObjectnextState) {
-     *     return nextProps.id !== this.props.id;
-     * }
-     *
-     * If shouldComponentUpdate returns false, then render() will be completely skipped until the next state change.
-     * (In addition, componentWillUpdate and componentDidUpdate will not be called.)
-     *
-     * By default, shouldComponentUpdate always returns true to prevent subtle bugs when state is mutated in place,
-     * but if you are careful to always treat state as immutable and to read only from props and state in render() then
-     * you can override shouldComponentUpdate with an implementation that compares the old props and state to their replacements.
-     *
-     * If performance is a bottleneck, especially with dozens or hundreds of components, use shouldComponentUpdate to speed up your app.
-     */
     protected shouldComponentUpdate(nextProps: PropsT, nextState: StateT): boolean;
-
-    /**
-     * Invoked immediately before rendering when new props or state are being received.
-     * This method is not called for the initial render.
-     *
-     * Use this as an opportunity to perform preparation before an update occurs.
-     *
-     * Note:
-     * You cannot use this.setState() in this method.
-     * If you need to update state in response to a prop change, use componentWillReceiveProps instead.
-     */
     protected componentWillUpdate(nextProps: PropsT, nextState: StateT): void;
-
-    /**
-     * Invoked immediately after the component's updates are flushed to the DOM.
-     * This method is not called for the initial render.
-     *
-     * Use this as an opportunity to operate on the DOM when the component has been updated.
-     */
     protected componentDidUpdate(prevProps: PropsT, prevState: StateT): void;
-
-    /**
-     * Invoked immediately before a component is unmounted from the DOM.
-     *
-     * Perform any necessary cleanup in this method, such as invalidating timers or
-     * cleaning up any DOM Elements that were created in componentDidMount.
-     */
     protected componentWillUnmount(): void;
 }
 
-/**
- * React.PureComponent is exactly like React.Component but implements shouldComponentUpdate() with a shallow prop and state comparison.
- */
 export external public abstract class PureComponent<PropsT extends ComponentProps, StateT extends Object>
         extends Component<PropsT, StateT> {
 }
 
-/**
- * Create and return a new Element of the given type.
- * The type argument can be either an html tag name string (eg. 'div', 'span', etc),
- * or a ReactClass.
- */
 // mor TODO IDE-2323
 //    public static <PropsT extends ComponentProps> createElement(
 //        type: union{string, {function(PropsT?): Element}, constructor{Component<PropsT, ?>}},
@@ -196,39 +55,13 @@ export external public function createElement(
     props: Object =,
     ...children: union{string, Element, Array<Element>}): Element;
 
-/**
- * Clone and return a new Element using Element as the starting point.
- * The resulting Element will have the original Element's props with the new props merged in shallowly.
- * New children will replace existing children.
- * Unlike R.addons.cloneWithProps, key and ref from the original Element will be preserved.
- * There is no special behavior for merging any props (unlike cloneWithProps).
- */
 export external public function cloneElement(
     Element: Element,
     props: Object =,
     ...children: union{string, Element, Array<Element>}): Element;
 
-/**
- * Verifies the object is an Element.
- */
 export external public function isValidElement(object: Object): boolean;
-
-/**
- * Render a Element to its initial HTML. This should only be used on the server.
- * React will return an HTML string.
- * You can use this method to generate HTML on the server and send the markup down on the initial
- * request for faster page loads and to allow search engines to crawl your pages for SEO purposes.
- * If you call R.render() on a node that already has this server-rendered markup,
- * React will preserve it and only attach event handlers, allowing you to have a very performant first-load experience.
- */
 export external public function renderToString(Element: Element): string;
-
-/**
- * Similar to renderToString, except this doesn't create extra DOM attributes such as data-react-id,
- * that React uses internally.
- * This is useful if you want to use React as a simple static page generator, as stripping away the
- * extra attributes can save lots of bytes.
- */
 export external public function renderToStaticMarkup(Element: Element): string;
 
 export external public interface ~PropConstraint {
@@ -236,46 +69,19 @@ export external public interface ~PropConstraint {
 }
 export external public interface ~PropType extends PropConstraint {}
 
-/**
- * R.PropTypes includes types that can be used with a component's propTypes object to validate
- * props being passed to your components.
- *
- * @see http://facebook.github.io/react/docs/reusable-components.html
- */
 export external public class ~PropTypes {
-    // You can declare that a prop is a specific JS primitive. By default, these
-    // are all optional.
     public const array: PropType;
     public const bool: PropType;
     public const func: PropType;
     public const number: PropType;
     public const object: PropType;
     public const string: PropType;
-
-    // Anything that can be rendered: numbers, strings, Elements or an array
-    // containing these types.
     public const node: PropType;
-
-    // A React Element.
     public const Element: PropType;
-
-    // You can also declare that a prop is an instance of a class. This uses
-    // JS's instanceof operator.
     public static instanceOf(comp: Object): PropConstraint;
-
-    // You can ensure that your prop is limited to specific values by treating
-    // it as an enum.
     public static oneOf(...values: any): PropConstraint;
-
-    // An object that could be one of many types
     public static oneOfType(...constraints: PropConstraint): PropConstraint;
-
-    // An array of a certain type
     public static arrayOf(elemType: PropType): PropConstraint;
-
-    // An object with property values of a certain type
     public static objectOf(valueType: PropType): PropConstraint;
-
-    // An object taking on a particular shape
     public static shape(Object): PropConstraint;
 }

--- a/tests/org.eclipse.n4js.hlc.tests/probands/n4jsx/react/index.n4jsd
+++ b/tests/org.eclipse.n4js.hlc.tests/probands/n4jsx/react/index.n4jsd
@@ -16,177 +16,36 @@ export external public abstract class Element {
 export external public interface ~ComponentProps {
     public children?: Array<Element>;
     public ref?: {function(Object /* node */): void};
-    // Attention: Beware that you can't read/rely on the key property when rendering, see https://facebook.github.io/react/docs/lists-and-keys.html
     public key?: string;
 }
 
 export external public abstract class Component<PropsT extends ComponentProps, StateT extends Object> {
     public get props(): PropsT;
     public state: StateT;
-
     public context: Object+;
     public get refs(): Object+;
     public static name: Object+;
-
     public abstract render(): Element;
-
-    /**
-     * Base class helpers for the updating state of a component.
-     */
     @CovariantConstructor
     public constructor(props: PropsT);
-
-    /**
-     * Values in the mapping will be set on this.props if that prop is not specified by the parent component (i.e. using an in check).
-     * Be aware that any complex objects will be shared across instances, not copied.
-     */
     protected static defaultProps: Object;
-
-    /**
-     * The propTypes object allows you to validate props being passed to your components.
-     *
-     * @see http://facebook.github.io/react/docs/reusable-components.html
-     */
     protected static propTypes: Object;
-
-    /**
-     * Forces an update. This should only be invoked when it is known with
-     * certainty that we are **not** in a DOM transaction.
-     *
-     * You may want to call this when you know that some deeper aspect of the
-     * component's state has changed but `setState` was not called.
-     *
-     * This will not invoke `shouldUpdateComponent`, but it will invoke
-     * `componentWillUpdate` and `componentDidUpdate`.
-     *
-     * @param callback - Called after update is complete.
-     */
     @Final protected forceUpdate(callback: Function =): void;
-
-    /**
-     * Sets a subset of the state. Always use this to mutate
-     * state. You should treat `this.state` as immutable.
-     *
-     * There is no guarantee that `this.state` will be immediately updated, so
-     * accessing `this.state` after calling this method may return the old value.
-     *
-     * There is no guarantee that calls to `setState` will run synchronously,
-     * as they may eventually be batched together.  You can provide an optional
-     * callback that will be executed when the call to setState is actually
-     * completed.
-     *
-     * When a function is provided to setState, it will be called at some point in
-     * the future (not synchronously). It will be called with the up to date
-     * component arguments (state, props, context). These values can be different
-     * from this.* because your function may be called after receiveProps but before
-     * shouldComponentUpdate, and this new state, props, and context will not yet be
-     * assigned to this.
-     *
-     * @param {object|function} partialState Next partial state or function to
-     *        produce next partial state to be merged with current state.
-     * @param {?function} callback Called after state is updated.
-     * @final
-     * @protected
-     */
     public setState(partialState: union{Object /* subset of StateT */, {function(state: Object /* subset of StateT */, props: PropsT, context: Object): void}}, callback: Function =): void;
-
-    /**
-     * Returns true if the component is rendered into the DOM, false otherwise.
-     * You can use this method to guard asynchronous calls to setState() or forceUpdate().
-     */
     public isMounted(): boolean;
-
-    //
-    // Lifecycle Methods:
-    //
-
-    /**
-     * Invoked once, both on the client and server, immediately before the initial rendering occurs.
-     * If you call setState within this method, render() will see the updated state and will be executed only once despite the state change.
-     */
     protected componentWillMount(): void;
-
-    /**
-     * Invoked once, only on the client (not on the server), immediately after the initial rendering occurs.
-     * At this point in the lifecycle, the component has a DOM representation which you can access via R.findDOMNode().
-     * If you want to integrate with other JavaScript frameworks, set timers using setTimeout or setInterval, or send AJAX requests, perform those operations in this method.
-     */
     protected componentDidMount(): void;
-
-    /**
-     * Invoked when a component is receiving new props.
-     * This method is not called for the initial render.
-     *
-     * Use this as an opportunity to react to a prop transition before render() is called by updating the state using this.setState().
-     * The old props can be accessed via this.props. Calling this.setState() within this function will not trigger an additional render.
-     *
-     * dbo TODO react deprecated?
-     */
     protected componentWillReceiveProps(nextProps: Object): void;
-
-    /**
-     * Invoked before rendering when new props or state are being received.
-     * This method is not called for the initial render or when forceUpdate is used.
-     *
-     * Use this as an opportunity to return false when you're certain that the transition to the new props and state will not require a component update.
-     *
-     * <pre>
-     * @Override boolean shouldComponentUpdate(Object nextProps, ObjectnextState) {
-     *     return nextProps.id !== this.props.id;
-     * }
-     *
-     * If shouldComponentUpdate returns false, then render() will be completely skipped until the next state change.
-     * (In addition, componentWillUpdate and componentDidUpdate will not be called.)
-     *
-     * By default, shouldComponentUpdate always returns true to prevent subtle bugs when state is mutated in place,
-     * but if you are careful to always treat state as immutable and to read only from props and state in render() then
-     * you can override shouldComponentUpdate with an implementation that compares the old props and state to their replacements.
-     *
-     * If performance is a bottleneck, especially with dozens or hundreds of components, use shouldComponentUpdate to speed up your app.
-     */
     protected shouldComponentUpdate(nextProps: PropsT, nextState: StateT): boolean;
-
-    /**
-     * Invoked immediately before rendering when new props or state are being received.
-     * This method is not called for the initial render.
-     *
-     * Use this as an opportunity to perform preparation before an update occurs.
-     *
-     * Note:
-     * You cannot use this.setState() in this method.
-     * If you need to update state in response to a prop change, use componentWillReceiveProps instead.
-     */
     protected componentWillUpdate(nextProps: PropsT, nextState: StateT): void;
-
-    /**
-     * Invoked immediately after the component's updates are flushed to the DOM.
-     * This method is not called for the initial render.
-     *
-     * Use this as an opportunity to operate on the DOM when the component has been updated.
-     */
     protected componentDidUpdate(prevProps: PropsT, prevState: StateT): void;
-
-    /**
-     * Invoked immediately before a component is unmounted from the DOM.
-     *
-     * Perform any necessary cleanup in this method, such as invalidating timers or
-     * cleaning up any DOM Elements that were created in componentDidMount.
-     */
     protected componentWillUnmount(): void;
 }
 
-/**
- * React.PureComponent is exactly like React.Component but implements shouldComponentUpdate() with a shallow prop and state comparison.
- */
 export external public abstract class PureComponent<PropsT extends ComponentProps, StateT extends Object>
         extends Component<PropsT, StateT> {
 }
 
-/**
- * Create and return a new Element of the given type.
- * The type argument can be either an html tag name string (eg. 'div', 'span', etc),
- * or a ReactClass.
- */
 // mor TODO IDE-2323
 //    public static <PropsT extends ComponentProps> createElement(
 //        type: union{string, {function(PropsT?): Element}, constructor{Component<PropsT, ?>}},
@@ -196,39 +55,13 @@ export external public function createElement(
     props: Object =,
     ...children: union{string, Element, Array<Element>}): Element;
 
-/**
- * Clone and return a new Element using Element as the starting point.
- * The resulting Element will have the original Element's props with the new props merged in shallowly.
- * New children will replace existing children.
- * Unlike R.addons.cloneWithProps, key and ref from the original Element will be preserved.
- * There is no special behavior for merging any props (unlike cloneWithProps).
- */
 export external public function cloneElement(
     Element: Element,
     props: Object =,
     ...children: union{string, Element, Array<Element>}): Element;
 
-/**
- * Verifies the object is an Element.
- */
 export external public function isValidElement(object: Object): boolean;
-
-/**
- * Render a Element to its initial HTML. This should only be used on the server.
- * React will return an HTML string.
- * You can use this method to generate HTML on the server and send the markup down on the initial
- * request for faster page loads and to allow search engines to crawl your pages for SEO purposes.
- * If you call R.render() on a node that already has this server-rendered markup,
- * React will preserve it and only attach event handlers, allowing you to have a very performant first-load experience.
- */
 export external public function renderToString(Element: Element): string;
-
-/**
- * Similar to renderToString, except this doesn't create extra DOM attributes such as data-react-id,
- * that React uses internally.
- * This is useful if you want to use React as a simple static page generator, as stripping away the
- * extra attributes can save lots of bytes.
- */
 export external public function renderToStaticMarkup(Element: Element): string;
 
 export external public interface ~PropConstraint {
@@ -236,47 +69,19 @@ export external public interface ~PropConstraint {
 }
 export external public interface ~PropType extends PropConstraint {}
 
-/**
- * R.PropTypes includes types that can be used with a component's propTypes object to validate
- * props being passed to your components.
- *
- * @see http://facebook.github.io/react/docs/reusable-components.html
- */
 export external public class ~PropTypes {
-    // You can declare that a prop is a specific JS primitive. By default, these
-    // are all optional.
     public const array: PropType;
     public const bool: PropType;
     public const func: PropType;
     public const number: PropType;
     public const object: PropType;
     public const string: PropType;
-
-    // Anything that can be rendered: numbers, strings, Elements or an array
-    // containing these types.
     public const node: PropType;
-
-    // A React Element.
     public const Element: PropType;
-
-    // You can also declare that a prop is an instance of a class. This uses
-    // JS's instanceof operator.
     public static instanceOf(comp: Object): PropConstraint;
-
-    // You can ensure that your prop is limited to specific values by treating
-    // it as an enum.
     public static oneOf(...values: any): PropConstraint;
-
-    // An object that could be one of many types
     public static oneOfType(...constraints: PropConstraint): PropConstraint;
-
-    // An array of a certain type
     public static arrayOf(elemType: PropType): PropConstraint;
-
-    // An object with property values of a certain type
     public static objectOf(valueType: PropType): PropConstraint;
-
-    // An object taking on a particular shape
     public static shape(Object): PropConstraint;
 }
-

--- a/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/scoping/InfiniteRecursionTest.xtend
+++ b/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/scoping/InfiniteRecursionTest.xtend
@@ -40,7 +40,7 @@ class InfiniteRecursionTest {
 			    Frame = require("n4/lupenrein_js/uirobot/Frame");
 			var TestApi = require("n4/lupenrein_js/TestAPI");
 			var LAYERS_PAGE = "?n4-load=devel&n4-nologin&n4-noanim#WebTeamTest/layers";
-			var FABELHAFT_PAGE = "?n4-load=devel&n4-nologin&n4-noanim#n4/newsfeed";
+			var SOME_PAGE = "?n4-load=devel&n4-nologin&n4-noanim#n4/newsfeed";
 			/**
 			 * @Category LT
 			 * @Timeout 999000
@@ -64,8 +64,8 @@ class InfiniteRecursionTest {
 			            var t = this.bot;
 
 			            Promise.when(null).then(function () {
-			                t.openPage(FABELHAFT_PAGE);
-			                return t.waitFor(".appl-middlepane", [['is', ':visible']], true, undefined, "waiting for fabelhaft page view failed", 555 * 1000, 1 * 1000);
+			                t.openPage(SOME_PAGE);
+			                return t.waitFor(".appl-middlepane", [['is', ':visible']], true, undefined, "waiting for some page view failed", 555 * 1000, 1 * 1000);
 			            }).then(function () {
 			                t.delay(7 * 1000);
 			                t.openPage(LAYERS_PAGE);

--- a/tests/org.eclipse.n4js.n4jsx.spec.ui.tests/xpectTests/react/index.n4jsd
+++ b/tests/org.eclipse.n4js.n4jsx.spec.ui.tests/xpectTests/react/index.n4jsd
@@ -11,186 +11,41 @@
 
 export external public abstract class Element {
     private constructor();
-    public get type(): union{string, constructor{Component}};
-    public get props(): PropsT;
-    public get key(): string;
-    public get ref(): string;
 };
 
 export external public interface ~ComponentProps {
     public children?: Array<Element>;
     public ref?: {function(Object /* node */): void};
-    // Attention: Beware that you can't read/rely on the key property when rendering, see https://facebook.github.io/react/docs/lists-and-keys.html
     public key?: string;
 }
 
 export external public abstract class Component<PropsT extends ComponentProps, StateT extends Object> {
     public get props(): PropsT;
     public state: StateT;
-
     public context: Object+;
     public get refs(): Object+;
     public static name: Object+;
-
     public abstract render(): Element;
-
-    /**
-     * Base class helpers for the updating state of a component.
-     */
     @CovariantConstructor
     public constructor(props: PropsT);
-
-    /**
-     * Values in the mapping will be set on this.props if that prop is not specified by the parent component (i.e. using an in check).
-     * Be aware that any complex objects will be shared across instances, not copied.
-     */
     protected static defaultProps: Object;
-
-    /**
-     * The propTypes object allows you to validate props being passed to your components.
-     *
-     * @see http://facebook.github.io/react/docs/reusable-components.html
-     */
     protected static propTypes: Object;
-
-    /**
-     * Forces an update. This should only be invoked when it is known with
-     * certainty that we are **not** in a DOM transaction.
-     *
-     * You may want to call this when you know that some deeper aspect of the
-     * component's state has changed but `setState` was not called.
-     *
-     * This will not invoke `shouldUpdateComponent`, but it will invoke
-     * `componentWillUpdate` and `componentDidUpdate`.
-     *
-     * @param callback - Called after update is complete.
-     */
     @Final protected forceUpdate(callback: Function =): void;
-
-    /**
-     * Sets a subset of the state. Always use this to mutate
-     * state. You should treat `this.state` as immutable.
-     *
-     * There is no guarantee that `this.state` will be immediately updated, so
-     * accessing `this.state` after calling this method may return the old value.
-     *
-     * There is no guarantee that calls to `setState` will run synchronously,
-     * as they may eventually be batched together.  You can provide an optional
-     * callback that will be executed when the call to setState is actually
-     * completed.
-     *
-     * When a function is provided to setState, it will be called at some point in
-     * the future (not synchronously). It will be called with the up to date
-     * component arguments (state, props, context). These values can be different
-     * from this.* because your function may be called after receiveProps but before
-     * shouldComponentUpdate, and this new state, props, and context will not yet be
-     * assigned to this.
-     *
-     * @param {object|function} partialState Next partial state or function to
-     *        produce next partial state to be merged with current state.
-     * @param {?function} callback Called after state is updated.
-     * @final
-     * @protected
-     */
     public setState(partialState: union{Object /* subset of StateT */, {function(state: Object /* subset of StateT */, props: PropsT, context: Object): void}}, callback: Function =): void;
-
-    /**
-     * Returns true if the component is rendered into the DOM, false otherwise.
-     * You can use this method to guard asynchronous calls to setState() or forceUpdate().
-     */
     public isMounted(): boolean;
-
-    //
-    // Lifecycle Methods:
-    //
-
-    /**
-     * Invoked once, both on the client and server, immediately before the initial rendering occurs.
-     * If you call setState within this method, render() will see the updated state and will be executed only once despite the state change.
-     */
     protected componentWillMount(): void;
-
-    /**
-     * Invoked once, only on the client (not on the server), immediately after the initial rendering occurs.
-     * At this point in the lifecycle, the component has a DOM representation which you can access via R.findDOMNode().
-     * If you want to integrate with other JavaScript frameworks, set timers using setTimeout or setInterval, or send AJAX requests, perform those operations in this method.
-     */
     protected componentDidMount(): void;
-
-    /**
-     * Invoked when a component is receiving new props.
-     * This method is not called for the initial render.
-     *
-     * Use this as an opportunity to react to a prop transition before render() is called by updating the state using this.setState().
-     * The old props can be accessed via this.props. Calling this.setState() within this function will not trigger an additional render.
-     *
-     * dbo TODO react deprecated?
-     */
     protected componentWillReceiveProps(nextProps: Object): void;
-
-    /**
-     * Invoked before rendering when new props or state are being received.
-     * This method is not called for the initial render or when forceUpdate is used.
-     *
-     * Use this as an opportunity to return false when you're certain that the transition to the new props and state will not require a component update.
-     *
-     * <pre>
-     * @Override boolean shouldComponentUpdate(Object nextProps, ObjectnextState) {
-     *     return nextProps.id !== this.props.id;
-     * }
-     *
-     * If shouldComponentUpdate returns false, then render() will be completely skipped until the next state change.
-     * (In addition, componentWillUpdate and componentDidUpdate will not be called.)
-     *
-     * By default, shouldComponentUpdate always returns true to prevent subtle bugs when state is mutated in place,
-     * but if you are careful to always treat state as immutable and to read only from props and state in render() then
-     * you can override shouldComponentUpdate with an implementation that compares the old props and state to their replacements.
-     *
-     * If performance is a bottleneck, especially with dozens or hundreds of components, use shouldComponentUpdate to speed up your app.
-     */
     protected shouldComponentUpdate(nextProps: PropsT, nextState: StateT): boolean;
-
-    /**
-     * Invoked immediately before rendering when new props or state are being received.
-     * This method is not called for the initial render.
-     *
-     * Use this as an opportunity to perform preparation before an update occurs.
-     *
-     * Note:
-     * You cannot use this.setState() in this method.
-     * If you need to update state in response to a prop change, use componentWillReceiveProps instead.
-     */
     protected componentWillUpdate(nextProps: PropsT, nextState: StateT): void;
-
-    /**
-     * Invoked immediately after the component's updates are flushed to the DOM.
-     * This method is not called for the initial render.
-     *
-     * Use this as an opportunity to operate on the DOM when the component has been updated.
-     */
     protected componentDidUpdate(prevProps: PropsT, prevState: StateT): void;
-
-    /**
-     * Invoked immediately before a component is unmounted from the DOM.
-     *
-     * Perform any necessary cleanup in this method, such as invalidating timers or
-     * cleaning up any DOM Elements that were created in componentDidMount.
-     */
     protected componentWillUnmount(): void;
 }
 
-/**
- * React.PureComponent is exactly like React.Component but implements shouldComponentUpdate() with a shallow prop and state comparison.
- */
 export external public abstract class PureComponent<PropsT extends ComponentProps, StateT extends Object>
         extends Component<PropsT, StateT> {
 }
 
-/**
- * Create and return a new Element of the given type.
- * The type argument can be either an html tag name string (eg. 'div', 'span', etc),
- * or a ReactClass.
- */
 // mor TODO IDE-2323
 //    public static <PropsT extends ComponentProps> createElement(
 //        type: union{string, {function(PropsT?): Element}, constructor{Component<PropsT, ?>}},
@@ -200,39 +55,13 @@ export external public function createElement(
     props: Object =,
     ...children: union{string, Element, Array<Element>}): Element;
 
-/**
- * Clone and return a new Element using Element as the starting point.
- * The resulting Element will have the original Element's props with the new props merged in shallowly.
- * New children will replace existing children.
- * Unlike R.addons.cloneWithProps, key and ref from the original Element will be preserved.
- * There is no special behavior for merging any props (unlike cloneWithProps).
- */
 export external public function cloneElement(
     Element: Element,
     props: Object =,
     ...children: union{string, Element, Array<Element>}): Element;
 
-/**
- * Verifies the object is an Element.
- */
 export external public function isValidElement(object: Object): boolean;
-
-/**
- * Render a Element to its initial HTML. This should only be used on the server.
- * React will return an HTML string.
- * You can use this method to generate HTML on the server and send the markup down on the initial
- * request for faster page loads and to allow search engines to crawl your pages for SEO purposes.
- * If you call R.render() on a node that already has this server-rendered markup,
- * React will preserve it and only attach event handlers, allowing you to have a very performant first-load experience.
- */
 export external public function renderToString(Element: Element): string;
-
-/**
- * Similar to renderToString, except this doesn't create extra DOM attributes such as data-react-id,
- * that React uses internally.
- * This is useful if you want to use React as a simple static page generator, as stripping away the
- * extra attributes can save lots of bytes.
- */
 export external public function renderToStaticMarkup(Element: Element): string;
 
 export external public interface ~PropConstraint {
@@ -240,46 +69,19 @@ export external public interface ~PropConstraint {
 }
 export external public interface ~PropType extends PropConstraint {}
 
-/**
- * R.PropTypes includes types that can be used with a component's propTypes object to validate
- * props being passed to your components.
- *
- * @see http://facebook.github.io/react/docs/reusable-components.html
- */
 export external public class ~PropTypes {
-    // You can declare that a prop is a specific JS primitive. By default, these
-    // are all optional.
     public const array: PropType;
     public const bool: PropType;
     public const func: PropType;
     public const number: PropType;
     public const object: PropType;
     public const string: PropType;
-
-    // Anything that can be rendered: numbers, strings, Elements or an array
-    // containing these types.
     public const node: PropType;
-
-    // A React Element.
     public const Element: PropType;
-
-    // You can also declare that a prop is an instance of a class. This uses
-    // JS's instanceof operator.
     public static instanceOf(comp: Object): PropConstraint;
-
-    // You can ensure that your prop is limited to specific values by treating
-    // it as an enum.
     public static oneOf(...values: any): PropConstraint;
-
-    // An object that could be one of many types
     public static oneOfType(...constraints: PropConstraint): PropConstraint;
-
-    // An array of a certain type
     public static arrayOf(elemType: PropType): PropConstraint;
-
-    // An object with property values of a certain type
     public static objectOf(valueType: PropType): PropConstraint;
-
-    // An object taking on a particular shape
     public static shape(Object): PropConstraint;
 }

--- a/tests/org.eclipse.n4js.n4jsx.xpect.ui.tests/react-implementations/valid/index.n4jsd
+++ b/tests/org.eclipse.n4js.n4jsx.xpect.ui.tests/react-implementations/valid/index.n4jsd
@@ -16,177 +16,36 @@ export external public abstract class Element {
 export external public interface ~ComponentProps {
     public children?: Array<Element>;
     public ref?: {function(Object /* node */): void};
-    // Attention: Beware that you can't read/rely on the key property when rendering, see https://facebook.github.io/react/docs/lists-and-keys.html
     public key?: string;
 }
 
 export external public abstract class Component<PropsT extends ComponentProps, StateT extends Object> {
     public get props(): PropsT;
     public state: StateT;
-
     public context: Object+;
     public get refs(): Object+;
     public static name: Object+;
-
     public abstract render(): Element;
-
-    /**
-     * Base class helpers for the updating state of a component.
-     */
     @CovariantConstructor
     public constructor(props: PropsT);
-
-    /**
-     * Values in the mapping will be set on this.props if that prop is not specified by the parent component (i.e. using an in check).
-     * Be aware that any complex objects will be shared across instances, not copied.
-     */
     protected static defaultProps: Object;
-
-    /**
-     * The propTypes object allows you to validate props being passed to your components.
-     *
-     * @see http://facebook.github.io/react/docs/reusable-components.html
-     */
     protected static propTypes: Object;
-
-    /**
-     * Forces an update. This should only be invoked when it is known with
-     * certainty that we are **not** in a DOM transaction.
-     *
-     * You may want to call this when you know that some deeper aspect of the
-     * component's state has changed but `setState` was not called.
-     *
-     * This will not invoke `shouldUpdateComponent`, but it will invoke
-     * `componentWillUpdate` and `componentDidUpdate`.
-     *
-     * @param callback - Called after update is complete.
-     */
     @Final protected forceUpdate(callback: Function =): void;
-
-    /**
-     * Sets a subset of the state. Always use this to mutate
-     * state. You should treat `this.state` as immutable.
-     *
-     * There is no guarantee that `this.state` will be immediately updated, so
-     * accessing `this.state` after calling this method may return the old value.
-     *
-     * There is no guarantee that calls to `setState` will run synchronously,
-     * as they may eventually be batched together.  You can provide an optional
-     * callback that will be executed when the call to setState is actually
-     * completed.
-     *
-     * When a function is provided to setState, it will be called at some point in
-     * the future (not synchronously). It will be called with the up to date
-     * component arguments (state, props, context). These values can be different
-     * from this.* because your function may be called after receiveProps but before
-     * shouldComponentUpdate, and this new state, props, and context will not yet be
-     * assigned to this.
-     *
-     * @param {object|function} partialState Next partial state or function to
-     *        produce next partial state to be merged with current state.
-     * @param {?function} callback Called after state is updated.
-     * @final
-     * @protected
-     */
     public setState(partialState: union{Object /* subset of StateT */, {function(state: Object /* subset of StateT */, props: PropsT, context: Object): void}}, callback: Function =): void;
-
-    /**
-     * Returns true if the component is rendered into the DOM, false otherwise.
-     * You can use this method to guard asynchronous calls to setState() or forceUpdate().
-     */
     public isMounted(): boolean;
-
-    //
-    // Lifecycle Methods:
-    //
-
-    /**
-     * Invoked once, both on the client and server, immediately before the initial rendering occurs.
-     * If you call setState within this method, render() will see the updated state and will be executed only once despite the state change.
-     */
     protected componentWillMount(): void;
-
-    /**
-     * Invoked once, only on the client (not on the server), immediately after the initial rendering occurs.
-     * At this point in the lifecycle, the component has a DOM representation which you can access via R.findDOMNode().
-     * If you want to integrate with other JavaScript frameworks, set timers using setTimeout or setInterval, or send AJAX requests, perform those operations in this method.
-     */
     protected componentDidMount(): void;
-
-    /**
-     * Invoked when a component is receiving new props.
-     * This method is not called for the initial render.
-     *
-     * Use this as an opportunity to react to a prop transition before render() is called by updating the state using this.setState().
-     * The old props can be accessed via this.props. Calling this.setState() within this function will not trigger an additional render.
-     *
-     * dbo TODO react deprecated?
-     */
     protected componentWillReceiveProps(nextProps: Object): void;
-
-    /**
-     * Invoked before rendering when new props or state are being received.
-     * This method is not called for the initial render or when forceUpdate is used.
-     *
-     * Use this as an opportunity to return false when you're certain that the transition to the new props and state will not require a component update.
-     *
-     * <pre>
-     * @Override boolean shouldComponentUpdate(Object nextProps, ObjectnextState) {
-     *     return nextProps.id !== this.props.id;
-     * }
-     *
-     * If shouldComponentUpdate returns false, then render() will be completely skipped until the next state change.
-     * (In addition, componentWillUpdate and componentDidUpdate will not be called.)
-     *
-     * By default, shouldComponentUpdate always returns true to prevent subtle bugs when state is mutated in place,
-     * but if you are careful to always treat state as immutable and to read only from props and state in render() then
-     * you can override shouldComponentUpdate with an implementation that compares the old props and state to their replacements.
-     *
-     * If performance is a bottleneck, especially with dozens or hundreds of components, use shouldComponentUpdate to speed up your app.
-     */
     protected shouldComponentUpdate(nextProps: PropsT, nextState: StateT): boolean;
-
-    /**
-     * Invoked immediately before rendering when new props or state are being received.
-     * This method is not called for the initial render.
-     *
-     * Use this as an opportunity to perform preparation before an update occurs.
-     *
-     * Note:
-     * You cannot use this.setState() in this method.
-     * If you need to update state in response to a prop change, use componentWillReceiveProps instead.
-     */
     protected componentWillUpdate(nextProps: PropsT, nextState: StateT): void;
-
-    /**
-     * Invoked immediately after the component's updates are flushed to the DOM.
-     * This method is not called for the initial render.
-     *
-     * Use this as an opportunity to operate on the DOM when the component has been updated.
-     */
     protected componentDidUpdate(prevProps: PropsT, prevState: StateT): void;
-
-    /**
-     * Invoked immediately before a component is unmounted from the DOM.
-     *
-     * Perform any necessary cleanup in this method, such as invalidating timers or
-     * cleaning up any DOM Elements that were created in componentDidMount.
-     */
     protected componentWillUnmount(): void;
 }
 
-/**
- * React.PureComponent is exactly like React.Component but implements shouldComponentUpdate() with a shallow prop and state comparison.
- */
 export external public abstract class PureComponent<PropsT extends ComponentProps, StateT extends Object>
         extends Component<PropsT, StateT> {
 }
 
-/**
- * Create and return a new Element of the given type.
- * The type argument can be either an html tag name string (eg. 'div', 'span', etc),
- * or a ReactClass.
- */
 // mor TODO IDE-2323
 //    public static <PropsT extends ComponentProps> createElement(
 //        type: union{string, {function(PropsT?): Element}, constructor{Component<PropsT, ?>}},
@@ -196,39 +55,13 @@ export external public function createElement(
     props: Object =,
     ...children: union{string, Element, Array<Element>}): Element;
 
-/**
- * Clone and return a new Element using Element as the starting point.
- * The resulting Element will have the original Element's props with the new props merged in shallowly.
- * New children will replace existing children.
- * Unlike R.addons.cloneWithProps, key and ref from the original Element will be preserved.
- * There is no special behavior for merging any props (unlike cloneWithProps).
- */
 export external public function cloneElement(
     Element: Element,
     props: Object =,
     ...children: union{string, Element, Array<Element>}): Element;
 
-/**
- * Verifies the object is an Element.
- */
 export external public function isValidElement(object: Object): boolean;
-
-/**
- * Render a Element to its initial HTML. This should only be used on the server.
- * React will return an HTML string.
- * You can use this method to generate HTML on the server and send the markup down on the initial
- * request for faster page loads and to allow search engines to crawl your pages for SEO purposes.
- * If you call R.render() on a node that already has this server-rendered markup,
- * React will preserve it and only attach event handlers, allowing you to have a very performant first-load experience.
- */
 export external public function renderToString(Element: Element): string;
-
-/**
- * Similar to renderToString, except this doesn't create extra DOM attributes such as data-react-id,
- * that React uses internally.
- * This is useful if you want to use React as a simple static page generator, as stripping away the
- * extra attributes can save lots of bytes.
- */
 export external public function renderToStaticMarkup(Element: Element): string;
 
 export external public interface ~PropConstraint {
@@ -236,46 +69,19 @@ export external public interface ~PropConstraint {
 }
 export external public interface ~PropType extends PropConstraint {}
 
-/**
- * R.PropTypes includes types that can be used with a component's propTypes object to validate
- * props being passed to your components.
- *
- * @see http://facebook.github.io/react/docs/reusable-components.html
- */
 export external public class ~PropTypes {
-    // You can declare that a prop is a specific JS primitive. By default, these
-    // are all optional.
     public const array: PropType;
     public const bool: PropType;
     public const func: PropType;
     public const number: PropType;
     public const object: PropType;
     public const string: PropType;
-
-    // Anything that can be rendered: numbers, strings, Elements or an array
-    // containing these types.
     public const node: PropType;
-
-    // A React Element.
     public const Element: PropType;
-
-    // You can also declare that a prop is an instance of a class. This uses
-    // JS's instanceof operator.
     public static instanceOf(comp: Object): PropConstraint;
-
-    // You can ensure that your prop is limited to specific values by treating
-    // it as an enum.
     public static oneOf(...values: any): PropConstraint;
-
-    // An object that could be one of many types
     public static oneOfType(...constraints: PropConstraint): PropConstraint;
-
-    // An array of a certain type
     public static arrayOf(elemType: PropType): PropConstraint;
-
-    // An object with property values of a certain type
     public static objectOf(valueType: PropType): PropConstraint;
-
-    // An object taking on a particular shape
     public static shape(Object): PropConstraint;
 }

--- a/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch08_01_04_ArrayLiteral/ArrayLiteral_useCases.n4js.xt
+++ b/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch08_01_04_ArrayLiteral/ArrayLiteral_useCases.n4js.xt
@@ -13,7 +13,7 @@
 
 
 //
-// some tests for ArrayLiteral type inference derived from fabelhaft code:
+// some tests for ArrayLiteral type inference:
 //
 
 

--- a/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch08_01_05_ObjectLiteral/ObjectLiteral_performance.n4js.xt
+++ b/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch08_01_05_ObjectLiteral/ObjectLiteral_performance.n4js.xt
@@ -11,11 +11,6 @@
 
 /* XPECT_SETUP org.eclipse.n4js.spec.tests.N4JSSpecTest END_SETUP */
 
-//
-// real-world example from fabelhaft code
-// (taken from testConfig.n4js in eu.numberfour.fabelhaft.fntests.web)
-//
-
 export var testConfig : Object+ = {
 
 rootViewTemplates: {


### PR DESCRIPTION
#1238 

## "copied from"

When searching the N4JS repository for "copied from" string, approx. 100 results are returned. I checked these occurrences and identified some files actually copying code from other Eclipse projects not properly documented in the copyright header.

The following Java (or Xtend) files contain code copied from one of the following Eclipse projects:
xtext, jdt, emf, xtend, gef. Added name of original file, bundle and copyright remarks from original code.

- ComputeProjectOrder
- EclipseLogAppender
- MultiElementListSelectionDialog
- AbstractN4JSPreferencePage
- ActivationTrigger
- WizardNewProjectCreationPage
- JSONSTRINGValueConverter
- MyReferenceSearchResultContentProviderCustomModule
- N4JSBuilderPreferencePage
- N4JSCache
- N4JSDoubleClickStrategyProvider
- N4JSExternalReferenceChecker
- N4JSHover
- N4JSHyperlinkDetector
- N4JSIssue
- N4JSParseHelper
- N4JSResource
- N4JSResourceDescriptionDelta
- N4JSShowInheritedMembersOutlineContribution
- Rectangle
- RecursionGuard
- SemverResourceValidator
- TestResultsView
- ValueConverterUtils

The following files contain only copies of other code found in the N4JS project:

- 07_DiMetaForConstructors.n4js.xt
- ActivationTrigger
- DIScriptDeps.n4js.xt
- IsTestableLocationPropertyTester
- N4JSAntlrGeneratorFragment2
- N4TSQualifiedNameConverter
- N4JSStandaloneSetup
- N4JSTypeInformationHoverProvider
- TypeRefs.xcore

## React

In tests we use a definition file for react, which accidentally contained JSDoc comments from original React project. Removed these comments since they are not required for tests.

## boothen.github.io/Json-Eclipse-Plugin

Removed reference to external JSON editor. The N4JS project provides its own JSON editor meanwhile.

## "fabelhaft"

Removed references in regression tests to NumberFour internal framework. The regression tests were added when bugs were found when developing this internal framework.