### PR TITLE
GH-1361: As a smith I want to make builds simpler and more consistent (part 2)

### DIFF
--- a/inhouse-ci.jenkinsfile
+++ b/inhouse-ci.jenkinsfile
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2017 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+pipeline {
+    agent {
+        dockerfile {
+            filename 'Dockerfile'
+            dir 'docker-build/'
+            // Reuse repository.volume container if one exists, to speed up subsequent builds.
+            // Bind to host's docker sock to use host's docker daemon
+            args '--group-add 994 --network=host -v n4js-m2-repository:/usr/share/maven/ref/repository/ -v /var/run/docker.sock:/var/run/docker.sock'
+            additionalBuildArgs '--build-arg MAVEN_CENTRAL_URL=' + env.MAVEN_CENTRAL_URL
+            label 'm5xlarge'
+        }
+    }
+
+    options {
+        ansiColor('xterm')
+        buildDiscarder(
+            logRotator(
+                numToKeepStr:          '20',
+                daysToKeepStr:         '30',
+                artifactNumToKeepStr:  '20',
+                artifactDaysToKeepStr: '30'))
+        timeout(time: 4, unit: 'HOURS')
+        timestamps()
+    }
+
+    environment {
+        MAVEN_OPTS = '-XX:+UnlockExperimentalVMOptions '           +
+                     '-Xms4096m -Xmx8192m -XX:MaxPermSize=1024m '  +
+                     '-XshowSettings:vm'
+    }
+
+    triggers {
+        pollSCM('H/5 * * * *') // every 5 minutes
+    }
+
+    stages {
+
+        stage('Build N4JS') {
+            steps {
+                sshagent(['github-com-ssh-key']) {
+                    script {
+                        def xvfb = 'xvfb-run -a --server-args="-screen 0 1024x768x24" '
+                        def options = '-Dmaven.test.redirectTestOutputToFile=true -Dmaven.test.failure.ignore -e -DWORKSPACE=' + env.WORKSPACE
+                        def profiles = [
+                            'buildProduct',
+                            'execute-plugin-tests',
+                            'execute-plugin-ui-tests',
+                            'execute-hlc-integration-tests'
+                        ].join(',')
+
+                        // Execute in the n4js repository folder since the BuildN4jsLibs requires this
+                        dir ('n4js') {
+                            sh "export SWT_GTK3=0; ${xvfb} mvn --batch-mode --update-snapshots clean verify -P${profiles} ${options}"
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            archiveArtifacts allowEmptyArchive: false, artifacts: '**/builds/**/target/products/*.zip'
+            archiveArtifacts allowEmptyArchive: false, artifacts: '**/tools/**/target/n4jsc.jar'
+            archiveArtifacts allowEmptyArchive: true, artifacts: '**/logs/*.log'
+            archiveArtifacts allowEmptyArchive: true, artifacts: '**/tests/**/target/**/*-output.txt'
+            junit '**/surefire-reports/**/*.xml'
+            junit '**/failsafe-reports/**/*.xml'
+        }
+        cleanup {
+            // Execute after every other post condition has been evaluated, regardless of status
+            // See https://jenkins.io/doc/book/pipeline/syntax/#post
+            echo 'Cleaning up workspace'
+            deleteDir()
+         }
+    }
+}

--- a/inhouse-ci.jenkinsfile
+++ b/inhouse-ci.jenkinsfile
@@ -59,10 +59,7 @@ pipeline {
                             'execute-hlc-integration-tests'
                         ].join(',')
 
-                        // Execute in the n4js repository folder since the BuildN4jsLibs requires this
-                        dir ('n4js') {
-                            sh "export SWT_GTK3=0; ${xvfb} mvn --batch-mode --update-snapshots clean verify -P${profiles} ${options}"
-                        }
+                        sh "export SWT_GTK3=0; ${xvfb} mvn --batch-mode --update-snapshots clean verify -P${profiles} ${options}"
                     }
                 }
             }


### PR DESCRIPTION
Moves `inhouse-ci.jenkinsfile` back to repository `n4js`. See commit message for rationale.