### PR TITLE
GH-1409: (Part 2) As a smith I need more design documentation publicly available

### DIFF
--- a/docs/org.eclipse.n4js.ide.spec/chapters/02_views/views.adoc
+++ b/docs/org.eclipse.n4js.ide.spec/chapters/02_views/views.adoc
@@ -61,7 +61,24 @@ The N4JS equivalent to the JUnit test view.
 
 === Source Graphs
 
-Shows the AST of the current source code in the editor windows.
+Shows the AST, type model (ie. TModule), and the control flow graph of the current source code in the editor window.
+The view is implemented in the bundle `org.eclipse.n4js.smith.graph`.
+
+There are two ways for showing an AST / type model in the view:
+
+Manually:: Open the view and an N4JS editor with some example code and click either the AST graph or the control flow graph button in the view.
+
+Programmatically:: Open the view while debugging code, add a call to method `UtilN4.takeSnapshotInGraphView(String, ResourceSet)` anywhere in the code to create an image of the AST graph.
+You can take several snapshots without deleting the previous ones.
+The pause button in the view will suppress programmatically triggered snapshots.
+
+When taking snapshots, the Xtext resources should not be modified in any way by the graph view, in particular, proxies won’t be resolved.
+If they are it is a bug.
+
+The graph view is intended for small test code and is expected to be customized in the source code to suit a particular debugging use case (e.g. to show more / other information in the graph).
+Therefore it won't work well / won't scale on large code bases and does not support all conceivable use cases out of the box.
+Main entry point for customizations is class `EMFGraphProvider`.
+
 
 === API Compare
 

--- a/tools/org.eclipse.n4js.hlc/src/org/eclipse/n4js/hlc/ProductLauncher.java
+++ b/tools/org.eclipse.n4js.hlc/src/org/eclipse/n4js/hlc/ProductLauncher.java
@@ -34,7 +34,26 @@ import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 
 /**
- * Product launcher that is responsible for starting Equinox / Eclipse and then loading and running concrete bundles.
+ * Product launcher that is responsible for starting Equinox/Eclipse and then loading and running concrete bundles.
+ * <p>
+ * While the actual compiler implementation is done in {@code org.eclipse.hlc.base} and its transitive dependencies, the
+ * headless tool contains two small code parts related only to packaging and startup.
+ * <p>
+ * First is the custom class loader and main class. Since the headless tool is packaged as JAR-with-JARs, it requires a
+ * custom class loader to be able to load dependencies from within itself. Currently we use an implementation copied
+ * from the JDT tools see <a href=
+ * "https://github.com/eclipse/eclipse.jdt.ui/tree/master/org.eclipse.jdt.ui/jar%20in%20jar%20loader/org/eclipse/jdt/internal/jarinjarloader">jarinjarloader</a>
+ * <p>
+ * As for the main class we can highlight three classes that delegate to each other at startup of the application:
+ * <ul>
+ * <li/><b>org.eclipse.jdt.internal.jarinjarloader.JarRsrcLoader</b> is the main class from a plain JAR point of view.
+ * It is tightly integrated with the custom class loader. In general it is infrastructure level, and in principle it
+ * should not require any modifications (unless the packaging of the jar is changed).
+ * <li/><b>org.eclipse.n4js.hlc.ProductLauncher</b> is a middleware. It bootstraps Eclipse/Equinox platform and loads
+ * all the bundles.
+ * <li/><b>org.eclipse.n4js.hlc.base.N4jscBase</b> is the main entry point. This is the place were actual compiler code
+ * starts.
+ * </ul>
  */
 @SuppressWarnings("restriction")
 public class ProductLauncher {


### PR DESCRIPTION
part two of https://github.com/eclipse/n4js/issues/1409

In order to get rid of the internal design document, this PR moves some remaining documentation from the internal design document to the public design document or to Java classes.