### PR TITLE
GH-1444: As a smith I need to review the handling of Wildcards / ExistentialTypeRefs (aka capture conversion)

### DIFF
--- a/n4js-libs/packages/n4js-mangelhaft-cli/src/n4js/org/eclipse/n4js/mangelhaft/runner/node/NodeTestRunner.n4js
+++ b/n4js-libs/packages/n4js-mangelhaft-cli/src/n4js/org/eclipse/n4js/mangelhaft/runner/node/NodeTestRunner.n4js
@@ -89,7 +89,7 @@ class NodeTestRunner  {
             testCatalog.testDescriptors = descriptors;
         }
         
-        const log = options.quiet ? function() {} : console.log.bind(console);
+        const log = options.quiet ? function(...p) {} : console.log.bind(console);
         this.consoleReporter.cliColor = cli_color_.default;
         this.consoleReporter.setLogger(log);
 


### PR DESCRIPTION
See #1444.

Just a minor change in n4js-libs. This creates a (correct) error on branch `GH-1444` but not on master. Merging this ahead of time will simplify dealing with various tests, etc. on branch `GH-1444`.