### PR TITLE
GH-1561: Reduce memory footprint of LSP headless builder

### DIFF
--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/N4JSIdeModule.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/N4JSIdeModule.java
@@ -20,11 +20,15 @@ import org.eclipse.n4js.ide.server.hover.N4JSHoverService;
 import org.eclipse.n4js.ide.server.symbol.N4JSDocumentSymbolMapper;
 import org.eclipse.n4js.ide.server.symbol.N4JSHierarchicalDocumentSymbolService;
 import org.eclipse.n4js.ide.validation.N4JSDiagnosticConverter;
+import org.eclipse.n4js.ide.xtext.server.DefaultBuildRequestFactory;
+import org.eclipse.n4js.ide.xtext.server.IBuildRequestFactory;
+import org.eclipse.n4js.ide.xtext.server.WorkspaceAwareCanLoadFromDescriptionHelper;
 import org.eclipse.n4js.ide.xtext.server.XBuildManager;
 import org.eclipse.n4js.ide.xtext.server.XIProjectDescriptionFactory;
 import org.eclipse.n4js.ide.xtext.server.XIWorkspaceConfigFactory;
 import org.eclipse.n4js.ide.xtext.server.XProjectManager;
 import org.eclipse.n4js.ide.xtext.server.XWorkspaceManager;
+import org.eclipse.n4js.scoping.utils.CanLoadFromDescriptionHelper;
 import org.eclipse.xtext.generator.IGenerator;
 import org.eclipse.xtext.generator.OutputConfigurationProvider;
 import org.eclipse.xtext.ide.editor.contentassist.IdeContentProposalProvider;
@@ -53,8 +57,16 @@ public class N4JSIdeModule extends AbstractN4JSIdeModule {
 		return XWorkspaceManager.class;
 	}
 
+	public Class<? extends IBuildRequestFactory> bindBuildRequestFactory() {
+		return DefaultBuildRequestFactory.class;
+	}
+
 	public Class<? extends XIWorkspaceConfigFactory> bindXIWorkspaceConfigFactory() {
 		return FileBasedWorkspaceInitializer.class;
+	}
+
+	public Class<? extends CanLoadFromDescriptionHelper> bindCanLoadFromDescriptionHelper() {
+		return WorkspaceAwareCanLoadFromDescriptionHelper.class;
 	}
 
 	public Class<? extends XProjectManager> bindXProjectManager() {

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/validation/N4JSIssue.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/validation/N4JSIssue.java
@@ -25,7 +25,7 @@ import org.eclipse.xtext.validation.Issue.IssueImpl;
  * GH-1537
  */
 public class N4JSIssue extends IssueImpl implements Externalizable {
-	private static final String NULL = "NULL";
+	private static final String NULL = "";
 	private int lineNumberEnd;
 	private int columnEnd;
 
@@ -80,12 +80,12 @@ public class N4JSIssue extends IssueImpl implements Externalizable {
 		out.writeUTF(uriToProblemStr);
 
 		Severity severity = this.getSeverity();
-		String severityStr = uriToProblem == null ? NULL : severity.name();
-		out.writeUTF(severityStr);
+		int severityKey = severity == null ? 0 : severity.ordinal() + 1;
+		out.writeInt(severityKey);
 
 		CheckType checkType = this.getType();
-		String checkTypeStr = checkType == null ? NULL : checkType.name();
-		out.writeUTF(checkTypeStr);
+		int checkTypeKey = checkType == null ? 0 : checkType.ordinal() + 1;
+		out.writeInt(checkTypeKey);
 	}
 
 	@Override
@@ -103,13 +103,35 @@ public class N4JSIssue extends IssueImpl implements Externalizable {
 		URI uriToProblem = NULL.equals(uriToProblemStr) ? null : URI.createURI(uriToProblemStr);
 		this.setUriToProblem(uriToProblem);
 
-		String severityStr = in.readUTF();
-		Severity severity = NULL.equals(severityStr) ? null : Severity.valueOf(severityStr);
+		int severityKey = in.readInt();
+		Severity severity = severityFromKey(severityKey);
 		this.setSeverity(severity);
 
-		String checkTypeStr = in.readUTF();
-		CheckType checkType = NULL.equals(checkTypeStr) ? null : CheckType.valueOf(checkTypeStr);
+		int checkTypeKey = in.readInt();
+		CheckType checkType = checkTypeFromKey(checkTypeKey);
 		this.setType(checkType);
+	}
+
+	private static final Severity[] severities = Severity.values();
+
+	private static Severity severityFromKey(int severityKey) {
+		switch (severityKey) {
+		case 0:
+			return null;
+		default:
+			return severities[severityKey - 1];
+		}
+	}
+
+	private static final CheckType[] checkTypes = CheckType.values();
+
+	private static CheckType checkTypeFromKey(int checkTypeKey) {
+		switch (checkTypeKey) {
+		case 0:
+			return null;
+		default:
+			return checkTypes[checkTypeKey - 1];
+		}
 	}
 
 	@Override

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/GlobalUriResourceMap.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/GlobalUriResourceMap.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) 2019 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+package org.eclipse.n4js.ide.xtext.server;
+
+import java.util.HashMap;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+
+import com.google.inject.Singleton;
+
+/**
+ * A global, well known map in the injector that contains all the resources per URI that are currently loaded in the LSP
+ * workspace.
+ */
+@Singleton
+public class GlobalUriResourceMap extends HashMap<URI, Resource> {
+	// nothing to do
+}

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ProjectStatePersister.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ProjectStatePersister.java
@@ -83,7 +83,7 @@ public class ProjectStatePersister {
 	 * - #vs times:
 	 * 	- source URI
 	 * 	- Number #vi of issues of source
-	 * 	- #vi times a validation issue
+	 * 	- #vi times a validation issue per N4JSIssue.writeExternal
 	 * </pre>
 	 */
 	private static final int VERSION_1 = 1;
@@ -112,7 +112,6 @@ public class ProjectStatePersister {
 		try {
 			File file = getDataFile(project);
 			try (OutputStream nativeOut = Files.asByteSink(file).openBufferedStream()) {
-
 				writeProjectState(nativeOut, N4JSLanguageUtils.getLanguageVersion(), state, files, validationIssues);
 
 			} catch (IOException e) {
@@ -183,16 +182,16 @@ public class ProjectStatePersister {
 		}
 	}
 
-	private void writeValidationIssues(Map<URI, ? extends Collection<Issue>> validationIssues, ObjectOutput ouput)
+	private void writeValidationIssues(Map<URI, ? extends Collection<Issue>> validationIssues, ObjectOutput output)
 			throws IOException {
 
 		int numberSources = validationIssues.size();
-		ouput.writeInt(numberSources);
+		output.writeInt(numberSources);
 		for (Map.Entry<URI, ? extends Collection<Issue>> srcIssues : validationIssues.entrySet()) {
 			URI source = srcIssues.getKey();
 			Collection<Issue> issues = srcIssues.getValue();
 
-			ouput.writeUTF(source.toString());
+			output.writeUTF(source.toString());
 
 			Collection<N4JSIssue> n4Issues = new ArrayList<>();
 			for (Issue issue : issues) {
@@ -202,9 +201,9 @@ public class ProjectStatePersister {
 			}
 
 			int numberIssues = n4Issues.size();
-			ouput.writeInt(numberIssues);
+			output.writeInt(numberIssues);
 			for (N4JSIssue issue : n4Issues) {
-				ouput.writeObject(issue);
+				issue.writeExternal(output);
 			}
 		}
 	}
@@ -325,7 +324,8 @@ public class ProjectStatePersister {
 			int numberOfIssues = input.readInt();
 			while (numberOfIssues > 0) {
 				numberOfIssues--;
-				N4JSIssue issue = (N4JSIssue) input.readObject();
+				N4JSIssue issue = new N4JSIssue();
+				issue.readExternal(input);
 				validationIssues.get(source).add(issue);
 			}
 		}

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ProjectStatePersister.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ProjectStatePersister.java
@@ -83,7 +83,7 @@ public class ProjectStatePersister {
 	 * - #vs times:
 	 * 	- source URI
 	 * 	- Number #vi of issues of source
-	 * 	- #vi times a validation issue per N4JSIssue.writeExternal
+	 * 	- #vi times a validation issue as per {@link N4JSIssue#writeExternal(ObjectOutput) N4JSIssue.writeExternal}
 	 * </pre>
 	 */
 	private static final int VERSION_1 = 1;

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ProjectUriResourceMap.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ProjectUriResourceMap.java
@@ -24,13 +24,13 @@ import com.google.common.collect.ForwardingMap;
 import com.google.inject.Inject;
 
 /**
- * A project specific map of resources per URI. It acts as a mere filter to the {@link GlobalUriResourceMap} such that
+ * A project specific map of resources per URI. It acts as a mere filter to the {@link WorkspaceUriResourceMap} such that
  * an invocation of {@link #clear()} does not wipe out the entire map contents but only the resources from the current
  * project.
  */
-public class UriResourceMap extends ForwardingMap<URI, Resource> {
+public class ProjectUriResourceMap extends ForwardingMap<URI, Resource> {
 
-	private final GlobalUriResourceMap globalMap;
+	private final WorkspaceUriResourceMap globalMap;
 
 	private final Set<URI> localContents;
 
@@ -38,7 +38,7 @@ public class UriResourceMap extends ForwardingMap<URI, Resource> {
 	 * Standard constructor
 	 */
 	@Inject
-	public UriResourceMap(GlobalUriResourceMap globalMap) {
+	public ProjectUriResourceMap(WorkspaceUriResourceMap globalMap) {
 		this.globalMap = globalMap;
 		this.localContents = new HashSet<>();
 	}

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/UriResourceMap.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/UriResourceMap.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2019 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+package org.eclipse.n4js.ide.xtext.server;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ForwardingMap;
+import com.google.inject.Inject;
+
+/**
+ * A project specific map of resources per URI. It acts as a mere filter to the {@link GlobalUriResourceMap} such that
+ * an invocation of {@link #clear()} does not wipe out the entire map contents but only the resources from the current
+ * project.
+ */
+public class UriResourceMap extends ForwardingMap<URI, Resource> {
+
+	private final GlobalUriResourceMap globalMap;
+
+	private final Set<URI> localContents;
+
+	/**
+	 * Standard constructor
+	 */
+	@Inject
+	public UriResourceMap(GlobalUriResourceMap globalMap) {
+		this.globalMap = globalMap;
+		this.localContents = new HashSet<>();
+	}
+
+	@Override
+	protected Map<URI, Resource> delegate() {
+		return globalMap;
+	}
+
+	@Override
+	public void clear() {
+		delegate().keySet().removeAll(localContents);
+		localContents.clear();
+	}
+
+	@Override
+	public Resource put(URI key, Resource value) {
+		localContents.add(key);
+		return super.put(key, value);
+	}
+
+	@Override
+	public void putAll(Map<? extends URI, ? extends Resource> map) {
+		localContents.addAll(map.keySet());
+		super.putAll(map);
+	}
+
+	@Override
+	public boolean remove(Object key, Object value) {
+		if (localContents.remove(key)) {
+			return super.remove(key, value);
+		}
+		return false;
+	}
+
+	@Override
+	public Collection<Resource> values() {
+		if (localContents.isEmpty()) {
+			return Collections.emptyList();
+		}
+		return Collections2.filter(super.values(), resource -> localContents.contains(resource.getURI()));
+	}
+
+}

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/WorkspaceAwareCanLoadFromDescriptionHelper.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/WorkspaceAwareCanLoadFromDescriptionHelper.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2019 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+package org.eclipse.n4js.ide.xtext.server;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.ResourceSet;
+import org.eclipse.n4js.scoping.utils.CanLoadFromDescriptionHelper;
+import org.eclipse.xtext.resource.XtextResourceSet;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+
+/**
+ * A specialization that will create the resources in the correct project specific resource set.
+ */
+@Singleton
+public class WorkspaceAwareCanLoadFromDescriptionHelper extends CanLoadFromDescriptionHelper {
+
+	@Inject
+	private XWorkspaceManager workspaceManager;
+
+	@Override
+	public Resource createResource(ResourceSet resourceSet, URI resourceURI) {
+		XtextResourceSet projectResourceSet = workspaceManager.getProjectManager(resourceURI).getResourceSet();
+		return super.createResource(projectResourceSet, resourceURI);
+	}
+
+}

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/WorkspaceAwareResourceLocator.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/WorkspaceAwareResourceLocator.java
@@ -10,8 +10,6 @@
  */
 package org.eclipse.n4js.ide.xtext.server;
 
-import java.util.Map;
-
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
 import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
@@ -22,27 +20,24 @@ import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl.ResourceLocator;
  */
 public class WorkspaceAwareResourceLocator extends ResourceLocator {
 
-	private final XProjectManager projectManager;
-	private final Map<URI, Resource> allResources;
+	private final XWorkspaceManager workspaceManager;
 
 	/**
 	 * Standard constructor
 	 */
-	public WorkspaceAwareResourceLocator(ResourceSetImpl resourceSet, XProjectManager projectManager) {
+	public WorkspaceAwareResourceLocator(ResourceSetImpl resourceSet, XWorkspaceManager workspaceManager) {
 		super(resourceSet);
-		this.projectManager = projectManager;
-		this.allResources = resourceSet.getURIResourceMap();
+		this.workspaceManager = workspaceManager;
 	}
 
-	@SuppressWarnings("hiding")
 	@Override
 	public Resource getResource(URI uri, boolean loadOnDemand) {
-		Resource candidate = allResources.get(uri);
+		Resource candidate = resourceSet.getURIResourceMap().get(uri);
 		if (candidate != null) {
 			return candidate;
 		}
-		XProjectManager projectManager = this.projectManager.workspaceManager.getProjectManager(uri);
-		if (projectManager == this.projectManager || projectManager == null) {
+		XProjectManager projectManager = this.workspaceManager.getProjectManager(uri);
+		if (projectManager == null || projectManager.getResourceSet() == resourceSet) {
 			return basicGetResource(uri, loadOnDemand);
 		}
 		return projectManager.getResourceSet().getResource(uri, loadOnDemand);

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/WorkspaceAwareResourceLocator.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/WorkspaceAwareResourceLocator.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2019 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+package org.eclipse.n4js.ide.xtext.server;
+
+import java.util.Map;
+
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl;
+import org.eclipse.emf.ecore.resource.impl.ResourceSetImpl.ResourceLocator;
+
+/**
+ * A resource locator that will redirect requests to the resource set of the containing project.
+ */
+public class WorkspaceAwareResourceLocator extends ResourceLocator {
+
+	private final XProjectManager projectManager;
+	private final Map<URI, Resource> allResources;
+
+	/**
+	 * Standard constructor
+	 */
+	public WorkspaceAwareResourceLocator(ResourceSetImpl resourceSet, XProjectManager projectManager) {
+		super(resourceSet);
+		this.projectManager = projectManager;
+		this.allResources = resourceSet.getURIResourceMap();
+	}
+
+	@SuppressWarnings("hiding")
+	@Override
+	public Resource getResource(URI uri, boolean loadOnDemand) {
+		Resource candidate = allResources.get(uri);
+		if (candidate != null) {
+			return candidate;
+		}
+		XProjectManager projectManager = this.projectManager.workspaceManager.getProjectManager(uri);
+		if (projectManager == this.projectManager || projectManager == null) {
+			return basicGetResource(uri, loadOnDemand);
+		}
+		return projectManager.getResourceSet().getResource(uri, loadOnDemand);
+	}
+
+}

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/WorkspaceUriResourceMap.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/WorkspaceUriResourceMap.java
@@ -22,6 +22,6 @@ import com.google.inject.Singleton;
  * workspace.
  */
 @Singleton
-public class GlobalUriResourceMap extends HashMap<URI, Resource> {
+public class WorkspaceUriResourceMap extends HashMap<URI, Resource> {
 	// nothing to do
 }

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/XBuildManager.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/XBuildManager.java
@@ -268,12 +268,12 @@ public class XBuildManager {
 
 	private Map<ProjectDescription, Set<URI>> computeProjectToUriMap(Collection<URI> uris) {
 		Map<ProjectDescription, Set<URI>> project2uris = new HashMap<>();
-		for (URI deleted : uris) {
-			ProjectDescription projectDescription = workspaceManager.getProjectManager(deleted).getProjectDescription();
+		for (URI uri : uris) {
+			ProjectDescription projectDescription = workspaceManager.getProjectManager(uri).getProjectDescription();
 			if (!project2uris.containsKey(projectDescription)) {
 				project2uris.put(projectDescription, new HashSet<>());
 			}
-			project2uris.get(projectDescription).add(deleted);
+			project2uris.get(projectDescription).add(uri);
 		}
 		return project2uris;
 	}

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/XLanguageServerImpl.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/XLanguageServerImpl.java
@@ -1149,30 +1149,31 @@ public class XLanguageServerImpl implements LanguageServer, WorkspaceService, Te
 
 	@Override
 	public void afterBuild(List<IResourceDescription.Delta> deltas) {
-		FluentIterable.from(deltas).filter(it -> it.getNew() != null).transform(it -> it.getUri().toString()).forEach(
-				it -> {
-					access.doRead(it, ctx -> {
-						if (ctx.isDocumentOpen()) {
-							if (ctx.getResource() instanceof XtextResource) {
-								XtextResource resource = ((XtextResource) ctx.getResource());
-								IColoringService coloringService = resource.getResourceServiceProvider()
-										.get(IColoringService.class);
-								if (coloringService != null && client instanceof LanguageClientExtensions) {
-									Document doc = ctx.getDocument();
-									List<? extends ColoringInformation> coloringInfos = coloringService
-											.getColoring(resource, doc);
-									if (!IterableExtensions.isNullOrEmpty(coloringInfos)) {
-										String uri = resource.getURI().toString();
-										((LanguageClientExtensions) client)
-												.updateColoring(new ColoringParams(uri, coloringInfos));
+		FluentIterable.from(deltas).filter(it -> it.getNew() != null && workspaceManager.isDocumentOpen(it.getUri()))
+				.transform(it -> it.getUri().toString()).forEach(
+						it -> {
+							access.doRead(it, ctx -> {
+								if (ctx.isDocumentOpen()) {
+									if (ctx.getResource() instanceof XtextResource) {
+										XtextResource resource = ((XtextResource) ctx.getResource());
+										IColoringService coloringService = resource.getResourceServiceProvider()
+												.get(IColoringService.class);
+										if (coloringService != null && client instanceof LanguageClientExtensions) {
+											Document doc = ctx.getDocument();
+											List<? extends ColoringInformation> coloringInfos = coloringService
+													.getColoring(resource, doc);
+											if (!IterableExtensions.isNullOrEmpty(coloringInfos)) {
+												String uri = resource.getURI().toString();
+												((LanguageClientExtensions) client)
+														.updateColoring(new ColoringParams(uri, coloringInfos));
+											}
+										}
 									}
 								}
-							}
-						}
-						semanticHighlightingRegistry.update(ctx);
-						return null;
-					});
-				});
+								semanticHighlightingRegistry.update(ctx);
+								return null;
+							});
+						});
 	}
 
 	/**

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/XProjectManager.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/XProjectManager.java
@@ -88,7 +88,7 @@ public class XProjectManager {
 	 * The map for this project's resource set.
 	 */
 	@Inject
-	protected UriResourceMap uriResourceMap;
+	protected ProjectUriResourceMap uriResourceMap;
 
 	/** The workspace manager */
 	@Inject

--- a/plugins/org.eclipse.n4js.transpiler.es/src/org/eclipse/n4js/transpiler/es/n4idl/N4IDLVersionedImportsTransformation.java
+++ b/plugins/org.eclipse.n4js.transpiler.es/src/org/eclipse/n4js/transpiler/es/n4idl/N4IDLVersionedImportsTransformation.java
@@ -17,6 +17,7 @@ import org.eclipse.n4js.n4JS.ImportDeclaration;
 import org.eclipse.n4js.n4JS.ImportSpecifier;
 import org.eclipse.n4js.n4JS.NamedImportSpecifier;
 import org.eclipse.n4js.n4idl.transpiler.utils.N4IDLTranspilerUtils;
+import org.eclipse.n4js.transpiler.AbstractTranspiler;
 import org.eclipse.n4js.transpiler.Transformation;
 import org.eclipse.n4js.transpiler.im.SymbolTableEntryOriginal;
 import org.eclipse.n4js.transpiler.im.VersionedNamedImportSpecifier_IM;
@@ -54,9 +55,11 @@ public class N4IDLVersionedImportsTransformation extends Transformation {
 
 	@Override
 	public void assertPostConditions() {
-		assertTrue("There should not be any more implicitly versioned imports in the IM.",
-				EcoreUtil2.getAllContentsOfType(getState().im, VersionedNamedImportSpecifier_IM.class)
-						.stream().noneMatch(VersionedNamedImportSpecifier_IM::isVersionedTypeImport));
+		if (AbstractTranspiler.DEBUG_PERFORM_ASSERTIONS) {
+			assertTrue("There should not be any more implicitly versioned imports in the IM.",
+					EcoreUtil2.getAllContentsOfType(getState().im, VersionedNamedImportSpecifier_IM.class)
+							.stream().noneMatch(VersionedNamedImportSpecifier_IM::isVersionedTypeImport));
+		}
 	}
 
 	@Override

--- a/plugins/org.eclipse.n4js.transpiler.es/src/org/eclipse/n4js/transpiler/es/transform/ArrowFunction_Part2_Transformation.xtend
+++ b/plugins/org.eclipse.n4js.transpiler.es/src/org/eclipse/n4js/transpiler/es/transform/ArrowFunction_Part2_Transformation.xtend
@@ -18,6 +18,7 @@ import org.eclipse.n4js.transpiler.TransformationDependency.Requires
 import static org.eclipse.n4js.transpiler.TranspilerBuilderBlocks.*
 
 import static extension org.eclipse.n4js.typesystem.utils.RuleEnvironmentExtensions.*
+import org.eclipse.n4js.transpiler.AbstractTranspiler
 
 /**
  * Part 2 of {@link ArrowFunction_Part1_Transformation}.
@@ -36,7 +37,9 @@ class ArrowFunction_Part2_Transformation extends Transformation {
 	}
 
 	override assertPostConditions() {
-		"No arrow-function left in IM".assertTrue( collectNodes(state.im, ArrowFunction, true).isEmpty );
+		if (AbstractTranspiler.DEBUG_PERFORM_ASSERTIONS) {
+			"No arrow-function left in IM".assertTrue( collectNodes(state.im, ArrowFunction, true).isEmpty );
+		}
 	}
 
 	override transform() {

--- a/plugins/org.eclipse.n4js.transpiler.es/src/org/eclipse/n4js/transpiler/es/transform/DestructuringTransformation.xtend
+++ b/plugins/org.eclipse.n4js.transpiler.es/src/org/eclipse/n4js/transpiler/es/transform/DestructuringTransformation.xtend
@@ -48,6 +48,7 @@ import static org.eclipse.n4js.transpiler.TranspilerBuilderBlocks.*
 
 import static extension org.eclipse.n4js.n4JS.DestructureUtils.*
 import static extension org.eclipse.n4js.typesystem.utils.RuleEnvironmentExtensions.*
+import org.eclipse.n4js.transpiler.AbstractTranspiler
 
 /**
  * Transforms ES6 destructuring patterns into equivalent ES5 code. If the target engine supports ES6 destructuring
@@ -169,8 +170,10 @@ class DestructuringTransformation extends Transformation {
 			if(!stmnt.varDeclsOrBindings.empty) {
 				// something like: for( var [a,b] of [ [1,2], [3,4] ] ) {}
 
-				assertTrue("there should be exactly one VariableBinding in stmnt.varDeclsOrBindings",
-					stmnt.varDeclsOrBindings.size===1 && stmnt.varDeclsOrBindings.get(0) instanceof VariableBinding);
+				if (AbstractTranspiler.DEBUG_PERFORM_ASSERTIONS) {
+					assertTrue("there should be exactly one VariableBinding in stmnt.varDeclsOrBindings",
+						stmnt.varDeclsOrBindings.size===1 && stmnt.varDeclsOrBindings.get(0) instanceof VariableBinding);					
+				}
 
 				val rootNode = DestructNode.unify(stmnt.varDeclsOrBindings.head as VariableBinding);
 				traverse(helperVars, simpleAssignments, rootNode, _IdentRef(iterVarSTE), null);  // fparname = null since we do not generate any function.
@@ -267,9 +270,10 @@ class DestructuringTransformation extends Transformation {
 		val currHelperVarDecl = _VariableDeclaration(currHelperVarName);
 		helperVars += currHelperVarDecl;
 		val SymbolTableEntry currHelperVarSTE = findSymbolTableEntryForElement(currHelperVarDecl, true);
-		assertTrue("", currHelperVarSTE.getVariableDeclarationFromSTE === currHelperVarDecl);
-		assertTrue("", currHelperVarSTE.elementsOfThisName.contains(currHelperVarDecl));
-
+		if (AbstractTranspiler.DEBUG_PERFORM_ASSERTIONS) {
+			assertTrue("", currHelperVarSTE.getVariableDeclarationFromSTE === currHelperVarDecl);
+			assertTrue("", currHelperVarSTE.elementsOfThisName.contains(currHelperVarDecl));
+		}
 		var $sliceToArrayForDestructSTE = steFor_$sliceToArrayForDestruct;
 
 		if(isRest) {

--- a/plugins/org.eclipse.n4js.transpiler.es/src/org/eclipse/n4js/transpiler/es/transform/EnumAccessTransformation.xtend
+++ b/plugins/org.eclipse.n4js.transpiler.es/src/org/eclipse/n4js/transpiler/es/transform/EnumAccessTransformation.xtend
@@ -41,7 +41,6 @@ class EnumAccessTransformation extends Transformation {
 
 
 	override assertPreConditions() {
-		member_StringBasedEnum_literals = state.G.n4StringBasedEnumType.findOwnedMember("literals", false, true);
 		assertNotNull("member of built-in type not found: StringBasedEnum#literals", member_StringBasedEnum_literals);
 	}
 
@@ -49,6 +48,7 @@ class EnumAccessTransformation extends Transformation {
 	}
 
 	override analyze() {
+		member_StringBasedEnum_literals = state.G.n4StringBasedEnumType.findOwnedMember("literals", false, true);
 	}
 
 	override transform() {

--- a/plugins/org.eclipse.n4js.transpiler.es/src/org/eclipse/n4js/transpiler/es/transform/RestParameterTransformation.xtend
+++ b/plugins/org.eclipse.n4js.transpiler.es/src/org/eclipse/n4js/transpiler/es/transform/RestParameterTransformation.xtend
@@ -18,6 +18,7 @@ import org.eclipse.n4js.transpiler.TransformationDependency.RequiresBefore
 import org.eclipse.xtext.EcoreUtil2
 
 import static org.eclipse.n4js.transpiler.TranspilerBuilderBlocks.*
+import org.eclipse.n4js.transpiler.AbstractTranspiler
 
 /**
  * Transforms ES2015 rest parameters to an ES5 equivalent.
@@ -44,10 +45,12 @@ class RestParameterTransformation extends Transformation {
 	}
 
 	override assertPostConditions() {
-		// as a result of this transformation no rest parameter should be found in the entire model.
-		val allFormalParameter = EcoreUtil2.eAllOfType(state.im, FormalParameter);
-		val stillVariadic = allFormalParameter.filter[it.isVariadic].toList;
-		assertTrue("no rest parameter should be in the model.", stillVariadic.size === 0);
+		if (AbstractTranspiler.DEBUG_PERFORM_ASSERTIONS) {
+			// as a result of this transformation no rest parameter should be found in the entire model.
+			val allFormalParameter = EcoreUtil2.eAllOfType(state.im, FormalParameter);
+			val stillVariadic = allFormalParameter.filter[it.isVariadic].toList;
+			assertTrue("no rest parameter should be in the model.", stillVariadic.size === 0);
+		}
 	}
 
 

--- a/plugins/org.eclipse.n4js.transpiler.es/src/org/eclipse/n4js/transpiler/es/transform/SanitizeImportsTransformation.xtend
+++ b/plugins/org.eclipse.n4js.transpiler.es/src/org/eclipse/n4js/transpiler/es/transform/SanitizeImportsTransformation.xtend
@@ -23,6 +23,7 @@ import org.eclipse.n4js.transpiler.im.SymbolTableEntryOriginal
 import org.eclipse.n4js.transpiler.utils.TranspilerUtils
 import org.eclipse.n4js.utils.N4JSLanguageUtils
 import org.eclipse.xtext.EcoreUtil2
+import org.eclipse.n4js.transpiler.AbstractTranspiler
 
 /**
  * Transformation to clean up imports:
@@ -37,16 +38,20 @@ class SanitizeImportsTransformation extends Transformation {
 	}
 
 	override assertPreConditions() {
-		assertTrue("requires a fully resolved script", state.im.flaggedUsageMarkingFinished);
+		if (AbstractTranspiler.DEBUG_PERFORM_ASSERTIONS) {
+			assertTrue("requires a fully resolved script", state.im.flaggedUsageMarkingFinished);
+		}
 	}
 
 	override assertPostConditions() {
-		// no import with flag used in code = false contained.
-		val unusedImports = EcoreUtil2.getAllContentsOfType( state.im, ImportSpecifier ).filter[!isUsed].toList;
-		assertTrue( "There should not be any unused import."
-			+" Unused="+ Joiner.on(",").join(unusedImports)
-			, unusedImports.size === 0
-		);
+		if (AbstractTranspiler.DEBUG_PERFORM_ASSERTIONS) {
+			// no import with flag used in code = false contained.
+			val unusedImports = EcoreUtil2.getAllContentsOfType( state.im, ImportSpecifier ).filter[!isUsed].toList;
+			assertTrue( "There should not be any unused import."
+				+" Unused="+ Joiner.on(",").join(unusedImports)
+				, unusedImports.size === 0
+			);
+		}
 	}
 
 	override transform() {

--- a/plugins/org.eclipse.n4js.transpiler/src/org/eclipse/n4js/transpiler/AbstractTranspiler.java
+++ b/plugins/org.eclipse.n4js.transpiler/src/org/eclipse/n4js/transpiler/AbstractTranspiler.java
@@ -48,9 +48,13 @@ import com.google.inject.Inject;
  */
 public abstract class AbstractTranspiler {
 
+	/** */
 	public static final boolean DEBUG_DUMP_STATE = false;
+	/** */
 	public static final boolean DEBUG_DRAW_STATE = false;
+	/** */
 	public static final boolean DEBUG_PERFORM_ASSERTIONS = false;
+	/** */
 	public static final boolean DEBUG_PERFORM_VALIDATIONS = false;
 
 	@Inject

--- a/plugins/org.eclipse.n4js.transpiler/src/org/eclipse/n4js/transpiler/AbstractTranspiler.java
+++ b/plugins/org.eclipse.n4js.transpiler/src/org/eclipse/n4js/transpiler/AbstractTranspiler.java
@@ -48,10 +48,10 @@ import com.google.inject.Inject;
  */
 public abstract class AbstractTranspiler {
 
-	private static final boolean DEBUG_DUMP_STATE = false;
-	private static final boolean DEBUG_DRAW_STATE = false;
-	private static final boolean DEBUG_PERFORM_ASSERTIONS = true;
-	private static final boolean DEBUG_PERFORM_VALIDATIONS = true;
+	public static final boolean DEBUG_DUMP_STATE = false;
+	public static final boolean DEBUG_DRAW_STATE = false;
+	public static final boolean DEBUG_PERFORM_ASSERTIONS = false;
+	public static final boolean DEBUG_PERFORM_VALIDATIONS = false;
 
 	@Inject
 	private PreparationStep preparationStep;

--- a/plugins/org.eclipse.n4js.transpiler/src/org/eclipse/n4js/transpiler/assistants/TypeAssistant.xtend
+++ b/plugins/org.eclipse.n4js.transpiler/src/org/eclipse/n4js/transpiler/assistants/TypeAssistant.xtend
@@ -34,6 +34,7 @@ import java.util.List
 import static org.eclipse.n4js.transpiler.TranspilerBuilderBlocks.*
 
 import static extension org.eclipse.n4js.typesystem.utils.RuleEnvironmentExtensions.*
+import org.eclipse.n4js.transpiler.AbstractTranspiler
 
 /**
  */
@@ -46,21 +47,24 @@ class TypeAssistant extends TransformationAssistant {
 	 * therefore factored out into this helper method.
 	 */
 	def public void assertClassifierPreConditions() {
-		val allClassifierDecls = collectNodes(state.im, N4ClassifierDeclaration, false);
-		assertTrue("all classifier declarations must have an original defined type",
-			allClassifierDecls.forall[state.info.getOriginalDefinedType(it)!==null]);
-		assertTrue("all class declarations must have a superClassRef pointing to a STE with an original target (if non-null)",
-			allClassifierDecls.filter(N4ClassDeclaration).map[superClassRef].filterNull.filter(ParameterizedTypeRef_IM)
-			.forall[
-				val originalDeclType = originalTargetOfRewiredTarget;
-				return originalDeclType instanceof TClass || originalDeclType instanceof TObjectPrototype;
-			]);
-		assertTrue("all classifier declarations must have all implementedOrExtendedInterfaceRefs pointing to a STE with an original target",
-			allClassifierDecls.map[implementedOrExtendedInterfaceRefs].flatten.filter(ParameterizedTypeRef_IM)
-			.forall[
-				val originalDeclType = originalTargetOfRewiredTarget;
-				return originalDeclType instanceof TInterface;
-			]);
+		if (AbstractTranspiler.DEBUG_PERFORM_ASSERTIONS) {
+			val allClassifierDecls = collectNodes(state.im, N4ClassifierDeclaration, false);
+			assertTrue("all classifier declarations must have an original defined type",
+				allClassifierDecls.forall[state.info.getOriginalDefinedType(it)!==null]);
+			assertTrue("all class declarations must have a superClassRef pointing to a STE with an original target (if non-null)",
+				allClassifierDecls.filter(N4ClassDeclaration).map[superClassRef].filterNull.filter(ParameterizedTypeRef_IM)
+				.forall[
+					val originalDeclType = originalTargetOfRewiredTarget;
+					return originalDeclType instanceof TClass || originalDeclType instanceof TObjectPrototype;
+				]);
+			assertTrue("all classifier declarations must have all implementedOrExtendedInterfaceRefs pointing to a STE with an original target",
+				allClassifierDecls.map[implementedOrExtendedInterfaceRefs].flatten.filter(ParameterizedTypeRef_IM)
+				.forall[
+					val originalDeclType = originalTargetOfRewiredTarget;
+					return originalDeclType instanceof TInterface;
+				]);
+			
+		}
 	}
 
 	/**

--- a/plugins/org.eclipse.n4js.ts.model/src/org/eclipse/n4js/ts/types/util/AllSuperTypeRefsCollector.java
+++ b/plugins/org.eclipse.n4js.ts.model/src/org/eclipse/n4js/ts/types/util/AllSuperTypeRefsCollector.java
@@ -12,8 +12,6 @@ package org.eclipse.n4js.ts.types.util;
 
 import java.util.List;
 
-import com.google.common.collect.Lists;
-
 import org.eclipse.n4js.ts.typeRefs.ParameterizedTypeRef;
 import org.eclipse.n4js.ts.typeRefs.TypeRefsFactory;
 import org.eclipse.n4js.ts.types.ContainerType;
@@ -21,6 +19,8 @@ import org.eclipse.n4js.ts.types.PrimitiveType;
 import org.eclipse.n4js.ts.types.TClass;
 import org.eclipse.n4js.ts.types.TInterface;
 import org.eclipse.n4js.ts.types.TObjectPrototype;
+
+import com.google.common.collect.Lists;
 
 /**
  */

--- a/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/labeling/helper/ImageDescriptionHelper.xtend
+++ b/plugins/org.eclipse.n4js.ui/src/org/eclipse/n4js/ui/labeling/helper/ImageDescriptionHelper.xtend
@@ -32,6 +32,7 @@ import org.eclipse.xtext.resource.FileExtensionProvider
 import org.eclipse.xtext.util.CancelIndicator
 import org.eclipse.xtext.validation.IResourceValidator
 import org.eclipse.xtext.validation.Issue
+import org.eclipse.xtext.validation.CheckMode
 
 /**
  * Helper class to create and cache image descriptions as triggered by
@@ -164,15 +165,15 @@ class ImageDescriptionHelper {
 	 */
 	def private IssueSummary getOrElseUpdateSummary(EObject eo, CancelIndicator cancelIndicator) {
 		val res = eo.eResource
-		synchronized(cache) {
-			val issues = cache.getOrElseUpdateIssues(resourceValidator, res, cancelIndicator)
+		val summary = cache.get("ImageDescriptionHelper-IssueSummary", res) [|
+			val issues = resourceValidator.validate(res, CheckMode.ALL, cancelIndicator);
 			if ((null === issues) || cancelIndicator.isCanceled) {
 				// due to cancellation the list of issues may be incomplete, thus don't store in the cache
 				return IssueSummary.EMPTY_SUMMARY
-			}
-			val summary = cache.get("ImageDescriptionHelper-IssueSummary", res, [| IssueSummary.create(issues)])
-			return summary
-		}
+			} 
+			return IssueSummary.create(issues)
+		]
+		return summary
 	}
 
 	/**

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/generator/AbstractSubGenerator.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/generator/AbstractSubGenerator.xtend
@@ -44,6 +44,7 @@ import org.eclipse.xtext.validation.IResourceValidator
 import org.eclipse.xtext.validation.Issue
 
 import static org.eclipse.xtext.diagnostics.Severity.*
+import org.eclipse.xtext.validation.CheckMode
 
 /**
  * All sub generators should extend this class. It provides basic blocks of the logic, and
@@ -207,7 +208,7 @@ abstract class AbstractSubGenerator implements ISubGenerator, IGenerator2 {
 	 * If validation was canceled before finishing, don't assume absence of errors.
 	 */
 	private def boolean hasNoErrors(Resource input, CancelIndicator monitor) {
-		val issues = cache.getOrElseUpdateIssues(resVal, input, monitor)
+		val issues = resVal.validate(input, CheckMode.ALL, monitor);
 		if (null === issues) {
 			// Cancellation occurred likely before all validations completed, thus can't assume absence of errors.
 			// Cancellation may result in exit via normal control-flow (this case) or via exceptional control-flow (see exception handler below)

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSCache.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSCache.java
@@ -28,6 +28,7 @@ import org.eclipse.xtext.service.OperationCanceledError;
 import org.eclipse.xtext.service.OperationCanceledManager;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.util.OnChangeEvictingCache;
+import org.eclipse.xtext.validation.CheckMode;
 import org.eclipse.xtext.validation.IResourceValidator;
 import org.eclipse.xtext.validation.Issue;
 
@@ -81,11 +82,14 @@ public class N4JSCache extends OnChangeEvictingCache {
 	 * Other threads besides those for outline view and transpiler could in principle access the cache. However that's a
 	 * situation that's pre-existent to the just described sharing between outline and transpiler.
 	 */
-	public synchronized List<Issue> getOrElseUpdateIssues(IResourceValidator resourceValidator, Resource res,
+	public List<Issue> getOrElseUpdateIssues(
+			IResourceValidator resourceValidator,
+			Resource res,
+			CheckMode checkMode,
 			CancelIndicator monitor) {
 		try {
-			List<Issue> issues = get("N4JS-IDE-AllIssues", res,
-					new IssuesProvider(resourceValidator, res, operationCanceledManager, monitor));
+			List<Issue> issues = get("N4JS-IDE-AllIssues" + checkMode, res,
+					new IssuesProvider(resourceValidator, res, checkMode, operationCanceledManager, monitor));
 			return issues;
 		} catch (OperationCanceledError oce) {
 			// observation: the cache remains unchanged, to avoid cache corruption.

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSResource.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/resource/N4JSResource.java
@@ -460,6 +460,14 @@ public class N4JSResource extends PostProcessingAwareResource implements ProxyRe
 		return script != null && module != null && isASTProxy(script) && !module.eIsProxy();
 	}
 
+	@Override
+	public IParseResult getParseResult() {
+		if (!aboutToBeUnloaded && isLoadedFromDescription()) {
+			getContents().get(0);
+		}
+		return super.getParseResult();
+	}
+
 	/**
 	 * Adds just a check, that a not loaded resource is not allowed to be saved.
 	 */

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/scoping/utils/CanLoadFromDescriptionHelper.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/scoping/utils/CanLoadFromDescriptionHelper.java
@@ -244,9 +244,19 @@ public class CanLoadFromDescriptionHelper {
 	}
 
 	/**
-	 * Create a resource in the context of the given resource set.
+	 * Create a resource in the context of the given resource set. This is only necessary when working with
+	 * {@link UserDataAwareScope} where we don't use {@link ResourceSet#getResource(URI, boolean) getResource} but
+	 * {@link ResourceSet#createResource(URI) createResource} to implement a custom semantics with
+	 * {@link N4JSResource#loadFromDescription(IResourceDescription)}.
+	 *
+	 * It is not a generic replacement for all clients of the resource set.
 	 */
 	public Resource createResource(ResourceSet resourceSet, URI resourceURI) {
+		/*
+		 * Implementation note: In LSP we need to redirect the request to create a resource to a well defined resource
+		 * set. LSP associates projects to resource sets and we have to make sure that we do not create resources in the
+		 * wrong project context. Therefore this method if overridden for LSP.
+		 */
 		return resourceSet.createResource(resourceURI);
 	}
 

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/scoping/utils/CanLoadFromDescriptionHelper.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/scoping/utils/CanLoadFromDescriptionHelper.java
@@ -243,4 +243,11 @@ public class CanLoadFromDescriptionHelper {
 		return Optional.ofNullable(description).flatMap(UserdataMapper::readDependenciesFromDescription);
 	}
 
+	/**
+	 * Create a resource in the context of the given resource set.
+	 */
+	public Resource createResource(ResourceSet resourceSet, URI resourceURI) {
+		return resourceSet.createResource(resourceURI);
+	}
+
 }

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/scoping/utils/UserDataAwareScope.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/scoping/utils/UserDataAwareScope.java
@@ -173,7 +173,7 @@ public class UserDataAwareScope extends PolyfillAwareSelectableBasedScope {
 				return original;
 			}
 			if (resource == null) {
-				resource = resourceSet.createResource(resourceURI);
+				resource = canLoadFromDescriptionHelper.createResource(resourceSet, resourceURI);
 			}
 			if (resource instanceof N4JSResource) {
 				if (resource.getContents().isEmpty()) {

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/N4JSResourceValidator.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/N4JSResourceValidator.java
@@ -21,6 +21,7 @@ import org.eclipse.n4js.packagejson.PackageJsonUtils;
 import org.eclipse.n4js.projectDescription.ProjectType;
 import org.eclipse.n4js.projectModel.IN4JSCore;
 import org.eclipse.n4js.projectModel.IN4JSProject;
+import org.eclipse.n4js.resource.N4JSCache;
 import org.eclipse.n4js.resource.N4JSResource;
 import org.eclipse.n4js.utils.ResourceType;
 import org.eclipse.xtext.service.OperationCanceledManager;
@@ -48,9 +49,10 @@ public class N4JSResourceValidator extends ResourceValidatorImpl {
 	private IN4JSCore n4jsCore;
 	@Inject
 	private OperationCanceledManager operationCanceledManager;
+	@Inject
+	private N4JSCache n4jsCache;
 
-	@Override
-	public List<Issue> validate(Resource resource, CheckMode mode, CancelIndicator cancelIndicator) {
+	private List<Issue> doValidate(Resource resource, CheckMode mode, CancelIndicator cancelIndicator) {
 		// QUICK EXIT #1: in case of invalid file type (e.g. js file in a project with project type definition)
 		final IN4JSProject project = n4jsCore.findProject(resource.getURI()).orNull();
 		if (project != null && !isValidFileTypeForProjectType(resource, project)) {
@@ -100,6 +102,11 @@ public class N4JSResourceValidator extends ResourceValidatorImpl {
 			}
 		}
 		return super.validate(resource, mode, cancelIndicator);
+	}
+
+	@Override
+	public List<Issue> validate(Resource resource, CheckMode mode, CancelIndicator cancelIndicator) {
+		return n4jsCache.getOrElseUpdateIssues(this::doValidate, resource, mode, cancelIndicator);
 	}
 
 	/**

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/helper/IssuesProvider.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/helper/IssuesProvider.java
@@ -42,12 +42,14 @@ public final class IssuesProvider implements Provider<List<Issue>> {
 	private final Resource r;
 	private final OperationCanceledManager operationCanceledManager;
 	private final CancelIndicator ci;
+	private final CheckMode checkMode;
 
 	@SuppressWarnings("javadoc")
-	public IssuesProvider(IResourceValidator resourceValidator, Resource res,
+	public IssuesProvider(IResourceValidator resourceValidator, Resource res, CheckMode checkMode,
 			OperationCanceledManager operationCanceledManager, CancelIndicator ci) {
 		this.rv = resourceValidator;
 		this.r = res;
+		this.checkMode = checkMode;
 		this.operationCanceledManager = operationCanceledManager;
 		this.ci = ci;
 	}
@@ -71,7 +73,7 @@ public final class IssuesProvider implements Provider<List<Issue>> {
 				: N4JSDataCollectors.dcValidations;
 		List<Issue> issues;
 		try (Measurement m = dc.getMeasurement("validation");) {
-			issues = rv.validate(r, CheckMode.ALL, ci);
+			issues = rv.validate(r, checkMode, ci);
 		}
 		if (!issues.contains(null)) {
 			operationCanceledManager.checkCanceled(ci);

--- a/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/resource/N4JSResourceLoadStatesTest.xtend
+++ b/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/resource/N4JSResourceLoadStatesTest.xtend
@@ -285,10 +285,10 @@ class N4JSResourceLoadStatesTest extends AbstractN4JSTest {
 		assertNotNull(info);
 		switch(info.parseResult) {
 			case NULL: {
-				assertNull("in state " + state + " parse result should be null", res.parseResult);
+				assertNull("in state " + state + " parse result should be null", res.basicGetParseResult);
 			}
 			case AVAILABLE: {
-				assertNotNull("in state " + state + " parse result should be available", res.parseResult);
+				assertNotNull("in state " + state + " parse result should be available", res.basicGetParseResult);
 			}
 			default: {
 				throw new IllegalStateException("unknown literal: " + info.parseResult);
@@ -364,7 +364,7 @@ class N4JSResourceLoadStatesTest extends AbstractN4JSTest {
 				info.reconciled, res.reconciled);
 		}
 	}
-
+	
 	def private boolean containsDeferredTypeRef(EObject root) {
 		return !root.eAllContents.filter(DeferredTypeRef).empty;
 	}

--- a/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/resource/N4JSResourceLoadStatesTest.xtend
+++ b/tests/org.eclipse.n4js.lang.tests/src/org/eclipse/n4js/tests/resource/N4JSResourceLoadStatesTest.xtend
@@ -364,7 +364,7 @@ class N4JSResourceLoadStatesTest extends AbstractN4JSTest {
 				info.reconciled, res.reconciled);
 		}
 	}
-	
+
 	def private boolean containsDeferredTypeRef(EObject root) {
 		return !root.eAllContents.filter(DeferredTypeRef).empty;
 	}


### PR DESCRIPTION
This PR ensures that resources are not loaded redundantly in the LSP builder case but
resolved from the dependent project's associated resource set instead. ResourceLocators to the rescue.

When a project is built initially, all its resources are loaded into a resource set including their AST. After the project build is done, the resource set is cleared.

Downstream projects in the dependency graph will attempt to use the resources from their dependencies. These are loaded from description into the resource set of their own project. Other projects may reuse these without the need to load them again. With the AST, the resources are very slim and can be kept in memory (for now).

Also the caching of validation issues was improved.

see #1561 