### PR TITLE
GH-1317: n4js-mangelhaft should use "own" esm version as a fallback when executing tests

### DIFF
--- a/n4js-libs/packages/n4js-mangelhaft-cli/src/n4js/org/eclipse/n4js/mangelhaft/runner/node/NodeTestAPI.n4js
+++ b/n4js-libs/packages/n4js-mangelhaft-cli/src/n4js/org/eclipse/n4js/mangelhaft/runner/node/NodeTestAPI.n4js
@@ -148,7 +148,8 @@ export default public class NodeTestAPI {
             const hasOption = (opt: string): boolean => checkOption(execArgvOptions, opt) || checkOption(nodeOptions, opt);
             
             if (!["-r esm", "--require=esm", "--experimental-modules"].some(hasOption)) {
-                execArgv.push("-r", "esm");
+                const esm = require.resolve("esm"); // use "own" esm version
+                execArgv.push("-r", esm);
             }
             if (options.inspectBrk) {
                 execArgv.push(`--inspect-brk=${options.inspectBrk}`);

--- a/n4js-libs/yarn.lock
+++ b/n4js-libs/yarn.lock
@@ -823,7 +823,7 @@ eslint@^3.19.0:
     text-table "~0.2.0"
     user-home "^2.0.0"
 
-esm@~3.2.10:
+esm@3.2.22:
   version "3.2.22"
   resolved "https://registry.npmjs.org/esm/-/esm-3.2.22.tgz#5062c2e22fee3ccfee4e8f20da768330da90d6e3"
   integrity sha512-z8YG7U44L82j1XrdEJcqZOLUnjxco8pO453gKOlaMD1/md1n/5QrscAmYG+oKUspsmDLuBFZrpbxI6aQ67yRxA==


### PR DESCRIPTION
#1317

@mmews-n4 please