### PR TITLE
GH-1532: moved jenkins to subfolder, disabled smoke tests

### DIFF
--- a/jenkins/haw-pr.jenkinsfile
+++ b/jenkins/haw-pr.jenkinsfile
@@ -51,7 +51,7 @@ pipeline {
                             'execute-plugin-ui-tests',
                             'execute-ecma-tests',
                             'execute-accesscontrol-tests',
-                            'execute-smoke-tests'
+                         //   'execute-smoke-tests' // #1533
                          //'execute-hlc-integration-tests'
                         ].join(',')
 


### PR DESCRIPTION
#1532

Side note: also use [ghef](https://www.npmjs.com/package/ghef) to filter events we can ignore on Jenkins (this does not change the repository)

Also disabled smoke tests since they caused problems... created #1533 for that.