### PR TITLE
GH-1496: As a user I want JSDoc comments prefilled on creation

### DIFF
--- a/docs/org.eclipse.n4js.ide.spec/chapters/05_assistance/assistance.adoc
+++ b/docs/org.eclipse.n4js.ide.spec/chapters/05_assistance/assistance.adoc
@@ -579,13 +579,13 @@ If more then one option leads to a possible resolution the situation should be c
 
 == AutoEdit
 
-AutoEdit can help you write JSDoc comments. It creates `@param` and `@return` tags and also prefills their type, if it's known.
+AutoEdit can help you write JSDoc comments. It creates `@param` and `@return` tags.
 
-When you create a comment for a method eg. `/\*`, `*/` is appended automatically.
+When you create a comment for a method e.g. `/\*`, `*/` is appended automatically.
 
-If you add another asteriks eg. `/**` and hit enter, AutoEdit will add an asteriks to every new line and create a JSDoc comment based on the method signature. 
+If you add another asterisk e.g. `/**` and hit enter, AutoEdit will add an asterisk to every new line and create a JSDoc comment based on the method signature.
 
-Hitting enter again, will result in another new line with an asteriks at the beginning.
+Hitting enter again, will result in another new line with an asterisk at the beginning.
 
 Given the following (`|` being the current position of your cursor):
 ```
@@ -601,9 +601,9 @@ Hitting enter, will result in:
 class Foo {
   /**
    * |
-   * @param {String} s
-   * @param {boolean} n
-   * @return {boolean} 
+   * @param s
+   * @param n
+   * @return
    */
   bar(s: String, n: boolean): boolean {
     return false;

--- a/docs/org.eclipse.n4js.ide.spec/chapters/05_assistance/assistance.adoc
+++ b/docs/org.eclipse.n4js.ide.spec/chapters/05_assistance/assistance.adoc
@@ -577,3 +577,36 @@ If more then one option leads to a possible resolution the situation should be c
 * more then one module provides an element, which would render a formerly unresolved reference to be valid.
 * for a wildcard-imported element `X` there are unknown members and a different module provides an element `X` containing the missing members. In such a case a named import of `X` would be proposed, optionally using an alias.
 
+== AutoEdit
+
+AutoEdit can help you write JSDoc comments. It creates `@param` and `@return` tags and also prefills their type, if it's known.
+
+When you create a comment for a method eg. `/\*`, `*/` is appended automatically.
+
+If you add another asteriks eg. `/**` and hit enter, AutoEdit will add an asteriks to every new line and create a JSDoc comment based on the method signature. 
+
+Hitting enter again, will result in another new line with an asteriks at the beginning.
+
+Given the following (`|` being the current position of your cursor):
+```
+class Foo {
+  /**| */
+  bar(s: String, n: boolean): boolean {
+    return false;
+  }
+}
+```
+Hitting enter, will result in:
+```
+class Foo {
+  /**
+   * |
+   * @param {String} s
+   * @param {boolean} n
+   * @return {boolean} 
+   */
+  bar(s: String, n: boolean): boolean {
+    return false;
+  }
+}
+```

--- a/plugins/org.eclipse.n4js.jsdoc/src/org/eclipse/n4js/jsdoc/DocletParser.java
+++ b/plugins/org.eclipse.n4js.jsdoc/src/org/eclipse/n4js/jsdoc/DocletParser.java
@@ -86,7 +86,7 @@ public class DocletParser extends AbstractJSDocParser {
 		while (null != (token = tagTitleTokenizer.nextToken(scanner))) {
 			ITagDefinition tagDefinition = lineTagDictionary.getDefinition(token.token);
 			int lineTagEnd = scanner.findLineTagEnd();
-			scanner.fence(lineTagEnd);
+			scanner.fence(lineTagEnd + 1); // fence is excluing the upper bound
 			if (tagDefinition != null) {
 				TagTitle tagTitle = createTagTitle(token, tagDefinition);
 				LineTag tag = (LineTag) tagDefinition.parse(tagTitle, scanner, descriptionParser);

--- a/plugins/org.eclipse.n4js.jsdoc/src/org/eclipse/n4js/jsdoc/JSDocCharScanner.java
+++ b/plugins/org.eclipse.n4js.jsdoc/src/org/eclipse/n4js/jsdoc/JSDocCharScanner.java
@@ -412,8 +412,11 @@ public class JSDocCharScanner {
 	}
 
 	/**
-	 * Temporary sets end of text in order to ensure that sub-parsers do not exceed that point. Has to be undone via
+	 * Temporarily sets end of text in order to ensure that sub-parsers do not exceed that point. Has to be undone via
 	 * {@link #unfence()} eventually. The fencePosition must be AFTER the current offset!
+	 *
+	 * @param fencePosition
+	 *            the end of the fence, this position is excluded from current area.
 	 */
 	public void fence(int fencePosition) {
 		if (offset > fencePosition) {

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/AutoEditStrategyProvider.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/AutoEditStrategyProvider.java
@@ -17,11 +17,18 @@ import static org.eclipse.n4js.ui.editor.syntaxcoloring.TokenTypeToPartitionMapp
 import org.eclipse.jface.text.IAutoEditStrategy;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.xtext.ui.editor.autoedit.DefaultAutoEditStrategyProvider;
+import org.eclipse.xtext.ui.editor.autoedit.MultiLineTerminalsEditStrategy;
 import org.eclipse.xtext.ui.editor.model.TerminalsTokenTypeToPartitionMapper;
+
+import com.google.inject.Inject;
+import com.google.inject.MembersInjector;
 
 /**
  */
 public class AutoEditStrategyProvider extends DefaultAutoEditStrategyProvider {
+
+	@Inject
+	private MembersInjector<MultiLineTerminalsEditStrategy> injector;
 
 	@Override
 	protected void configure(IEditStrategyAcceptor acceptor) {
@@ -38,10 +45,21 @@ public class AutoEditStrategyProvider extends DefaultAutoEditStrategyProvider {
 
 	@Override
 	protected void configureMultilineComments(IEditStrategyAcceptor acceptor) {
+		// IAutoEditStrategy jsdoc = multiLineTerminals.newInstance("/**", " + ", " */");
+
+		MultiLineTerminalsEditStrategy jsdoc = new JSDocEditStrategy("/**", " + ", " */");
+		injector.injectMembers(jsdoc);
+
 		IAutoEditStrategy multiline = multiLineTerminals.newInstance("/*", " * ", " */");
 		IAutoEditStrategy singleline = singleLineTerminals.newInstance("/*", " */", new SupressingMLCommentPredicate());
 
 		acceptor.accept(singleline, IDocument.DEFAULT_CONTENT_TYPE);
+
+		acceptor.accept(jsdoc, IDocument.DEFAULT_CONTENT_TYPE);
+		acceptor.accept(jsdoc, TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);
+		acceptor.accept(jsdoc, JS_DOC_PARTITION);
+		acceptor.accept(jsdoc, REG_EX_PARTITION);
+
 		acceptor.accept(multiline, IDocument.DEFAULT_CONTENT_TYPE);
 		acceptor.accept(multiline, TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);
 		acceptor.accept(multiline, JS_DOC_PARTITION);

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/AutoEditStrategyProvider.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/AutoEditStrategyProvider.java
@@ -45,17 +45,29 @@ public class AutoEditStrategyProvider extends DefaultAutoEditStrategyProvider {
 
 	@Override
 	protected void configureMultilineComments(IEditStrategyAcceptor acceptor) {
-		JSDocEditStrategy multiline = new JSDocEditStrategy("/**", " * ", " */");
-		injector.injectMembers(multiline);
+		IAutoEditStrategy multiline3AndMoreStars = multiLineTerminals.newInstance("/***", " * ", " */");
+		JSDocEditStrategy multilineJsDoc = new JSDocEditStrategy("/**", " * ", " */");
+		IAutoEditStrategy multiline1Star = multiLineTerminals.newInstance("/*", " * ", " */");
+		injector.injectMembers(multilineJsDoc);
 		IAutoEditStrategy singleline = singleLineTerminals.newInstance("/*", " */", new SupressingMLCommentPredicate());
 
 		acceptor.accept(singleline, IDocument.DEFAULT_CONTENT_TYPE);
-
-		acceptor.accept(multiline, IDocument.DEFAULT_CONTENT_TYPE);
-		acceptor.accept(multiline, TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);
-		acceptor.accept(multiline, JS_DOC_PARTITION);
 		acceptor.accept(singleLineTerminals.newInstance("/*", " */"), REG_EX_PARTITION);
-		acceptor.accept(multiline, REG_EX_PARTITION);
+
+		acceptor.accept(multiline3AndMoreStars, IDocument.DEFAULT_CONTENT_TYPE);
+		acceptor.accept(multiline3AndMoreStars, TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);
+		acceptor.accept(multiline3AndMoreStars, JS_DOC_PARTITION);
+		acceptor.accept(multiline3AndMoreStars, REG_EX_PARTITION);
+
+		acceptor.accept(multilineJsDoc, IDocument.DEFAULT_CONTENT_TYPE);
+		acceptor.accept(multilineJsDoc, TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);
+		acceptor.accept(multilineJsDoc, JS_DOC_PARTITION);
+		acceptor.accept(multilineJsDoc, REG_EX_PARTITION);
+
+		acceptor.accept(multiline1Star, IDocument.DEFAULT_CONTENT_TYPE);
+		acceptor.accept(multiline1Star, TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);
+		acceptor.accept(multiline1Star, JS_DOC_PARTITION);
+		acceptor.accept(multiline1Star, REG_EX_PARTITION);
 	}
 
 	@Override

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/AutoEditStrategyProvider.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/AutoEditStrategyProvider.java
@@ -45,29 +45,24 @@ public class AutoEditStrategyProvider extends DefaultAutoEditStrategyProvider {
 
 	@Override
 	protected void configureMultilineComments(IEditStrategyAcceptor acceptor) {
-		IAutoEditStrategy multiline3AndMoreStars = multiLineTerminals.newInstance("/***", " * ", " */");
-		JSDocEditStrategy multilineJsDoc = new JSDocEditStrategy("/**", " * ", " */");
-		IAutoEditStrategy multiline1Star = multiLineTerminals.newInstance("/*", " * ", " */");
-		injector.injectMembers(multilineJsDoc);
+		JSDocEditStrategy jsdoc = new JSDocEditStrategy();
+		injector.injectMembers(jsdoc);
+
+		IAutoEditStrategy multiline = multiLineTerminals.newInstance("/*", " * ", " */");
 		IAutoEditStrategy singleline = singleLineTerminals.newInstance("/*", " */", new SupressingMLCommentPredicate());
 
 		acceptor.accept(singleline, IDocument.DEFAULT_CONTENT_TYPE);
 		acceptor.accept(singleLineTerminals.newInstance("/*", " */"), REG_EX_PARTITION);
 
-		acceptor.accept(multiline3AndMoreStars, IDocument.DEFAULT_CONTENT_TYPE);
-		acceptor.accept(multiline3AndMoreStars, TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);
-		acceptor.accept(multiline3AndMoreStars, JS_DOC_PARTITION);
-		acceptor.accept(multiline3AndMoreStars, REG_EX_PARTITION);
+		acceptor.accept(jsdoc, IDocument.DEFAULT_CONTENT_TYPE);
+		acceptor.accept(jsdoc, TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);
+		acceptor.accept(jsdoc, JS_DOC_PARTITION);
+		acceptor.accept(jsdoc, REG_EX_PARTITION);
 
-		acceptor.accept(multilineJsDoc, IDocument.DEFAULT_CONTENT_TYPE);
-		acceptor.accept(multilineJsDoc, TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);
-		acceptor.accept(multilineJsDoc, JS_DOC_PARTITION);
-		acceptor.accept(multilineJsDoc, REG_EX_PARTITION);
-
-		acceptor.accept(multiline1Star, IDocument.DEFAULT_CONTENT_TYPE);
-		acceptor.accept(multiline1Star, TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);
-		acceptor.accept(multiline1Star, JS_DOC_PARTITION);
-		acceptor.accept(multiline1Star, REG_EX_PARTITION);
+		acceptor.accept(multiline, IDocument.DEFAULT_CONTENT_TYPE);
+		acceptor.accept(multiline, TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);
+		acceptor.accept(multiline, JS_DOC_PARTITION);
+		acceptor.accept(multiline, REG_EX_PARTITION);
 	}
 
 	@Override

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/AutoEditStrategyProvider.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/AutoEditStrategyProvider.java
@@ -45,9 +45,7 @@ public class AutoEditStrategyProvider extends DefaultAutoEditStrategyProvider {
 
 	@Override
 	protected void configureMultilineComments(IEditStrategyAcceptor acceptor) {
-		// IAutoEditStrategy jsdoc = multiLineTerminals.newInstance("/**", " + ", " */");
-
-		MultiLineTerminalsEditStrategy jsdoc = new JSDocEditStrategy("/**", " + ", " */");
+		JSDocEditStrategy jsdoc = new JSDocEditStrategy("/**", " + ", " */");
 		injector.injectMembers(jsdoc);
 
 		IAutoEditStrategy multiline = multiLineTerminals.newInstance("/*", " * ", " */");

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/AutoEditStrategyProvider.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/AutoEditStrategyProvider.java
@@ -45,14 +45,19 @@ public class AutoEditStrategyProvider extends DefaultAutoEditStrategyProvider {
 
 	@Override
 	protected void configureMultilineComments(IEditStrategyAcceptor acceptor) {
+		// To avoid JSDocEditStrategy handling /***+ multiline3andMoreAsterisks instance is added
+		IAutoEditStrategy multiline3andMoreAsterisks = multiLineTerminals.newInstance("/***", " * ", " */");
 		JSDocEditStrategy jsdoc = new JSDocEditStrategy();
 		injector.injectMembers(jsdoc);
-
 		IAutoEditStrategy multiline = multiLineTerminals.newInstance("/*", " * ", " */");
 		IAutoEditStrategy singleline = singleLineTerminals.newInstance("/*", " */", new SupressingMLCommentPredicate());
 
 		acceptor.accept(singleline, IDocument.DEFAULT_CONTENT_TYPE);
 		acceptor.accept(singleLineTerminals.newInstance("/*", " */"), REG_EX_PARTITION);
+
+		acceptor.accept(multiline3andMoreAsterisks, IDocument.DEFAULT_CONTENT_TYPE);
+		acceptor.accept(multiline3andMoreAsterisks, TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);
+		acceptor.accept(multiline3andMoreAsterisks, REG_EX_PARTITION);
 
 		acceptor.accept(jsdoc, IDocument.DEFAULT_CONTENT_TYPE);
 		acceptor.accept(jsdoc, TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/AutoEditStrategyProvider.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/AutoEditStrategyProvider.java
@@ -45,18 +45,11 @@ public class AutoEditStrategyProvider extends DefaultAutoEditStrategyProvider {
 
 	@Override
 	protected void configureMultilineComments(IEditStrategyAcceptor acceptor) {
-		JSDocEditStrategy jsdoc = new JSDocEditStrategy("/**", " + ", " */");
-		injector.injectMembers(jsdoc);
-
-		IAutoEditStrategy multiline = multiLineTerminals.newInstance("/*", " * ", " */");
+		JSDocEditStrategy multiline = new JSDocEditStrategy("/**", " * ", " */");
+		injector.injectMembers(multiline);
 		IAutoEditStrategy singleline = singleLineTerminals.newInstance("/*", " */", new SupressingMLCommentPredicate());
 
 		acceptor.accept(singleline, IDocument.DEFAULT_CONTENT_TYPE);
-
-		acceptor.accept(jsdoc, IDocument.DEFAULT_CONTENT_TYPE);
-		acceptor.accept(jsdoc, TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);
-		acceptor.accept(jsdoc, JS_DOC_PARTITION);
-		acceptor.accept(jsdoc, REG_EX_PARTITION);
 
 		acceptor.accept(multiline, IDocument.DEFAULT_CONTENT_TYPE);
 		acceptor.accept(multiline, TerminalsTokenTypeToPartitionMapper.COMMENT_PARTITION);

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/JSDocEditStrategy.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/JSDocEditStrategy.java
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2019 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+package org.eclipse.n4js.ui.editor.autoedit;
+
+import org.eclipse.xtext.ui.editor.autoedit.MultiLineTerminalsEditStrategy;
+
+public class JSDocEditStrategy extends MultiLineTerminalsEditStrategy {
+
+	public JSDocEditStrategy(String leftTerminal, String indentationString, String rightTerminal) {
+		super(leftTerminal, indentationString, rightTerminal, false);
+	}
+
+}

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/JSDocEditStrategy.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/JSDocEditStrategy.java
@@ -10,12 +10,82 @@
  */
 package org.eclipse.n4js.ui.editor.autoedit;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.DocumentCommand;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.n4js.n4JS.FormalParameter;
+import org.eclipse.n4js.n4JS.N4MethodDeclaration;
+import org.eclipse.n4js.n4JS.Script;
+import org.eclipse.n4js.ui.editor.N4JSDocument;
+import org.eclipse.n4js.ui.organize.imports.XtextResourceUtils;
+import org.eclipse.xtext.nodemodel.ILeafNode;
+import org.eclipse.xtext.nodemodel.util.NodeModelUtils;
+import org.eclipse.xtext.ui.editor.autoedit.CommandInfo;
 import org.eclipse.xtext.ui.editor.autoedit.MultiLineTerminalsEditStrategy;
 
 public class JSDocEditStrategy extends MultiLineTerminalsEditStrategy {
+	private final String indentationString;
+	private final String paramString = "@param ";
+	private final String returnString = "@return ";
 
 	public JSDocEditStrategy(String leftTerminal, String indentationString, String rightTerminal) {
 		super(leftTerminal, indentationString, rightTerminal, false);
+		this.indentationString = indentationString;
 	}
 
+	/**
+	 * Expects the cursor to be in the same line as the start terminal puts any text between start terminal and cursor
+	 * into a separate newline before the cursor. puts any text between cursor and end terminal into a separate newline
+	 * after the cursor. puts the closing terminal into a separate line at the end. adds a closing terminal if not
+	 * existent.
+	 */
+	@Override
+	protected CommandInfo handleCursorInFirstLine(IDocument document, DocumentCommand command, IRegion startTerminal,
+			IRegion stopTerminal) throws BadLocationException {
+		CommandInfo newC = new CommandInfo();
+		newC.isChange = true;
+		if (document instanceof N4JSDocument) {
+			// index 0: if set to "void", the method has no return value; fpars start at index 1
+			List<String> retAndfparNames = ((N4JSDocument) document).tryReadOnly((state) -> {
+				Script script = XtextResourceUtils.getScript(state);
+				ILeafNode node = NodeModelUtils.findLeafNodeAtOffset(NodeModelUtils.findActualNodeFor(script),
+						startTerminal.getOffset());
+				EObject astElement = node.getSemanticElement();
+				List<String> retAndFPars = new ArrayList<>();
+				if (astElement instanceof N4MethodDeclaration) {
+					N4MethodDeclaration methodDecl = (N4MethodDeclaration) astElement;
+					if (methodDecl.getReturnTypeRef() != null) {
+						retAndFPars.add("return");
+					} else {
+						retAndFPars.add("void");
+					}
+					for (FormalParameter fpar : methodDecl.getFpars()) {
+						retAndFPars.add(fpar.getName());
+					}
+				}
+				return retAndFPars;
+			});
+		}
+		newC.offset = command.offset;
+		newC.text += command.text + indentationString + command.text + indentationString + paramString + command.text
+				+ indentationString + returnString;
+		newC.cursorOffset = command.offset + newC.text.length();
+		if (stopTerminal == null && atEndOfLineInput(document, command.offset)) {
+			newC.text += command.text + getRightTerminal();
+		}
+		if (stopTerminal != null && stopTerminal.getOffset() >= command.offset
+				&& util.isSameLine(document, stopTerminal.getOffset(), command.offset)) {
+			String string = document.get(command.offset, stopTerminal.getOffset() - command.offset);
+			if (string.trim().length() > 0)
+				newC.text += string.trim();
+			newC.text += command.text;
+			newC.length += string.length();
+		}
+		return newC;
+	}
 }

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/JSDocEditStrategy.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/JSDocEditStrategy.java
@@ -57,7 +57,7 @@ public class JSDocEditStrategy extends MultiLineTerminalsEditStrategy {
 						+ retTypeAndfparNames.get(i + 1);
 			}
 		}
-		String returnType = indentationString + RETURNSTR + retTypeAndfparNames.get(0);
+		String returnType = indentationString + RETURNSTR + "{" + retTypeAndfparNames.get(0) + "}";
 		newC.offset = command.offset;
 		newC.text += command.text + indentationString;
 

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/JSDocEditStrategy.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/JSDocEditStrategy.java
@@ -24,6 +24,7 @@ import org.eclipse.n4js.n4JS.FormalParameter;
 import org.eclipse.n4js.n4JS.LiteralOrComputedPropertyName;
 import org.eclipse.n4js.n4JS.N4MethodDeclaration;
 import org.eclipse.n4js.n4JS.Script;
+import org.eclipse.n4js.ts.typeRefs.BoundThisTypeRef;
 import org.eclipse.n4js.ts.typeRefs.DeferredTypeRef;
 import org.eclipse.n4js.ts.typeRefs.TypeRef;
 import org.eclipse.n4js.ts.types.TFunction;
@@ -149,7 +150,8 @@ public class JSDocEditStrategy extends MultiLineTerminalsEditStrategy {
 			if (tfunction != null) {
 				TypeRef returnTypeRef = tfunction.getReturnTypeRef();
 				if ((returnTypeRef != null) && !TypeUtils.isVoid(returnTypeRef)
-						&& !(returnTypeRef instanceof DeferredTypeRef)) {
+						&& !(returnTypeRef instanceof DeferredTypeRef)
+						&& !(returnTypeRef instanceof BoundThisTypeRef)) {
 					retAndFPars.add("return");
 				} else {
 					// e.g. constructor

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/JSDocEditStrategy.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/JSDocEditStrategy.java
@@ -48,19 +48,21 @@ public class JSDocEditStrategy extends MultiLineTerminalsEditStrategy {
 	protected CommandInfo handleCursorInFirstLine(IDocument document, DocumentCommand command, IRegion startTerminal,
 			IRegion stopTerminal) throws BadLocationException {
 		CommandInfo newC = new CommandInfo();
-		newC.isChange = true;
 		List<String> retTypeAndfparNames = getRetTypeAndparNamesAsList(document, startTerminal);
 		String paramString = "";
+		String returnType = "";
+		if (retTypeAndfparNames.size() > 0) {
+			returnType = indentationString + RETURNSTR + "{" + retTypeAndfparNames.get(0) + "}";
+		}
 		if (retTypeAndfparNames.size() > 1) {
 			for (int i = 1; i < retTypeAndfparNames.size(); i += 2) {
 				paramString += command.text + indentationString + PARAMSTR + "{" + retTypeAndfparNames.get(i) + "} "
 						+ retTypeAndfparNames.get(i + 1);
 			}
 		}
-		String returnType = indentationString + RETURNSTR + "{" + retTypeAndfparNames.get(0) + "}";
+		newC.isChange = true;
 		newC.offset = command.offset;
 		newC.text += command.text + indentationString;
-
 		newC.cursorOffset = command.offset + newC.text.length();
 		if (stopTerminal == null && atEndOfLineInput(document, command.offset)) {
 			newC.text += command.text + getRightTerminal();
@@ -70,8 +72,11 @@ public class JSDocEditStrategy extends MultiLineTerminalsEditStrategy {
 			String string = document.get(command.offset, stopTerminal.getOffset() - command.offset);
 			if (string.trim().length() > 0)
 				newC.text += string.trim();
-			newC.text += paramString
-					+ command.text + returnType + command.text;
+			if (!(retTypeAndfparNames.size() == 0)) {
+				newC.text += paramString + command.text + returnType + command.text;
+			} else {
+				newC.text += command.text;
+			}
 
 			newC.length += string.length();
 		}

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/JSDocEditStrategy.java
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/editor/autoedit/JSDocEditStrategy.java
@@ -74,11 +74,11 @@ public class JSDocEditStrategy extends MultiLineTerminalsEditStrategy {
 		}
 
 		String paramName = retAndfparNames.get(1);
-		String returnValue = retAndfparNames.get(0);
+		String returnType = retAndfparNames.get(0);
 		newC.offset = command.offset;
 		newC.text += command.text + indentationString + command.text + indentationString + paramString + paramName
 				+ command.text
-				+ indentationString + returnString + returnValue;
+				+ indentationString + returnString + returnType;
 		newC.cursorOffset = command.offset + newC.text.length();
 		if (stopTerminal == null && atEndOfLineInput(document, command.offset)) {
 			newC.text += command.text + getRightTerminal();

--- a/tests/org.eclipse.n4js.jsdoc.tests/src/org/eclipse/n4js/jsdoc/tags/LineTagTest.java
+++ b/tests/org.eclipse.n4js.jsdoc.tests/src/org/eclipse/n4js/jsdoc/tags/LineTagTest.java
@@ -14,14 +14,13 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 
-import org.junit.Test;
-
 import org.eclipse.n4js.jsdoc.DocletParser;
 import org.eclipse.n4js.jsdoc.TagDictionary;
 import org.eclipse.n4js.jsdoc.dom.Doclet;
 import org.eclipse.n4js.jsdoc.dom.LineTag;
 import org.eclipse.n4js.jsdoc.dom.TagValue;
 import org.eclipse.n4js.jsdoc.dom.Text;
+import org.junit.Test;
 
 /**
  * General tests for LineTag. A lot depends on line tag specific parse method. Few tests below are just checking if
@@ -33,7 +32,7 @@ public class LineTagTest {
 	@SuppressWarnings("javadoc")
 	@Test
 	public void testSimpleLineTag() {
-		String in = "/** foo.\n * @stubLineTagTitle \n */";
+		String in = "/** foo.\n * @stubLineTagTitle\n */";
 		AbstractLineTagDefinition tag = new StubLineTagWithRegionDefinition("stubLineTagTitle");
 		DocletParser docletParser = new DocletParser(new TagDictionary<>(Arrays.asList(tag)),
 				new TagDictionary<AbstractInlineTagDefinition>());
@@ -46,7 +45,7 @@ public class LineTagTest {
 	@SuppressWarnings("javadoc")
 	@Test
 	public void testLineTagWithRegion() {
-		String in = "/** foo.\n * @stubLineTagTitle {@region value} \n */";
+		String in = "/** foo.\n * @stubLineTagTitle {@region value}\n */";
 		AbstractLineTagDefinition tag = new StubLineTagWithRegionDefinition("stubLineTagTitle");
 		DocletParser docletParser = new DocletParser(new TagDictionary<>(Arrays.asList(tag)),
 				new TagDictionary<AbstractInlineTagDefinition>());
@@ -60,7 +59,7 @@ public class LineTagTest {
 
 	@SuppressWarnings("javadoc")
 	@Test
-	public void testLineTagDescr() {
+	public void testLineTagDescrWithTrimmedSpace() {
 		String in = "/** foo."
 				+ "\n * @stubLineTagTitle  tag description. "
 				+ "\n */";
@@ -73,13 +72,31 @@ public class LineTagTest {
 		TagValue vDescription = lineTag.getValueByKey(StubLineTagWithRegionDefinition.DESCR);
 		Text tabDescription = (Text) vDescription.getContents().get(0);
 		String deString = tabDescription.getText();
-		assertEquals("tag description. ", deString);
+		assertEquals("tag description.", deString);
+	}
+
+	@SuppressWarnings("javadoc")
+	@Test
+	public void testLineTagDescrWithOutSpace() {
+		String in = "/** foo."
+				+ "\n * @stubLineTagTitle  tag description."
+				+ "\n */";
+		AbstractLineTagDefinition tag = new StubLineTagWithRegionDefinition("stubLineTagTitle");
+		DocletParser docletParser = new DocletParser(new TagDictionary<>(Arrays.asList(tag)),
+				new TagDictionary<AbstractInlineTagDefinition>());
+		Doclet doclet = docletParser.parse(in);
+
+		LineTag lineTag = doclet.getLineTags().get(0);
+		TagValue vDescription = lineTag.getValueByKey(StubLineTagWithRegionDefinition.DESCR);
+		Text tabDescription = (Text) vDescription.getContents().get(0);
+		String deString = tabDescription.getText();
+		assertEquals("tag description.", deString);
 	}
 
 	@SuppressWarnings("javadoc")
 	@Test
 	public void testLineTagWithRegionAndDescr() {
-		String in = "/** foo.\n * @stubLineTagTitle {@region value} tag description. \n */";
+		String in = "/** foo.\n * @stubLineTagTitle {@region value} tag description.\n */";
 		AbstractLineTagDefinition tag = new StubLineTagWithRegionDefinition("stubLineTagTitle");
 		DocletParser docletParser = new DocletParser(new TagDictionary<>(Arrays.asList(tag)),
 				new TagDictionary<AbstractInlineTagDefinition>());
@@ -93,7 +110,7 @@ public class LineTagTest {
 		TagValue vDescription = lineTag.getValueByKey(StubLineTagWithRegionDefinition.DESCR);
 		Text tabDescription = (Text) vDescription.getContents().get(0);
 		String deString = tabDescription.getText();
-		assertEquals("tag description. ", deString);
+		assertEquals("tag description.", deString);
 	}
 
 }

--- a/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample1/expectedADoc/A.adoc
+++ b/tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc/SpecSample1/expectedADoc/A.adoc
@@ -34,7 +34,7 @@ srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSamp
 
 ==== Description
 
-This is some documentation for a final field. *
+This is some documentation for a final field.
 
 
 
@@ -49,7 +49,7 @@ srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSamp
 
 ==== Description
 
-This is some documentation for a final getter. *
+This is some documentation for a final getter.
 
 
 ==== Semantics
@@ -72,7 +72,7 @@ srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSamp
 
 ==== Description
 
-This is some documentation for a final setter. *
+This is some documentation for a final setter.
 
 
 ==== Semantics
@@ -136,7 +136,7 @@ srclnk:++n4js:tests/org.eclipse.n4js.jsdoc2spec.tests/testresourcesADoc:SpecSamp
 
 ==== Description
 
-This is some documentation for a final method. *
+This is some documentation for a final method.
 
 
 ==== Semantics

--- a/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/autoedit/AutoEditPluginUITest.xtend
+++ b/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/autoedit/AutoEditPluginUITest.xtend
@@ -246,6 +246,16 @@ class AutoEditPluginUITest extends AbstractCStyleLanguageAutoEditTest {
 		assertState(result, editor);
 	}
 
+	@Test def void testMLCommentsJSDoc_08() throws Exception {
+		val prepBegin = "export public class A {\n";
+		val prepS = "/**| */\n";
+		val prepEnd = "getOne() { return 1; }\n}";
+		val editor = openEditor(prepBegin + prepS + prepEnd);
+		pressKey(editor, '\n');
+		val result = prepBegin + "/**\n * |\n * @return \n */\n" + prepEnd;
+		assertState(result, editor);
+	}
+
 	/**  IDEBUG-390 */
 	@Test def void testBug368519() throws Exception {
 

--- a/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/autoedit/AutoEditPluginUITest.xtend
+++ b/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/autoedit/AutoEditPluginUITest.xtend
@@ -256,6 +256,16 @@ class AutoEditPluginUITest extends AbstractCStyleLanguageAutoEditTest {
 		assertState(result, editor);
 	}
 
+	@Test def void testMLCommentsJSDoc_09() throws Exception {
+		val prepBegin = "export public class A {\n";
+		val prepS = "/**| */\n";
+		val prepEnd = "constructor() {}\n}";
+		val editor = openEditor(prepBegin + prepS + prepEnd);
+		pressKey(editor, '\n');
+		val result = prepBegin + "/**\n * |\n */\n" + prepEnd;
+		assertState(result, editor);
+	}
+
 	/**  IDEBUG-390 */
 	@Test def void testBug368519() throws Exception {
 

--- a/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/autoedit/AutoEditPluginUITest.xtend
+++ b/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/autoedit/AutoEditPluginUITest.xtend
@@ -164,17 +164,56 @@ class AutoEditPluginUITest extends AbstractCStyleLanguageAutoEditTest {
 		assertState("   /* \n    * |\n    */\n", editor);
 	}
 
-	@Test def void testMLComments_22() throws Exception {
-		val prepBegin = "export public class Sternchen {\n";
-		val	prepS =		"/**| */\n";
-		val prepEnd = 	"public boa(): Sternchen {return null}";
+	@Test def void testMLCommentsJSDoc_01() throws Exception {
+		val prepBegin = "export public class Star {\n";
+		val prepS = "/**| */\n";
+		val prepEnd = "public getStar(): Star {return null}\n}";
 		val editor = openEditor(prepBegin + prepS + prepEnd);
 		pressKey(editor, '\n');
-		val result = prepBegin 
-					+ "/**\n * |\n * @return {Sternchen}\n */\n"
-					+ prepEnd;
+		val result = prepBegin + "/**\n * |\n * @return {Star}\n */\n" + prepEnd;
 		assertState(result, editor);
 	}
+
+	@Test def void testMLCommentsJSDoc_02() throws Exception {
+		val prepBegin = "export public class Star {\n";
+		val prepS = "/**| */\n";
+		val prepEnd = "public getBoolean(): boolean {return false}\n}";
+		val editor = openEditor(prepBegin + prepS + prepEnd);
+		pressKey(editor, '\n');
+		val result = prepBegin + "/**\n * |\n * @return {boolean}\n */\n" + prepEnd;
+		assertState(result, editor);
+	}
+
+	@Test def void testMLCommentsJSDoc_03() throws Exception {
+		val prepBegin = "export public class Star {\n";
+		val prepS = "/**| */\n";
+		val prepEnd = "public doStuff(): void {}\n}";
+		val editor = openEditor(prepBegin + prepS + prepEnd);
+		pressKey(editor, '\n');
+		val result = prepBegin + "/**\n * |\n * @return {void}\n */\n" + prepEnd;
+		assertState(result, editor);
+	}
+
+	@Test def void testMLCommentsJSDoc_04() throws Exception {
+		val prepBegin = "export public class Star {\n";
+		val prepS = "/**| */\n";
+		val prepEnd = "public getBoolean(n:number): boolean {return false}\n}";
+		val editor = openEditor(prepBegin + prepS + prepEnd);
+		pressKey(editor, '\n');
+		val result = prepBegin + "/**\n * |\n * @param {number} n\n * @return {boolean}\n */\n" + prepEnd;
+		assertState(result, editor);
+	}
+
+	@Test def void testMLCommentsJSDoc_05() throws Exception {
+		val prepBegin = "export public class Star {\n";
+		val prepS = "/**| */\n";
+		val prepEnd = "public getBoolean(n:number,s:String): boolean {return false}\n}";
+		val editor = openEditor(prepBegin + prepS + prepEnd);
+		pressKey(editor, '\n');
+		val result = prepBegin + "/**\n * |\n * @param {number} n\n * @param {String} s\n * @return {boolean}\n */\n" + prepEnd;
+		assertState(result, editor);
+	}
+
 	/**  IDEBUG-390 */
 	@Test def void testBug368519() throws Exception {
 

--- a/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/autoedit/AutoEditPluginUITest.xtend
+++ b/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/autoedit/AutoEditPluginUITest.xtend
@@ -164,6 +164,17 @@ class AutoEditPluginUITest extends AbstractCStyleLanguageAutoEditTest {
 		assertState("   /* \n    * |\n    */\n", editor);
 	}
 
+	@Test def void testMLComments_22() throws Exception {
+		val prepBegin = "export public class Sternchen {\n";
+		val	prepS =		"/**| */\n";
+		val prepEnd = 	"public boa(): Sternchen {return null}";
+		val editor = openEditor(prepBegin + prepS + prepEnd);
+		pressKey(editor, '\n');
+		val result = prepBegin 
+					+ "/**\n * |\n * @return {Sternchen}\n */\n"
+					+ prepEnd;
+		assertState(result, editor);
+	}
 	/**  IDEBUG-390 */
 	@Test def void testBug368519() throws Exception {
 

--- a/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/autoedit/AutoEditPluginUITest.xtend
+++ b/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/autoedit/AutoEditPluginUITest.xtend
@@ -177,52 +177,72 @@ class AutoEditPluginUITest extends AbstractCStyleLanguageAutoEditTest {
 	}
 
 	@Test def void testMLCommentsJSDoc_01() throws Exception {
-		val prepBegin = "export public class Star {\n";
+		val prepBegin = "export public class A {\n";
 		val prepS = "/**| */\n";
-		val prepEnd = "public getStar(): Star {return null}\n}";
+		val prepEnd = "public getA(): A {return null}\n}";
 		val editor = openEditor(prepBegin + prepS + prepEnd);
 		pressKey(editor, '\n');
-		val result = prepBegin + "/**\n * |\n * @return {Star}\n */\n" + prepEnd;
+		val result = prepBegin + "/**\n * |\n * @return \n */\n" + prepEnd;
 		assertState(result, editor);
 	}
 
 	@Test def void testMLCommentsJSDoc_02() throws Exception {
-		val prepBegin = "export public class Star {\n";
+		val prepBegin = "export public class A {\n";
 		val prepS = "/**| */\n";
-		val prepEnd = "public getBoolean(): boolean {return false}\n}";
+		val prepEnd = "public getThis(): this {return this}\n}";
 		val editor = openEditor(prepBegin + prepS + prepEnd);
 		pressKey(editor, '\n');
-		val result = prepBegin + "/**\n * |\n * @return {boolean}\n */\n" + prepEnd;
+		val result = prepBegin + "/**\n * |\n * @return \n */\n" + prepEnd;
 		assertState(result, editor);
 	}
 
 	@Test def void testMLCommentsJSDoc_03() throws Exception {
-		val prepBegin = "export public class Star {\n";
+		val prepBegin = "export public class A {\n";
 		val prepS = "/**| */\n";
 		val prepEnd = "public doStuff(): void {}\n}";
 		val editor = openEditor(prepBegin + prepS + prepEnd);
 		pressKey(editor, '\n');
-		val result = prepBegin + "/**\n * |\n * @return {void}\n */\n" + prepEnd;
+		val result = prepBegin + "/**\n * |\n */\n" + prepEnd;
 		assertState(result, editor);
 	}
 
 	@Test def void testMLCommentsJSDoc_04() throws Exception {
-		val prepBegin = "export public class Star {\n";
+		val prepBegin = "export public class A {\n";
 		val prepS = "/**| */\n";
 		val prepEnd = "public getBoolean(n:number): boolean {return false}\n}";
 		val editor = openEditor(prepBegin + prepS + prepEnd);
 		pressKey(editor, '\n');
-		val result = prepBegin + "/**\n * |\n * @param {number} n\n * @return {boolean}\n */\n" + prepEnd;
+		val result = prepBegin + "/**\n * |\n * @param n\n * @return \n */\n" + prepEnd;
 		assertState(result, editor);
 	}
 
 	@Test def void testMLCommentsJSDoc_05() throws Exception {
-		val prepBegin = "export public class Star {\n";
+		val prepBegin = "export public class A {\n";
 		val prepS = "/**| */\n";
 		val prepEnd = "public getBoolean(n:number,s:String): boolean {return false}\n}";
 		val editor = openEditor(prepBegin + prepS + prepEnd);
 		pressKey(editor, '\n');
-		val result = prepBegin + "/**\n * |\n * @param {number} n\n * @param {String} s\n * @return {boolean}\n */\n" + prepEnd;
+		val result = prepBegin + "/**\n * |\n * @param n\n * @param s\n * @return \n */\n" + prepEnd;
+		assertState(result, editor);
+	}
+
+	@Test def void testMLCommentsJSDoc_06() throws Exception {
+		val prepBegin = "export public class A {\n";
+		val prepS = "/**| */\n";
+		val prepEnd = "getBoolean(n:number,s:String): boolean {return false}\n}";
+		val editor = openEditor(prepBegin + prepS + prepEnd);
+		pressKey(editor, '\n');
+		val result = prepBegin + "/**\n * |\n * @param n\n * @param s\n * @return \n */\n" + prepEnd;
+		assertState(result, editor);
+	}
+
+	@Test def void testMLCommentsJSDoc_07() throws Exception {
+		val prepBegin = "export public class A {\n";
+		val prepS = "/**| */\n";
+		val prepEnd = "constructor(n:number,s:String) {}\n}";
+		val editor = openEditor(prepBegin + prepS + prepEnd);
+		pressKey(editor, '\n');
+		val result = prepBegin + "/**\n * |\n * @param n\n * @param s\n */\n" + prepEnd;
 		assertState(result, editor);
 	}
 

--- a/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/autoedit/AutoEditPluginUITest.xtend
+++ b/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/autoedit/AutoEditPluginUITest.xtend
@@ -164,6 +164,18 @@ class AutoEditPluginUITest extends AbstractCStyleLanguageAutoEditTest {
 		assertState("   /* \n    * |\n    */\n", editor);
 	}
 
+	@Test def void testMLComments_22() throws Exception {
+		val editor = openEditor("   /** |\n");
+		pressKey(editor, '\n');
+		assertState("   /** \n    * |\n    */\n", editor);
+	}
+
+	@Test def void testMLComments_23() throws Exception {
+		val editor = openEditor("   /*** |\n");
+		pressKey(editor, '\n');
+		assertState("   /*** \n    * |\n    */\n", editor);
+	}
+
 	@Test def void testMLCommentsJSDoc_01() throws Exception {
 		val prepBegin = "export public class Star {\n";
 		val prepS = "/**| */\n";


### PR DESCRIPTION
#1496 

This PR adds the ability to automatically add prefilled comments with some JSDoc-tags when a comment for a method is created by pressing `ENTER` when the courser is at the inner position of a JSDoc-comment: `/**| */`
Currently only these tags are prefilled: `@param` `@return`
```
    /**
     * |
     * @param a
     * @param b
     * @return
     */
    public bar(a: String, b: boolean): A {return null}
```
- [x] Strategy for generating a prefilled JSDoc-comment is added.
- [x] Tests are added to ensure the default behavior of multiline-comments.
- [x]  IDE spec is updated accordingly

---

`JSDocStrategy` extends the the `MultiLineTerminalsEditStrategy` by overriding the method `handleCursorInFirstLine` witch by default is extending multi line-comments.

Only if at the current position the next`(astElement instanceof N4MethodDeclaration)` in this PR the prefill-option is available, otherwise there will be created a default multi-line comment 
`/** */` -->
```
/**
 *
 */
```