### PR TITLE
GH-1453C: Asynchronous Jetty Server shutdown causes problems on Eclipse Jenkins

### DIFF
--- a/tests/org.eclipse.n4js.tester.tests/pom.xml
+++ b/tests/org.eclipse.n4js.tester.tests/pom.xml
@@ -36,6 +36,12 @@ Contributors:
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
+
+				<!-- Tester tests must be EXECUTED SEQUENTIALLY since they access hardware ports (9415) for communication. -->
+				<configuration>
+					<forkCount>1</forkCount>
+					<reuseForks>false</reuseForks>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Follow-up of GH-1453, since the actual problem was not solved before.

Turned out that on Eclipse Jenkins infrastructure, some defaults of Maven are different compared to enfore infrastructure (latter uses Docker). Namely, the maven-surefire plugin executes tests in parallel which caused races on hardware port 9415. Note that the race can be reproduced locally by setting the fork-count value to higher than one and setting the reuse-forks to true.

See Jenkins results of Eclipse of Branch GH-1453B here: https://ci.eclipse.org/n4js/job/GH-1453B/: The last five runs did not suffer anymore from the "could not bind" problem. Note that the one yellow build has a different problem.

Branch GH-1453C was introduced, since GH-1453B also contained lots of off-topic changes for testing reasons.