### PR TITLE
GH-1614: Incorrect signature of built-in method Array#concat()

### DIFF
--- a/plugins/org.eclipse.n4js.ts/src-env/env/builtin_js.n4ts
+++ b/plugins/org.eclipse.n4js.ts/src-env/env/builtin_js.n4ts
@@ -352,7 +352,7 @@ public providedByRuntime  object Array<T> extends Object indexed T @Global {
 	 *
 	 * @see ES5, 15.4.4.4
 	 */
-	public concat(...items: union {T, Array<T>}): Array<T>
+	public concat(...items: union {T, Array<? extends T>}): Array<T>
 	/**
 	 * The elements of the array are converted to Strings, and these Strings are then concatenated, separated by
      * occurrences of the separator. If no separator is provided, a single comma is used as the separator.

--- a/tests/org.eclipse.n4js.bugreports.tests/bugreports-tests/GH_1614_IncorrectSignatureOfArrayConcat.n4js.xt
+++ b/tests/org.eclipse.n4js.bugreports.tests/bugreports-tests/GH_1614_IncorrectSignatureOfArrayConcat.n4js.xt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.bugreports.tests.N4JSBugreportTest END_SETUP  */
+
+
+class A {}
+class B extends A {}
+
+
+let arrA: Array<A>;
+let arrB: Array<B>;
+
+// XPECT noerrors --> "Array<B> is not a subtype of union{A,Array<A>}."
+arrA.concat(arrB);


### PR DESCRIPTION
See #1614.