### PR TITLE
GH-1335: As a smith I want all nightly builds and deployment working with Java 11

### DIFF
--- a/builds/org.eclipse.n4js.product.build/pom.xml
+++ b/builds/org.eclipse.n4js.product.build/pom.xml
@@ -29,44 +29,6 @@ Contributors:
 
 	<profiles>
 		<profile>
-			<id>stagingNpmRegistry</id>
-			<activation>
-				<property>
-					<name>env.STAGING_NPM_REGISTRY</name>
-				</property>
-			</activation>
-			<build>
-				<plugins>
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>exec-maven-plugin</artifactId>
-						<version>${codehaus-exec-maven-plugin.version}</version>
-						<executions>
-							<!-- Publish n4js-libs to staging area if the env variable STAGING_NPM_REGISTRY is set.
-							The staging area is the place where we publish n4js-libs to, Other builds can retrieve n4js-lib npms from the staging area.
-							This is done here because first the publishing should only happen once and second it only makes sense to publish when we can build the product.
-							 -->
-							<execution>
-								<id>publish-n4js-libs</id>
-								<phase>verify</phase>
-								<goals>
-									<goal>exec</goal>
-								</goals>
-								<configuration>
-									<executable>bash</executable>
-									<arguments>
-										<argument>${project.basedir}/../../releng/utils/scripts/publish-n4js-libs.sh</argument>
-										<argument>bridge</argument>
-										<argument>${env.STAGING_NPM_REGISTRY}</argument>
-									</arguments>
-								</configuration>
-							</execution>
-						</executions>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-		<profile>
 			<id>buildProduct</id>
 				<properties>
 					<maven.build.timestamp.format>yyyy-MM-dd HH:mm:ss</maven.build.timestamp.format>

--- a/tests/org.eclipse.n4js.hlc.integrationtests/pom.xml
+++ b/tests/org.eclipse.n4js.hlc.integrationtests/pom.xml
@@ -187,7 +187,8 @@ Contributors:
 										<arg value="4873:4873"/>
 										<arg value="-v"/>
 										<arg value="${project.basedir}/verdaccioConfig/config.yaml:/verdaccio/conf/config.yaml"/>
-										<arg value="verdaccio/verdaccio:3.12"/>
+										<!-- verdaccio/verdaccio:3.12 -->
+										<arg value="verdaccio/verdaccio@sha256:e64056b6aa104197dbac07e77a1fbcf8f5c67d9b443e0ed2a191d41a1da7a944"/>
 									</exec>
 								</target>
 							</configuration>


### PR DESCRIPTION
See #1335.

This PR contains various simplifications and clean ups beyond making the builds green.

In particular:
- make extended nightly truly independent from inhouse nightly
- remove siblingRepo and siblingMavenRepo
- remove stagingNpmRegistry and STAGING_NPM_REGISTRY
- use digest instead of tag to reference verdaccio docker image
- remove obsolete steps in some Jenkinsfiles

NOTE: most changes are contained in repository `n4js-n4`.