### PR TITLE
[#1583] Distinguish between deleted and modified resources on project load

### DIFF
--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/server/N4JSOutputConfigurationProvider.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/server/N4JSOutputConfigurationProvider.java
@@ -25,10 +25,12 @@ import org.eclipse.xtext.generator.OutputConfigurationProvider;
 import org.eclipse.xtext.resource.impl.ProjectDescription;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
 /**
  *
  */
+@Singleton
 public class N4JSOutputConfigurationProvider extends OutputConfigurationProvider {
 
 	@Inject

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/validation/N4JSIssue.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/validation/N4JSIssue.java
@@ -19,6 +19,7 @@ import java.util.Objects;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.xtext.diagnostics.Severity;
 import org.eclipse.xtext.validation.CheckType;
+import org.eclipse.xtext.validation.Issue;
 import org.eclipse.xtext.validation.Issue.IssueImpl;
 
 /**
@@ -42,6 +43,33 @@ public class N4JSIssue extends IssueImpl implements Externalizable {
 		this.setUriToProblem(null);
 		this.setSeverity(Severity.IGNORE);
 		this.setType(CheckType.FAST);
+	}
+
+	/**
+	 * Copy constructor
+	 */
+	public N4JSIssue(Issue copyFrom) {
+		this();
+		if (copyFrom.getOffset() != null)
+			this.setOffset(copyFrom.getOffset());
+		if (copyFrom.getLength() != null)
+			this.setLength(copyFrom.getLength());
+		if (copyFrom.getColumn() != null)
+			this.setColumn(copyFrom.getColumn());
+		if (copyFrom.getLineNumber() != null)
+			this.setLineNumber(copyFrom.getLineNumber());
+		if (copyFrom.getCode() != null)
+			this.setCode(copyFrom.getCode());
+		if (copyFrom.getMessage() != null)
+			this.setMessage(copyFrom.getMessage());
+		if (copyFrom.getUriToProblem() != null)
+			this.setUriToProblem(copyFrom.getUriToProblem());
+		if (copyFrom.getSeverity() != null)
+			this.setSeverity(copyFrom.getSeverity());
+		if (copyFrom.getType() != null)
+			this.setType(copyFrom.getType());
+		if (copyFrom.getData() != null)
+			this.setData(copyFrom.getData());
 	}
 
 	/** @return line of end of issue */
@@ -86,6 +114,16 @@ public class N4JSIssue extends IssueImpl implements Externalizable {
 		CheckType checkType = this.getType();
 		int checkTypeKey = checkType == null ? 0 : checkType.ordinal() + 1;
 		out.writeInt(checkTypeKey);
+
+		String[] data = getData();
+		if (data == null) {
+			out.writeInt(0);
+		} else {
+			out.writeInt(data.length);
+			for (String s : data) {
+				out.writeUTF(s);
+			}
+		}
 	}
 
 	@Override
@@ -110,6 +148,14 @@ public class N4JSIssue extends IssueImpl implements Externalizable {
 		int checkTypeKey = in.readInt();
 		CheckType checkType = checkTypeFromKey(checkTypeKey);
 		this.setType(checkType);
+
+		int dataLength = in.readInt();
+		if (dataLength > 0) {
+			String[] data = new String[dataLength];
+			for (int i = 0; i < dataLength; i++) {
+				data[i] = in.readUTF();
+			}
+		}
 	}
 
 	private static final Severity[] severities = Severity.values();

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/validation/N4JSIssue.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/validation/N4JSIssue.java
@@ -155,6 +155,7 @@ public class N4JSIssue extends IssueImpl implements Externalizable {
 			for (int i = 0; i < dataLength; i++) {
 				data[i] = in.readUTF();
 			}
+			this.setData(data);
 		}
 	}
 

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ProjectStateHolder.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ProjectStateHolder.java
@@ -67,25 +67,18 @@ public class ProjectStateHolder {
 
 	/*
 	 * Implementation note: We use a sorted map to report the issues in a stable order. The values of the the map are
-	 * sorted by offset and message and severity
+	 * sorted by offset and severity and message.
+	 *
+	 * URI (keys in the multimap) are sorted according to their location in the file system. Turns out that the string
+	 * represenation yields the same result as a comparion per path segment.
+	 *
+	 * The sort order will look like this: /a/b, /a/b/c, /a/b/d, /a/c, /aa
 	 */
-	private final Multimap<URI, Issue> validationIssues = TreeMultimap.create(uriComparator, issueComparator);
-
-	private static final Comparator<URI> uriComparator = Comparator.comparing(URI::scheme)
-			.thenComparing((left, right) -> {
-				for (int i = 0, max = Math.min(left.segmentCount(), right.segmentCount()); i < max; i++) {
-					String leftSegment = left.segment(i);
-					String rightSegment = right.segment(i);
-					int segmentCompareResult = leftSegment.compareTo(rightSegment);
-					if (segmentCompareResult != 0) {
-						return segmentCompareResult;
-					}
-				}
-				return 0;
-			}).thenComparingInt(URI::segmentCount);
+	private final Multimap<URI, Issue> validationIssues = TreeMultimap.create(Comparator.comparing(URI::toString),
+			issueComparator);
 
 	private static final Comparator<Issue> issueComparator = Comparator.comparing(Issue::getOffset)
-			.thenComparing(Issue::getMessage).thenComparing(Issue::getSeverity).thenComparing(Issue::hashCode);
+			.thenComparing(Issue::getSeverity).thenComparing(Issue::getMessage).thenComparing(Issue::hashCode);
 
 	/** Clears type index of this project. */
 	public void doClear() {

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ProjectStateHolder.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ProjectStateHolder.java
@@ -67,7 +67,7 @@ public class ProjectStateHolder {
 
 	/*
 	 * Implementation note: We use a sorted map to report the issues in a stable order. The values of the the map are
-	 * sorted by line number, offset and message
+	 * sorted by offset and message and severity
 	 */
 	private final Multimap<URI, Issue> validationIssues = TreeMultimap.create(uriComparator, issueComparator);
 
@@ -85,7 +85,7 @@ public class ProjectStateHolder {
 			}).thenComparingInt(URI::segmentCount);
 
 	private static final Comparator<Issue> issueComparator = Comparator.comparing(Issue::getOffset)
-			.thenComparing(Issue::getMessage);
+			.thenComparing(Issue::getMessage).thenComparing(Issue::getSeverity).thenComparing(Issue::hashCode);
 
 	/** Clears type index of this project. */
 	public void doClear() {

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ProjectStateHolder.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ProjectStateHolder.java
@@ -12,10 +12,8 @@ package org.eclipse.n4js.ide.xtext.server;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +27,7 @@ import org.eclipse.n4js.ide.xtext.server.build.XBuildResult;
 import org.eclipse.n4js.ide.xtext.server.build.XIndexState;
 import org.eclipse.n4js.ide.xtext.server.build.XSource2GeneratedMapping;
 import org.eclipse.xtext.resource.IResourceDescription.Delta;
+import org.eclipse.xtext.resource.IResourceServiceProvider;
 import org.eclipse.xtext.util.IFileSystemScanner;
 import org.eclipse.xtext.validation.Issue;
 import org.eclipse.xtext.workspace.IProjectConfig;
@@ -58,15 +57,19 @@ public class ProjectStateHolder {
 	@Inject
 	protected ProjectStatePersisterConfig persistConfig;
 
+	/** Used to filter the traversed resources */
+	@Inject
+	protected IResourceServiceProvider.Registry resourceServiceProviders;
+
 	private XIndexState indexState = new XIndexState();
 
-	private Map<URI, HashedFileContent> hashFileMap = new HashMap<>();
+	private Map<URI, HashedFileContent> uriToHashedFileContents = new HashMap<>();
 
 	private final Map<URI, Collection<Issue>> validationIssues = new HashMap<>();
 
 	/** Clears type index of this project. */
 	public void doClear() {
-		hashFileMap.clear();
+		uriToHashedFileContents.clear();
 		setIndexState(new XIndexState());
 		validationIssues.clear();
 	}
@@ -82,8 +85,8 @@ public class ProjectStateHolder {
 
 	/** Persists the project state to disk */
 	public void writeProjectState(IProjectConfig projectConfig) {
-		if (persistConfig.isWriteToDisk(projectConfig) && !hashFileMap.isEmpty()) {
-			Collection<HashedFileContent> hashFileContents = hashFileMap.values();
+		if (persistConfig.isWriteToDisk(projectConfig) && !uriToHashedFileContents.isEmpty()) {
+			Collection<HashedFileContent> hashFileContents = uriToHashedFileContents.values();
 			projectStatePersister.writeProjectState(projectConfig, indexState, hashFileContents, validationIssues);
 		}
 	}
@@ -93,28 +96,38 @@ public class ProjectStateHolder {
 	 *
 	 * @return set of all source URIs with modified contents
 	 */
-	public Set<URI> readProjectState(IProjectConfig projectConfig) {
+	public ResourceChangeSet readProjectState(IProjectConfig projectConfig) {
 		if (persistConfig.isDeleteState(projectConfig)) {
 			deletePersistenceFile(projectConfig);
 		}
 
-		Set<URI> changedSources = new HashSet<>();
+		ResourceChangeSet result = new ResourceChangeSet();
 		doClear();
 
 		PersistedState persistedState = projectStatePersister.readProjectState(projectConfig);
 		if (persistedState != null) {
-
 			for (HashedFileContent hfc : persistedState.fileHashs.values()) {
-				URI uri = hfc.getUri();
-				if (isSourceUnchanged(hfc, persistedState)) {
-					hashFileMap.put(uri, hfc);
-				} else {
-					persistedState.indexState.getFileMappings().deleteSource(uri);
-					persistedState.validationIssues.remove(uri);
+				URI previouslyExistingFile = hfc.getUri();
+				switch (getSourceChangeKind(hfc, persistedState)) {
+				case UNCHANGED: {
+					uriToHashedFileContents.put(previouslyExistingFile, hfc);
+					break;
+				}
+				case CHANGED: {
+					result.getModified().add(previouslyExistingFile);
+					persistedState.validationIssues.remove(previouslyExistingFile);
+					break;
+				}
+				case DELETED: {
+					result.getDeleted().add(previouslyExistingFile);
+					persistedState.validationIssues.remove(previouslyExistingFile);
+					break;
+				}
 				}
 			}
 			setIndexState(persistedState.indexState);
 			mergeValidationIssues(persistedState.validationIssues);
+			// TODO this reports outdated issues - incremental changes may render old issues wrong
 			reportValidationIssues(persistedState.validationIssues);
 		}
 
@@ -122,18 +135,20 @@ public class ProjectStateHolder {
 		for (ISourceFolder srcFolder : projectConfig.getSourceFolders()) {
 			List<URI> allSourceFolderUris = srcFolder.getAllResources(fileSystemScanner);
 			for (URI srcFolderUri : allSourceFolderUris) {
-				if (!allIndexedUris.contains(srcFolderUri)) {
-					changedSources.add(srcFolderUri);
+				if (!srcFolderUri.hasTrailingPathSeparator() && !allIndexedUris.contains(srcFolderUri)) {
+					if (resourceServiceProviders.getResourceServiceProvider(srcFolderUri) != null) {
+						result.getModified().add(srcFolderUri);
+					}
 				}
 			}
 		}
 
-		return changedSources;
+		return result;
 	}
 
 	/** Updates the index state, file hashes and validation issues */
 	public void updateProjectState(XBuildRequest request, XBuildResult result) {
-		HashMap<URI, HashedFileContent> newFileContents = new HashMap<>(hashFileMap);
+		HashMap<URI, HashedFileContent> newFileContents = new HashMap<>(uriToHashedFileContents);
 		for (Delta delta : result.getAffectedResources()) {
 			URI uri = delta.getUri();
 			storeHash(newFileContents, uri);
@@ -144,16 +159,24 @@ public class ProjectStateHolder {
 
 		setIndexState(result.getIndexState());
 		mergeValidationIssues(request.getResultIssues());
-		hashFileMap = newFileContents;
+		uriToHashedFileContents = newFileContents;
 	}
 
-	private boolean isSourceUnchanged(HashedFileContent hfc, PersistedState persistedState) {
+	enum SourceChangeKind {
+		UNCHANGED, CHANGED, DELETED
+	}
+
+	private SourceChangeKind getSourceChangeKind(HashedFileContent hfc, PersistedState persistedState) {
 		URI sourceUri = hfc.getUri();
 		long loadedHash = hfc.getHash();
 
 		HashedFileContent newHash = doHash(sourceUri);
-		if (newHash == null || loadedHash != newHash.getHash()) {
-			return false;
+		if (newHash == null) {
+			return SourceChangeKind.DELETED;
+		}
+
+		if (loadedHash != newHash.getHash()) {
+			return SourceChangeKind.CHANGED;
 		}
 
 		XSource2GeneratedMapping sourceFileMappings = persistedState.indexState.getFileMappings();
@@ -163,20 +186,22 @@ public class ProjectStateHolder {
 			if (genFingerprint != null) {
 				HashedFileContent generatedHash = doHash(generated);
 				if (generatedHash == null || generatedHash.getHash() != genFingerprint.getHash()) {
-					return false;
+					return SourceChangeKind.CHANGED;
 				}
 			}
 		}
-
-		return true;
+		return SourceChangeKind.UNCHANGED;
 	}
 
 	private HashedFileContent doHash(URI uri) {
 		try {
-			File srcFile = new File(new java.net.URI(uri.toString()));
+			File srcFile = new File(uri.path());
+			if (!srcFile.isFile()) {
+				return null;
+			}
 			HashedFileContent generatedTargetContent = new HashedFileContent(uri, srcFile);
 			return generatedTargetContent;
-		} catch (IOException | URISyntaxException e) {
+		} catch (IOException e) {
 			return null;
 		}
 	}

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ProjectStatePersister.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ProjectStatePersister.java
@@ -33,6 +33,7 @@ import org.eclipse.emf.common.util.URI;
 import org.eclipse.n4js.ide.validation.N4JSIssue;
 import org.eclipse.n4js.ide.xtext.server.build.XIndexState;
 import org.eclipse.n4js.ide.xtext.server.build.XSource2GeneratedMapping;
+import org.eclipse.n4js.projectModel.locations.FileURI;
 import org.eclipse.n4js.utils.N4JSLanguageUtils;
 import org.eclipse.xtext.build.Source2GeneratedMapping;
 import org.eclipse.xtext.resource.IResourceDescription;
@@ -197,6 +198,8 @@ public class ProjectStatePersister {
 			for (Issue issue : issues) {
 				if (issue instanceof N4JSIssue) {
 					n4Issues.add((N4JSIssue) issue);
+				} else {
+					n4Issues.add(new N4JSIssue(issue));
 				}
 			}
 
@@ -342,7 +345,6 @@ public class ProjectStatePersister {
 	/** @return the file URI of the persisted index */
 	public URI getFileName(IProjectConfig project) {
 		URI rootPath = project.getPath();
-		URI fileName = rootPath.appendSegment(FILENAME);
-		return fileName;
+		return new FileURI(rootPath).appendSegment(FILENAME).toURI();
 	}
 }

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ResourceChangeSet.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ResourceChangeSet.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2019 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+package org.eclipse.n4js.ide.xtext.server;
+
+import java.util.Set;
+
+import org.eclipse.emf.common.util.URI;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.Sets;
+
+/**
+ * A tuple of deleted and modified resources.
+ */
+public class ResourceChangeSet {
+
+	private final Set<URI> changed = Sets.newHashSet();
+	private final Set<URI> deleted = Sets.newHashSet();
+
+	/**
+	 * Return the deleted uris.
+	 */
+	public Set<URI> getDeleted() {
+		return deleted;
+	}
+
+	/**
+	 * Return the modified uris.
+	 */
+	public Set<URI> getModified() {
+		return changed;
+	}
+
+	@Override
+	public String toString() {
+		Joiner joiner = Joiner.on("\n  ");
+		StringBuilder result = new StringBuilder();
+		result.append("CHANGED:\n  ");
+		joiner.appendTo(result, changed);
+		result.append("\nDELETED:\n  ");
+		joiner.appendTo(result, deleted);
+		return result.toString();
+	}
+
+}

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/XProjectManager.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/XProjectManager.java
@@ -124,9 +124,8 @@ public class XProjectManager {
 
 	/** Initial build reads the project state and resolves changes. */
 	public XBuildResult doInitialBuild(CancelIndicator cancelIndicator) {
-		Set<URI> changedSources = projectStateHolder.readProjectState(projectConfig);
-		// TODO distinguish between changed sources and deleted sources
-		XBuildResult result = doIncrementalBuild(changedSources, Collections.emptySet(),
+		ResourceChangeSet changeSet = projectStateHolder.readProjectState(projectConfig);
+		XBuildResult result = doIncrementalBuild(changeSet.getModified(), changeSet.getDeleted(),
 				Collections.emptyList(), cancelIndicator);
 
 		// clear the resource set to release memory

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/build/XBuildRequest.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/build/XBuildRequest.java
@@ -150,27 +150,6 @@ public class XBuildRequest {
 		this.afterValidate(source, issues);
 	}
 
-	/**
-	 * Getter.
-	 */
-	public AfterValidateListener getAfterValidateListener() {
-		return afterValidateListener;
-	}
-
-	/**
-	 * Getter.
-	 */
-	public AfterDeleteListener getAfterDeleteListener() {
-		return afterDeleteListener;
-	}
-
-	/**
-	 * Getter.
-	 */
-	public AfterGenerateListener getAfterGenerateListener() {
-		return afterGenerateListener;
-	}
-
 	/** Setter. */
 	public void setAfterValidateListener(AfterValidateListener afterValidateListener) {
 		this.afterValidateListener = afterValidateListener;

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/build/XBuildRequest.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/build/XBuildRequest.java
@@ -150,6 +150,27 @@ public class XBuildRequest {
 		this.afterValidate(source, issues);
 	}
 
+	/**
+	 * Getter.
+	 */
+	public AfterValidateListener getAfterValidateListener() {
+		return afterValidateListener;
+	}
+
+	/**
+	 * Getter.
+	 */
+	public AfterDeleteListener getAfterDeleteListener() {
+		return afterDeleteListener;
+	}
+
+	/**
+	 * Getter.
+	 */
+	public AfterGenerateListener getAfterGenerateListener() {
+		return afterGenerateListener;
+	}
+
 	/** Setter. */
 	public void setAfterValidateListener(AfterValidateListener afterValidateListener) {
 		this.afterValidateListener = afterValidateListener;

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/build/XStatefulIncrementalBuilder.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/build/XStatefulIncrementalBuilder.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CancellationException;
 
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.resource.Resource;
+import org.eclipse.emf.ecore.resource.URIConverter;
 import org.eclipse.n4js.ide.xtext.server.XWorkspaceManager;
 import org.eclipse.xtext.EcoreUtil2;
 import org.eclipse.xtext.generator.GeneratorContext;
@@ -50,6 +51,7 @@ import org.eclipse.xtext.xbase.lib.Exceptions;
 
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
 import com.google.inject.Inject;
 
 /** Builder instance that is bound to a single running build. */
@@ -132,22 +134,20 @@ public class XStatefulIncrementalBuilder {
 	}
 
 	private void removeGeneratedFiles(URI source, XSource2GeneratedMapping source2GeneratedMapping) {
-		Map<URI, String> outputConfigMap = source2GeneratedMapping
-				.deleteSourceAndGetOutputConfigs(source);
+		Map<URI, String> outputConfigMap = source2GeneratedMapping.deleteSourceAndGetOutputConfigs(source);
 		IResourceServiceProvider serviceProvider = context.getResourceServiceProvider(source);
 		IContextualOutputConfigurationProvider2 outputConfigurationProvider = serviceProvider
 				.get(IContextualOutputConfigurationProvider2.class);
 		XtextResourceSet resourceSet = request.getResourceSet();
-		Set<OutputConfiguration> outputConfigs = outputConfigurationProvider
-				.getOutputConfigurations(resourceSet);
-
+		Set<OutputConfiguration> outputConfigs = outputConfigurationProvider.getOutputConfigurations(resourceSet);
+		Map<String, OutputConfiguration> outputConfigsMap = Maps.uniqueIndex(outputConfigs,
+				OutputConfiguration::getName);
+		URIConverter uriConverter = resourceSet.getURIConverter();
 		for (URI generated : outputConfigMap.keySet()) {
-			String configName = outputConfigMap.get(generated);
-			OutputConfiguration config = FluentIterable.from(outputConfigs)
-					.firstMatch(oc -> oc.getName().equals(configName)).orNull();
+			OutputConfiguration config = outputConfigsMap.get(outputConfigMap.get(generated));
 			if (config != null && config.isCleanUpDerivedResources()) {
 				try {
-					resourceSet.getURIConverter().delete(generated, CollectionLiterals.emptyMap());
+					uriConverter.delete(generated, CollectionLiterals.emptyMap());
 					request.setResultDeleteFile(generated);
 				} catch (IOException e) {
 					Exceptions.sneakyThrow(e);
@@ -171,7 +171,7 @@ public class XStatefulIncrementalBuilder {
 		URI source = resource.getURI();
 		IResourceServiceProvider serviceProvider = getResourceServiceProvider(resource);
 		IResourceDescription.Manager manager = serviceProvider.getResourceDescriptionManager();
-		IResourceValidator resourceValidator = getResourceServiceProvider(resource).getResourceValidator();
+		IResourceValidator resourceValidator = serviceProvider.getResourceValidator();
 
 		IResourceDescription description = manager.getResourceDescription(resource);
 		SerializableResourceDescription copiedDescription = SerializableResourceDescription.createCopy(description);
@@ -185,7 +185,7 @@ public class XStatefulIncrementalBuilder {
 
 			if (proceedGenerate) {
 				operationCanceledManager.checkCanceled(cancelIndicator);
-				generate(resource, newSource2GeneratedMapping);
+				generate(resource, newSource2GeneratedMapping, serviceProvider);
 			} else {
 				removeGeneratedFiles(resource.getURI(), newSource2GeneratedMapping);
 			}
@@ -203,14 +203,14 @@ public class XStatefulIncrementalBuilder {
 	}
 
 	/** Generate code for the given resource */
-	protected void generate(Resource resource, XSource2GeneratedMapping newMappings) {
-		IResourceServiceProvider serviceProvider = getResourceServiceProvider(resource);
+	protected void generate(Resource resource, XSource2GeneratedMapping newMappings,
+			IResourceServiceProvider serviceProvider) {
 		GeneratorDelegate generator = serviceProvider.get(GeneratorDelegate.class);
 		if (generator == null) {
 			return;
 		}
 
-		if (isResourceInOutputDirectory(resource)) {
+		if (isResourceInOutputDirectory(resource, serviceProvider)) {
 			return;
 		}
 
@@ -250,14 +250,12 @@ public class XStatefulIncrementalBuilder {
 		}
 	}
 
-	private boolean isResourceInOutputDirectory(Resource resource) {
-		IResourceServiceProvider serviceProvider = getResourceServiceProvider(resource);
+	private boolean isResourceInOutputDirectory(Resource resource, IResourceServiceProvider serviceProvider) {
 		XWorkspaceManager workspaceManager = serviceProvider.get(XWorkspaceManager.class);
-		OutputConfigurationProvider outputConfProvider = serviceProvider.get(OutputConfigurationProvider.class);
 		if (workspaceManager == null) {
 			return false;
 		}
-
+		OutputConfigurationProvider outputConfProvider = serviceProvider.get(OutputConfigurationProvider.class);
 		URI resourceUri = resource.getURI();
 		IProjectConfig projectConfig = workspaceManager.getProjectConfig(resourceUri);
 		Set<OutputConfiguration> outputConfigurations = outputConfProvider.getOutputConfigurations(resource);

--- a/testhelpers/org.eclipse.n4js.cli.tests.helper/src/org/eclipse/n4js/cli/N4jscTestOptions.java
+++ b/testhelpers/org.eclipse.n4js.cli.tests.helper/src/org/eclipse/n4js/cli/N4jscTestOptions.java
@@ -33,7 +33,14 @@ public class N4jscTestOptions extends N4jscOptions {
 	 * @return a new instance of {@link N4jscTestOptions} with goal compile
 	 */
 	static public N4jscTestOptions COMPILE(File... files) {
-		return COMPILE(Arrays.asList(files));
+		return COMPILE(true, Arrays.asList(files));
+	}
+
+	/**
+	 * @return a new instance of {@link N4jscTestOptions} with goal compile
+	 */
+	static public N4jscTestOptions COMPILE(boolean cleanNoPersist, File... files) {
+		return COMPILE(cleanNoPersist, Arrays.asList(files));
 	}
 
 	/**
@@ -42,9 +49,20 @@ public class N4jscTestOptions extends N4jscOptions {
 	 * @return a new instance of {@link N4jscTestOptions} with goal compile
 	 */
 	static public N4jscTestOptions COMPILE(List<File> files) {
+		return COMPILE(true, files);
+	}
+
+	/**
+	 * @return a new instance of {@link N4jscTestOptions} with goal compile
+	 */
+	static public N4jscTestOptions COMPILE(boolean cleanNoPersist, List<File> files) {
 		N4jscTestOptions instance = new N4jscTestOptions();
 		instance.options.goal = N4jscGoal.compile;
-		return instance.f(files).clean().noPersist();
+		instance.f(files);
+		if (cleanNoPersist) {
+			instance.clean().noPersist();
+		}
+		return instance;
 	}
 
 	/** @return a new instance of {@link N4jscTestOptions} with goal clean */

--- a/tests/org.eclipse.n4js.hlc.tests/src/org/eclipse/n4js/hlc/tests/N4jscBasicTest.java
+++ b/tests/org.eclipse.n4js.hlc.tests/src/org/eclipse/n4js/hlc/tests/N4jscBasicTest.java
@@ -12,12 +12,17 @@ package org.eclipse.n4js.hlc.tests;
 
 import static org.eclipse.n4js.cli.N4jscTestOptions.COMPILE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
 
 import org.eclipse.n4js.N4JSGlobals;
+import org.eclipse.n4js.cli.N4jscTestOptions;
 import org.eclipse.n4js.cli.helper.AbstractCliCompileTest;
 import org.eclipse.n4js.cli.helper.CliCompileResult;
 import org.eclipse.n4js.cli.helper.N4CliHelper;
@@ -26,6 +31,8 @@ import org.eclipse.n4js.utils.io.FileDeleter;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.google.common.base.Joiner;
 
 /**
  * Basic tests for N4jsc, testing various situations in which compiler exits with errors.
@@ -64,10 +71,199 @@ public class N4jscBasicTest extends AbstractCliCompileTest {
 		CliCompileResult cliResult = n4jsc(COMPILE(workspace));
 		assertEquals(cliResult.toString(), 16, cliResult.getTranspiledFilesCount());
 
-		Path fileA = proot.toPath().resolve("/P1/src-gen/A.js");
+		Path fileA = proot.toPath().resolve("P1/src-gen/A.js");
 
 		ProcessResult nodejsResult = runNodejs(workspace.toPath(), fileA);
-		assertEquals(nodejsResult.toString(), "", nodejsResult.getStdOut());
+		assertEquals(nodejsResult.toString(), "A", nodejsResult.getStdOut());
+	}
+
+	/** Test a second run of the compiler on the same sources */
+	@Test
+	public void testRunTwice() throws Exception {
+		N4CliHelper.copyN4jsLibsToLocation(workspace.toPath().resolve(N4JSGlobals.NODE_MODULES),
+				N4JSGlobals.N4JS_RUNTIME);
+
+		N4jscTestOptions compileOptions = COMPILE(workspace);
+		compileOptions.getDefinedOptions().remove("--noPersist");
+		compileOptions.getDefinedOptions().remove("--clean");
+
+		CliCompileResult firstRun = n4jsc(compileOptions);
+		assertEquals(firstRun.toString(), 16, firstRun.getTranspiledFilesCount());
+		Path fileA = proot.toPath().resolve("P1/.n4js.projectstate");
+		assertTrue(fileA.toFile().getAbsolutePath(), fileA.toFile().exists());
+
+		CliCompileResult secondRun = n4jsc(compileOptions);
+		assertEquals(secondRun.toString(), 0, secondRun.getTranspiledFilesCount());
+
+		assertOutputEqual(firstRun, secondRun);
+	}
+
+	/** Test a second run of the compiler after a source file was removed */
+	@Test
+	public void testFileRemovedIfN4JSRemoved() throws Exception {
+		N4CliHelper.copyN4jsLibsToLocation(workspace.toPath().resolve(N4JSGlobals.NODE_MODULES),
+				N4JSGlobals.N4JS_RUNTIME);
+
+		N4jscTestOptions compileOptions = COMPILE(workspace);
+		compileOptions.getDefinedOptions().remove("--noPersist");
+		compileOptions.getDefinedOptions().remove("--clean");
+
+		CliCompileResult firstRun = n4jsc(compileOptions);
+		assertEquals(firstRun.toString(), 16, firstRun.getTranspiledFilesCount());
+
+		File fileAn4js = proot.toPath().resolve("P1/src/A.n4js").toFile();
+		assertTrue(fileAn4js.getAbsolutePath(), fileAn4js.isFile());
+		assertTrue(fileAn4js.getAbsolutePath(), fileAn4js.exists());
+		assertTrue(fileAn4js.getAbsolutePath(), fileAn4js.delete());
+		assertFalse(fileAn4js.getAbsolutePath(), fileAn4js.exists());
+
+		File fileAjs = proot.toPath().resolve("P1/src-gen/A.js").toFile();
+		assertTrue(fileAjs.exists());
+		File fileAmap = proot.toPath().resolve("P1/src-gen/A.map").toFile();
+		assertTrue(fileAmap.exists());
+
+		CliCompileResult secondRun = n4jsc(compileOptions);
+		assertEquals(secondRun.toString(), 0, secondRun.getTranspiledFilesCount());
+		assertEquals(secondRun.toString(), 2, secondRun.getDeletedFilesCount());
+
+		assertFalse(fileAjs.exists());
+		assertFalse(fileAmap.exists());
+	}
+
+	/** Test a second run of the compiler after a generated map file was removed */
+	@Test
+	public void testFileRegeneratedIfJSRemoved() throws Exception {
+		N4CliHelper.copyN4jsLibsToLocation(workspace.toPath().resolve(N4JSGlobals.NODE_MODULES),
+				N4JSGlobals.N4JS_RUNTIME);
+
+		N4jscTestOptions compileOptions = COMPILE(workspace);
+		compileOptions.getDefinedOptions().remove("--noPersist");
+		compileOptions.getDefinedOptions().remove("--clean");
+
+		CliCompileResult firstRun = n4jsc(compileOptions);
+		assertEquals(firstRun.toString(), 16, firstRun.getTranspiledFilesCount());
+
+		File fileAjs = proot.toPath().resolve("P1/src-gen/A.js").toFile();
+		assertTrue(fileAjs.getAbsolutePath(), fileAjs.isFile());
+		assertTrue(fileAjs.getAbsolutePath(), fileAjs.exists());
+		assertTrue(fileAjs.getAbsolutePath(), fileAjs.delete());
+		assertFalse(fileAjs.getAbsolutePath(), fileAjs.exists());
+
+		CliCompileResult secondRun = n4jsc(compileOptions);
+		assertEquals(secondRun.toString(), 1, secondRun.getTranspiledFilesCount());
+		assertEquals(secondRun.toString(), 0, secondRun.getDeletedFilesCount());
+
+		assertTrue(fileAjs.exists());
+		File fileAmap = proot.toPath().resolve("P1/src-gen/A.map").toFile();
+		assertTrue(fileAmap.exists());
+
+		assertOutputEqual(firstRun, secondRun);
+	}
+
+	/** Test a second run of the compiler after a generated js file was removed */
+	@Test
+	public void testFileRegeneratedIfMapRemoved() throws Exception {
+		N4CliHelper.copyN4jsLibsToLocation(workspace.toPath().resolve(N4JSGlobals.NODE_MODULES),
+				N4JSGlobals.N4JS_RUNTIME);
+
+		N4jscTestOptions compileOptions = COMPILE(workspace);
+		compileOptions.getDefinedOptions().remove("--noPersist");
+		compileOptions.getDefinedOptions().remove("--clean");
+
+		CliCompileResult firstRun = n4jsc(compileOptions);
+		assertEquals(firstRun.toString(), 16, firstRun.getTranspiledFilesCount());
+
+		File fileAmap = proot.toPath().resolve("P1/src-gen/A.map").toFile();
+		assertTrue(fileAmap.getAbsolutePath(), fileAmap.isFile());
+		assertTrue(fileAmap.getAbsolutePath(), fileAmap.exists());
+		assertTrue(fileAmap.getAbsolutePath(), fileAmap.delete());
+		assertFalse(fileAmap.getAbsolutePath(), fileAmap.exists());
+
+		CliCompileResult secondRun = n4jsc(compileOptions);
+		assertEquals(secondRun.toString(), 1, secondRun.getTranspiledFilesCount());
+		assertEquals(secondRun.toString(), 0, secondRun.getDeletedFilesCount());
+
+		assertTrue(fileAmap.exists());
+		File fileAjs = proot.toPath().resolve("P1/src-gen/A.js").toFile();
+		assertTrue(fileAjs.exists());
+
+		assertOutputEqual(firstRun, secondRun);
+	}
+
+	/** Test a second run of the compiler after a file with downstream files was removed */
+	@Test
+	public void testBuildDependentFilesIfFileRemoved() throws Exception {
+		N4CliHelper.copyN4jsLibsToLocation(workspace.toPath().resolve(N4JSGlobals.NODE_MODULES),
+				N4JSGlobals.N4JS_RUNTIME);
+
+		N4jscTestOptions compileOptions = COMPILE(workspace);
+		compileOptions.getDefinedOptions().remove("--noPersist");
+		compileOptions.getDefinedOptions().remove("--clean");
+
+		CliCompileResult firstRun = n4jsc(compileOptions);
+		assertEquals(firstRun.toString(), 16, firstRun.getTranspiledFilesCount());
+
+		File fileCn4js = proot.toPath().resolve("P1/src/c/C.n4js").toFile();
+		assertTrue(fileCn4js.getAbsolutePath(), fileCn4js.isFile());
+		assertTrue(fileCn4js.getAbsolutePath(), fileCn4js.exists());
+		assertTrue(fileCn4js.getAbsolutePath(), fileCn4js.delete());
+		assertFalse(fileCn4js.getAbsolutePath(), fileCn4js.exists());
+
+		CliCompileResult secondRun = n4jsc(compileOptions);
+		assertEquals(secondRun.toString(), 0, secondRun.getTranspiledFilesCount());
+		// C and Y are affected (js and map)
+		assertEquals(secondRun.toString(), 4, secondRun.getDeletedFilesCount());
+
+		// Y.n4js depends on C.n4js
+		File fileYjs = proot.toPath().resolve("P1/src-gen/y/Y.js").toFile();
+		assertFalse(fileYjs.exists());
+	}
+
+	/** Test a second run of the compiler after a file was added to fix compile problems */
+	@Test
+	public void testBuildDependentFilesIfFileReadded() throws Exception {
+		N4CliHelper.copyN4jsLibsToLocation(workspace.toPath().resolve(N4JSGlobals.NODE_MODULES),
+				N4JSGlobals.N4JS_RUNTIME);
+
+		N4jscTestOptions compileOptions = COMPILE(workspace);
+		compileOptions.getDefinedOptions().remove("--noPersist");
+		compileOptions.getDefinedOptions().remove("--clean");
+
+		CliCompileResult firstRun = n4jsc(compileOptions);
+		assertEquals(firstRun.toString(), 16, firstRun.getTranspiledFilesCount());
+
+		Path fileCn4js = proot.toPath().resolve("P1/src/c/C.n4js");
+		byte[] bytesC = Files.readAllBytes(fileCn4js);
+		Files.delete(fileCn4js);
+
+		n4jsc(compileOptions);
+
+		// Y.n4js depends on C.n4js
+		File fileCjs = proot.toPath().resolve("P1/src-gen/c/C.js").toFile();
+		assertFalse(fileCjs.exists());
+		File fileYjs = proot.toPath().resolve("P1/src-gen/y/Y.js").toFile();
+		assertFalse(fileYjs.exists());
+
+		Files.write(fileCn4js, bytesC);
+
+		CliCompileResult thirdRun = n4jsc(compileOptions);
+
+		assertTrue(fileCjs.exists());
+		assertTrue(fileYjs.exists());
+
+		assertOutputEqual(firstRun, thirdRun);
+	}
+
+	private void assertOutputEqual(CliCompileResult expected, CliCompileResult actual) {
+		assertCollEquals(expected.getWrnFiles(), actual.getWrnFiles());
+		assertCollEquals(expected.getWrnMsgs(), actual.getWrnMsgs());
+		assertCollEquals(expected.getErrFiles(), actual.getErrFiles());
+		assertCollEquals(expected.getErrMsgs(), actual.getErrMsgs());
+	}
+
+	private <T, C extends Collection<T>> void assertCollEquals(C expected, C actual) {
+		final Joiner joiner = Joiner.on('\n');
+		assertEquals(joiner.join(expected), joiner.join(actual));
 	}
 
 }

--- a/tests/org.eclipse.n4js.hlc.tests/src/org/eclipse/n4js/hlc/tests/N4jscBasicTest.java
+++ b/tests/org.eclipse.n4js.hlc.tests/src/org/eclipse/n4js/hlc/tests/N4jscBasicTest.java
@@ -38,6 +38,9 @@ import com.google.common.base.Joiner;
  * Basic tests for N4jsc, testing various situations in which compiler exits with errors.
  */
 public class N4jscBasicTest extends AbstractCliCompileTest {
+
+	static final boolean DONT_CLEAN = false;
+
 	File workspace;
 	File proot;
 
@@ -83,9 +86,7 @@ public class N4jscBasicTest extends AbstractCliCompileTest {
 		N4CliHelper.copyN4jsLibsToLocation(workspace.toPath().resolve(N4JSGlobals.NODE_MODULES),
 				N4JSGlobals.N4JS_RUNTIME);
 
-		N4jscTestOptions compileOptions = COMPILE(workspace);
-		compileOptions.getDefinedOptions().remove("--noPersist");
-		compileOptions.getDefinedOptions().remove("--clean");
+		N4jscTestOptions compileOptions = COMPILE(DONT_CLEAN, workspace);
 
 		CliCompileResult firstRun = n4jsc(compileOptions);
 		assertEquals(firstRun.toString(), 16, firstRun.getTranspiledFilesCount());
@@ -104,9 +105,7 @@ public class N4jscBasicTest extends AbstractCliCompileTest {
 		N4CliHelper.copyN4jsLibsToLocation(workspace.toPath().resolve(N4JSGlobals.NODE_MODULES),
 				N4JSGlobals.N4JS_RUNTIME);
 
-		N4jscTestOptions compileOptions = COMPILE(workspace);
-		compileOptions.getDefinedOptions().remove("--noPersist");
-		compileOptions.getDefinedOptions().remove("--clean");
+		N4jscTestOptions compileOptions = COMPILE(DONT_CLEAN, workspace);
 
 		CliCompileResult firstRun = n4jsc(compileOptions);
 		assertEquals(firstRun.toString(), 16, firstRun.getTranspiledFilesCount());
@@ -136,9 +135,7 @@ public class N4jscBasicTest extends AbstractCliCompileTest {
 		N4CliHelper.copyN4jsLibsToLocation(workspace.toPath().resolve(N4JSGlobals.NODE_MODULES),
 				N4JSGlobals.N4JS_RUNTIME);
 
-		N4jscTestOptions compileOptions = COMPILE(workspace);
-		compileOptions.getDefinedOptions().remove("--noPersist");
-		compileOptions.getDefinedOptions().remove("--clean");
+		N4jscTestOptions compileOptions = COMPILE(DONT_CLEAN, workspace);
 
 		CliCompileResult firstRun = n4jsc(compileOptions);
 		assertEquals(firstRun.toString(), 16, firstRun.getTranspiledFilesCount());
@@ -166,9 +163,7 @@ public class N4jscBasicTest extends AbstractCliCompileTest {
 		N4CliHelper.copyN4jsLibsToLocation(workspace.toPath().resolve(N4JSGlobals.NODE_MODULES),
 				N4JSGlobals.N4JS_RUNTIME);
 
-		N4jscTestOptions compileOptions = COMPILE(workspace);
-		compileOptions.getDefinedOptions().remove("--noPersist");
-		compileOptions.getDefinedOptions().remove("--clean");
+		N4jscTestOptions compileOptions = COMPILE(DONT_CLEAN, workspace);
 
 		CliCompileResult firstRun = n4jsc(compileOptions);
 		assertEquals(firstRun.toString(), 16, firstRun.getTranspiledFilesCount());
@@ -196,9 +191,7 @@ public class N4jscBasicTest extends AbstractCliCompileTest {
 		N4CliHelper.copyN4jsLibsToLocation(workspace.toPath().resolve(N4JSGlobals.NODE_MODULES),
 				N4JSGlobals.N4JS_RUNTIME);
 
-		N4jscTestOptions compileOptions = COMPILE(workspace);
-		compileOptions.getDefinedOptions().remove("--noPersist");
-		compileOptions.getDefinedOptions().remove("--clean");
+		N4jscTestOptions compileOptions = COMPILE(DONT_CLEAN, workspace);
 
 		CliCompileResult firstRun = n4jsc(compileOptions);
 		assertEquals(firstRun.toString(), 16, firstRun.getTranspiledFilesCount());
@@ -225,9 +218,7 @@ public class N4jscBasicTest extends AbstractCliCompileTest {
 		N4CliHelper.copyN4jsLibsToLocation(workspace.toPath().resolve(N4JSGlobals.NODE_MODULES),
 				N4JSGlobals.N4JS_RUNTIME);
 
-		N4jscTestOptions compileOptions = COMPILE(workspace);
-		compileOptions.getDefinedOptions().remove("--noPersist");
-		compileOptions.getDefinedOptions().remove("--clean");
+		N4jscTestOptions compileOptions = COMPILE(DONT_CLEAN, workspace);
 
 		CliCompileResult firstRun = n4jsc(compileOptions);
 		assertEquals(firstRun.toString(), 16, firstRun.getTranspiledFilesCount());


### PR DESCRIPTION
When reading project state from disk that is no longer in sync with the file system, a proper incremental build must be triggered to ensure that transitively affected files are rebuilt.

Also we ensure that the build results are the same for the clean build and for the incremental build.

closes #1583 