### PR TITLE
GH-1561: Reduce memory consumption when creating the test catalog

### DIFF
--- a/plugins/org.eclipse.n4js.cli/src/org/eclipse/n4js/cli/compiler/N4jscCompiler.java
+++ b/plugins/org.eclipse.n4js.cli/src/org/eclipse/n4js/cli/compiler/N4jscCompiler.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.SortedMap;
@@ -202,7 +203,7 @@ public class N4jscCompiler {
 					true); // do not include "endpoint" property here
 
 			try (OutputStream os = new BufferedOutputStream(new FileOutputStream(testCatalogFile))) {
-				os.write(catalog.getBytes("UTF-8"));
+				os.write(catalog.getBytes(StandardCharsets.UTF_8));
 				os.flush();
 
 			} catch (IOException e) {

--- a/plugins/org.eclipse.n4js.cli/src/org/eclipse/n4js/cli/compiler/N4jscCompiler.java
+++ b/plugins/org.eclipse.n4js.cli/src/org/eclipse/n4js/cli/compiler/N4jscCompiler.java
@@ -198,7 +198,8 @@ public class N4jscCompiler {
 			Injector injector = N4jscFactory.getOrCreateInjector();
 			TestCatalogSupplier testCatalogSupplier = injector.getInstance(TestCatalogSupplier.class);
 
-			String catalog = testCatalogSupplier.get(true); // do not include "endpoint" property here
+			String catalog = testCatalogSupplier.get((uri) -> workspaceManager.getProjectManager(uri).getResourceSet(),
+					true); // do not include "endpoint" property here
 
 			try (OutputStream os = new BufferedOutputStream(new FileOutputStream(testCatalogFile))) {
 				os.write(catalog.getBytes("UTF-8"));

--- a/plugins/org.eclipse.n4js.cli/src/org/eclipse/n4js/cli/compiler/N4jscCompiler.java
+++ b/plugins/org.eclipse.n4js.cli/src/org/eclipse/n4js/cli/compiler/N4jscCompiler.java
@@ -10,9 +10,11 @@
  */
 package org.eclipse.n4js.cli.compiler;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.SortedMap;
@@ -198,9 +200,9 @@ public class N4jscCompiler {
 
 			String catalog = testCatalogSupplier.get(true); // do not include "endpoint" property here
 
-			try (FileOutputStream fos = new FileOutputStream(testCatalogFile)) {
-				fos.write(catalog.getBytes());
-				fos.flush();
+			try (OutputStream os = new BufferedOutputStream(new FileOutputStream(testCatalogFile))) {
+				os.write(catalog.getBytes("UTF-8"));
+				os.flush();
 
 			} catch (IOException e) {
 				String msg = "Error while writing test catalog file at: " + testCatalogFile;

--- a/plugins/org.eclipse.n4js.tester/src/org/eclipse/n4js/tester/TestCatalogSupplier.java
+++ b/plugins/org.eclipse.n4js.tester/src/org/eclipse/n4js/tester/TestCatalogSupplier.java
@@ -21,8 +21,8 @@ import com.google.common.base.Supplier;
 import com.google.inject.Inject;
 
 /**
- * Service for supplying the the test catalog based on all tests available available in the ({@link IN4JSCore N4JS core}
- * based) workspace. The content of the provided test catalog depends on the built state of the workspace.
+ * Service for supplying the test catalog based on all tests available in the ({@link IN4JSCore N4JS core} based)
+ * workspace. The content of the provided test catalog depends on the built state of the workspace.
  * <p>
  * By default, i.e. when method {@link #get()} is invoked, the generated JSON will include a top-level property
  * "endpoint" with a URL pointing to the Jetty server for test reporting. Method {@link #get(boolean)} may be used to

--- a/plugins/org.eclipse.n4js.tester/src/org/eclipse/n4js/tester/TestCatalogSupplier.java
+++ b/plugins/org.eclipse.n4js.tester/src/org/eclipse/n4js/tester/TestCatalogSupplier.java
@@ -11,24 +11,26 @@
 package org.eclipse.n4js.tester;
 
 import java.util.Collections;
+import java.util.function.Function;
 
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.emf.common.util.URI;
+import org.eclipse.emf.ecore.resource.ResourceSet;
 import org.eclipse.n4js.projectModel.IN4JSCore;
 import org.eclipse.n4js.tester.domain.TestTree;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.base.Supplier;
 import com.google.inject.Inject;
 
 /**
  * Service for supplying the test catalog based on all tests available in the ({@link IN4JSCore N4JS core} based)
  * workspace. The content of the provided test catalog depends on the built state of the workspace.
  * <p>
- * By default, i.e. when method {@link #get()} is invoked, the generated JSON will include a top-level property
- * "endpoint" with a URL pointing to the Jetty server for test reporting. Method {@link #get(boolean)} may be used to
- * avoid this property.
+ * By default, i.e. when method {@link #get(Function)} is invoked, the generated JSON will include a top-level property
+ * "endpoint" with a URL pointing to the Jetty server for test reporting. Method {@link #get(Function, boolean)} may be
+ * used to avoid this property.
  */
-public class TestCatalogSupplier implements Supplier<String> {
+public class TestCatalogSupplier {
 
 	@Inject
 	private ObjectMapper objectMapper;
@@ -46,18 +48,43 @@ public class TestCatalogSupplier implements Supplier<String> {
 	 *
 	 * @return the test catalog as a JSON formatted string.
 	 */
-	@Override
 	public String get() {
-		return get(false);
+		ResourceSet resourceSet = testDiscoveryHelper.newResourceSet();
+		return get(any -> resourceSet, false);
 	}
 
 	/**
-	 * Same as {@link #get()}, except that this method can be configured to not emit property "endpoint" to the returned
-	 * JSON string, by passing in <code>true</code> as argument for parameter <code>suppressEndpointProperty</code>.
+	 * Returns with the test catalog as a string representing all available tests in the workspace. This method may
+	 * return with a test catalog of an empty {@link TestTree test tree} if the the {@link Platform platform} is not
+	 * running.
+	 *
+	 * @return the test catalog as a JSON formatted string.
 	 */
 	public String get(boolean suppressEndpointProperty) {
+		ResourceSet resourceSet = testDiscoveryHelper.newResourceSet();
+		return get(any -> resourceSet, suppressEndpointProperty);
+	}
+
+	/**
+	 * Returns with the test catalog as a string representing all available tests in the workspace. This method may
+	 * return with a test catalog of an empty {@link TestTree test tree} if the the {@link Platform platform} is not
+	 * running.
+	 *
+	 * @return the test catalog as a JSON formatted string.
+	 */
+	public String get(Function<? super URI, ? extends ResourceSet> resourceSetAccess) {
+		return get(resourceSetAccess, false);
+	}
+
+	/**
+	 * Same as {@link #get(Function)}, except that this method can be configured to not emit property "endpoint" to the
+	 * returned JSON string, by passing in <code>true</code> as argument for parameter
+	 * <code>suppressEndpointProperty</code>.
+	 */
+	public String get(Function<? super URI, ? extends ResourceSet> resourceSetAccess,
+			boolean suppressEndpointProperty) {
 		try {
-			final TestTree testTree = getTreeForAllTests();
+			final TestTree testTree = getTreeForAllTests(resourceSetAccess);
 
 			final Object testCatalogObject = suppressEndpointProperty
 					? treeTransformer.apply(testTree, Collections.emptyMap())
@@ -71,7 +98,7 @@ public class TestCatalogSupplier implements Supplier<String> {
 	}
 
 	/** @return the {@link TestTree} for all tests */
-	protected TestTree getTreeForAllTests() {
-		return testDiscoveryHelper.collectAllTestsFromWorkspace();
+	protected TestTree getTreeForAllTests(Function<? super URI, ? extends ResourceSet> resourceSetAccess) {
+		return testDiscoveryHelper.collectAllTestsFromWorkspace(resourceSetAccess);
 	}
 }

--- a/plugins/org.eclipse.n4js.tester/src/org/eclipse/n4js/tester/TestDiscoveryHelper.java
+++ b/plugins/org.eclipse.n4js.tester/src/org/eclipse/n4js/tester/TestDiscoveryHelper.java
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -166,18 +167,27 @@ public class TestDiscoveryHelper {
 	 *         tree may be empty.
 	 */
 	public TestTree collectTests(final List<URI> uris) {
-		final ResourceSet resSet = n4jsCore.createResourceSet(Optional.absent());
-		final IResourceDescriptions index = n4jsCore.getXtextIndex(resSet);
-		return collectTests(resSet, index, uris);
+		final ResourceSet resSet = newResourceSet();
+		return collectTests(any -> resSet, uris);
+	}
+
+	/**
+	 * @return a new resource set.
+	 */
+	ResourceSet newResourceSet() {
+		return n4jsCore.createResourceSet(Optional.absent());
 	}
 
 	/**
 	 * Collects all test cases from the underlying (N4JS core-based) workspace and returns with a new test tree instance
 	 * representing those test cases.
 	 *
+	 * @param resourceSetAccess
+	 *            the accessor for the resource set
+	 *
 	 * @return a test tree representing all test cases in the workspace.
 	 */
-	public TestTree collectAllTestsFromWorkspace() {
+	public TestTree collectAllTestsFromWorkspace(Function<? super URI, ? extends ResourceSet> resourceSetAccess) {
 		List<URI> testableProjectURIs = new ArrayList<>();
 		Iterable<? extends IN4JSProject> findAllProjects = n4jsCore.findAllProjects();
 
@@ -187,7 +197,7 @@ public class TestDiscoveryHelper {
 				testableProjectURIs.add(location);
 			}
 		}
-		TestTree collectedTests = collectTests(testableProjectURIs);
+		TestTree collectedTests = collectTests(resourceSetAccess, testableProjectURIs);
 		return collectedTests;
 	}
 
@@ -196,20 +206,19 @@ public class TestDiscoveryHelper {
 	}
 
 	/**
-	 * Most clients should use method {@link #collectTests(List)} instead.
-	 * <p>
 	 * Low-level method to collect all test modules, i.e. N4JS files containing classes containing at least one method
 	 * annotated with &#64;Test, as {@link IResourceDescription}s.
 	 */
-	private List<URI> collectDistinctTestLocations(final IResourceDescriptions index, final ResourceSet resSet,
+	private List<URI> collectDistinctTestLocations(Function<? super URI, ? extends ResourceSet> resourceSetAccess,
 			List<URI> locations) {
-		return locations.stream().flatMap(loc -> collectTestLocations(index, resSet, loc)).distinct()
-				.collect(Collectors.toList());
+		return locations.stream().flatMap(loc -> {
+			ResourceSet resSet = resourceSetAccess.apply(loc);
+			IResourceDescriptions index = n4jsCore.getXtextIndex(resSet);
+			return collectTestLocations(index, resSet, loc);
+		}).distinct().collect(Collectors.toList());
 	}
 
 	/**
-	 * Most clients should use method {@link #collectTests(List)} instead!
-	 * <p>
 	 * Low-level method to collect all test modules, i.e. N4JS files containing classes containing at least one method
 	 * annotated with &#64;Test, as {@link IResourceDescription}s.
 	 */
@@ -267,18 +276,33 @@ public class TestDiscoveryHelper {
 		return Stream.empty();
 	}
 
-	private TestTree collectTests(final ResourceSet resSet, final IResourceDescriptions index,
+	/**
+	 * Collects all test methods available at the given location and returns a {@link TestTree} in which each test
+	 * method is represented by a {@link TestCase}. The location may point to an N4JS project or a folder or file within
+	 * an N4JS project.
+	 *
+	 * @param resourceSetAccess
+	 *            the accessor for the resource set
+	 *
+	 * @param locations
+	 *            the locations referencing to a resource. Can be an N4JS project, or a folder or a file within an N4JS
+	 *            project.
+	 * @return The test tree representing one or more test cases. Never returns with {@code null}, but the returned test
+	 *         tree may be empty.
+	 */
+	private TestTree collectTests(Function<? super URI, ? extends ResourceSet> resourceSetAccess,
 			final List<URI> locations) {
 
 		// create test cases (aggregated in test suites)
 		final Map<String, TestSuite> suites = new LinkedHashMap<>();
 
 		// create MultiMap from trimmed(!) URI -> original URIs for this prefix URI
-		final List<URI> testLocations = collectDistinctTestLocations(index, resSet, locations);
+		final List<URI> testLocations = collectDistinctTestLocations(resourceSetAccess, locations);
 		// module URI --> test case URIs
 		final HashMultimap<URI, URI> testLocationMapping = createTestLocationMapping(testLocations);
 		// module URI --> module
-		final Map<URI, TModule> moduleUri2Modules = loadModules(testLocationMapping.asMap().keySet(), index, resSet);
+		final Map<URI, TModule> moduleUri2Modules = loadModules(testLocationMapping.asMap().keySet(),
+				resourceSetAccess);
 
 		for (final URI moduleLocation : testLocationMapping.keySet()) {
 
@@ -409,11 +433,13 @@ public class TestDiscoveryHelper {
 		return classStr;
 	}
 
-	private Map<URI, TModule> loadModules(final Iterable<URI> moduleUris, final IResourceDescriptions index,
-			final ResourceSet resSet) {
+	private Map<URI, TModule> loadModules(final Iterable<URI> moduleUris,
+			Function<? super URI, ? extends ResourceSet> resourceSetAccess) {
 
 		final Map<URI, TModule> uri2Modules = newHashMap();
 		for (final URI moduleUri : moduleUris) {
+			ResourceSet resSet = resourceSetAccess.apply(moduleUri);
+			IResourceDescriptions index = n4jsCore.getXtextIndex(resSet);
 			final IResourceDescription resDesc = index.getResourceDescription(moduleUri);
 			uri2Modules.put(moduleUri, n4jsCore.loadModuleFromIndex(resSet, resDesc, false));
 		}

--- a/tools/org.eclipse.n4js.hlc.base/src/org/eclipse/n4js/hlc/base/N4jscBase.java
+++ b/tools/org.eclipse.n4js.hlc.base/src/org/eclipse/n4js/hlc/base/N4jscBase.java
@@ -18,10 +18,12 @@ import static org.eclipse.n4js.hlc.base.ErrorExitCode.EXITCODE_MODULE_TO_RUN_NOT
 import static org.eclipse.n4js.hlc.base.ErrorExitCode.EXITCODE_TEST_CATALOG_ASSEMBLATION_ERROR;
 import static org.eclipse.n4js.hlc.base.ErrorExitCode.EXITCODE_WRONG_CMDLINE_OPTIONS;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -893,9 +895,9 @@ public class N4jscBase implements IApplication {
 	private void writeTestCatalog() throws ExitCodeException {
 		if (null != testCatalogFile) {
 			final String catalog = testCatalogSupplier.get(true); // do not include "endpoint" property here
-			try (final FileOutputStream fos = new FileOutputStream(testCatalogFile)) {
-				fos.write(catalog.getBytes());
-				fos.flush();
+			try (final OutputStream os = new BufferedOutputStream(new FileOutputStream(testCatalogFile))) {
+				os.write(catalog.getBytes("UTF-8"));
+				os.flush();
 			} catch (IOException e) {
 				System.out.println("Error while writing test catalog file at: " + testCatalogFile);
 				throw new ExitCodeException(EXITCODE_TEST_CATALOG_ASSEMBLATION_ERROR);

--- a/tools/org.eclipse.n4js.hlc.base/src/org/eclipse/n4js/hlc/base/N4jscBase.java
+++ b/tools/org.eclipse.n4js.hlc.base/src/org/eclipse/n4js/hlc/base/N4jscBase.java
@@ -25,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -896,7 +897,7 @@ public class N4jscBase implements IApplication {
 		if (null != testCatalogFile) {
 			final String catalog = testCatalogSupplier.get(true); // do not include "endpoint" property here
 			try (final OutputStream os = new BufferedOutputStream(new FileOutputStream(testCatalogFile))) {
-				os.write(catalog.getBytes("UTF-8"));
+				os.write(catalog.getBytes(StandardCharsets.UTF_8));
 				os.flush();
 			} catch (IOException e) {
 				System.out.println("Error while writing test catalog file at: " + testCatalogFile);


### PR DESCRIPTION
The catalog used to be computed based on an empty resource set without any index information attached. This was fixed to use the available index also in the headless case.

see #1561