### PR TITLE
GH-1749: LSP builder not using Xtext API for handling cancellation exceptions

### DIFF
--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/XBuildManager.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/XBuildManager.java
@@ -296,13 +296,15 @@ public class XBuildManager {
 
 		} catch (CancellationException ce) {
 			throw ce;
-		} catch (Exception e) {
-			operationCanceledManager.propagateIfCancelException(e);
-			// unknown exception (and not a cancellation case):
+		} catch (Throwable th) {
+			operationCanceledManager.propagateIfCancelException(th);
+			// unknown exception or error (and not a cancellation case):
 			// recover and also discard the build queue - state is undefined afterwards.
 			this.dirtyFiles.clear();
 			this.deletedFiles.clear();
-			throw e;
+			this.dirtyFilesAwaitingGeneration.clear();
+			this.deletedFilesAwaitingGeneration.clear();
+			throw th;
 		}
 	}
 

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/XBuildManager.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/XBuildManager.java
@@ -20,7 +20,6 @@ import java.util.concurrent.CancellationException;
 
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
-import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.n4js.ide.xtext.server.ParallelBuildManager.ParallelJob;
 import org.eclipse.n4js.ide.xtext.server.ProjectBuildOrderInfo.ProjectBuildOrderIterator;
@@ -29,6 +28,7 @@ import org.eclipse.xtext.resource.IResourceDescription;
 import org.eclipse.xtext.resource.IResourceDescription.Delta;
 import org.eclipse.xtext.resource.impl.DefaultResourceDescriptionDelta;
 import org.eclipse.xtext.resource.impl.ProjectDescription;
+import org.eclipse.xtext.service.OperationCanceledManager;
 import org.eclipse.xtext.util.CancelIndicator;
 import org.eclipse.xtext.xbase.lib.IterableExtensions;
 import org.eclipse.xtext.xbase.lib.IteratorExtensions;
@@ -128,6 +128,9 @@ public class XBuildManager {
 
 	@Inject
 	private ProjectBuildOrderInfo.Provider projectBuildOrderInfoProvider;
+
+	@Inject
+	private OperationCanceledManager operationCanceledManager;
 
 	private final LinkedHashSet<URI> dirtyFiles = new LinkedHashSet<>();
 	private final LinkedHashSet<URI> deletedFiles = new LinkedHashSet<>();
@@ -291,9 +294,11 @@ public class XBuildManager {
 			allBuildDeltas = new ArrayList<>();
 			return result;
 
-		} catch (CancellationException | OperationCanceledException ce) {
+		} catch (CancellationException ce) {
 			throw ce;
 		} catch (Exception e) {
+			operationCanceledManager.propagateIfCancelException(e);
+			// unknown exception (and not a cancellation case):
 			// recover and also discard the build queue - state is undefined afterwards.
 			this.dirtyFiles.clear();
 			this.deletedFiles.clear();

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/build/XStatefulIncrementalBuilder.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/build/XStatefulIncrementalBuilder.java
@@ -157,7 +157,9 @@ public class XStatefulIncrementalBuilder {
 		} catch (CancellationException e) {
 			// catch CancellationException here and proceed normally to save already resolved deltas
 		} catch (Throwable th) {
-			if (!operationCanceledManager.isOperationCanceledException(th)) {
+			if (operationCanceledManager.isOperationCanceledException(th)) {
+				// catch OperationCanceledException, etc. here and proceed normally to save already resolved deltas
+			} else {
 				throw th;
 			}
 		}

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/build/XStatefulIncrementalBuilder.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/build/XStatefulIncrementalBuilder.java
@@ -156,6 +156,10 @@ public class XStatefulIncrementalBuilder {
 
 		} catch (CancellationException e) {
 			// catch CancellationException here and proceed normally to save already resolved deltas
+		} catch (Throwable th) {
+			if (!operationCanceledManager.isOperationCanceledException(th)) {
+				throw th;
+			}
 		}
 
 		return new XBuildResult(this.request.getState(), allProcessedDeltas);

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/concurrent/XRequestManager.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/concurrent/XRequestManager.java
@@ -34,7 +34,7 @@ public class XRequestManager {
 
 	private static final Logger LOG = Logger.getLogger(XRequestManager.class);
 
-	// TODO re-enable concurrent execution of read-requests
+	// TODO GH-1753 re-enable concurrent execution of read-requests
 	// @Inject
 	// private ExecutorService parallel;
 	private final ExecutorService parallel = Executors.newSingleThreadExecutor(

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/concurrent/XRequestManager.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/concurrent/XRequestManager.java
@@ -34,8 +34,11 @@ public class XRequestManager {
 
 	private static final Logger LOG = Logger.getLogger(XRequestManager.class);
 
-	@Inject
-	private ExecutorService parallel;
+	// TODO re-enable concurrent execution of read-requests
+	// @Inject
+	// private ExecutorService parallel;
+	private final ExecutorService parallel = Executors.newSingleThreadExecutor(
+			new ThreadFactoryBuilder().setDaemon(true).setNameFormat("XRequestManager-Parallel-%d").build());
 
 	@Inject
 	private OperationCanceledManager operationCanceledManager;

--- a/tests/org.eclipse.n4js.ide.tests/src/org/eclipse/n4js/ide/tests/xtext/XRequestManagerTest.xtend
+++ b/tests/org.eclipse.n4js.ide.tests/src/org/eclipse/n4js/ide/tests/xtext/XRequestManagerTest.xtend
@@ -155,8 +155,8 @@ class XRequestManagerTest {
 		assertEquals(2, sharedState.get)
 	}
 
-	// TODO when re-enabling concurrent execution of read-requests:
-	// delete the following test case and re-enable test #testRunReadConcurrent():
+	// when re-enabling concurrent execution of read-requests:
+	// TODO GH-1753 delete the following test case and re-enable #testRunReadConcurrent()
 	@Test(timeout = 2000)
 	def void testRunReadNotConcurrent() {
 		// as above in method #testRunReadConcurrent():

--- a/tests/org.eclipse.n4js.ide.tests/src/org/eclipse/n4js/ide/tests/xtext/XRequestManagerTest.xtend
+++ b/tests/org.eclipse.n4js.ide.tests/src/org/eclipse/n4js/ide/tests/xtext/XRequestManagerTest.xtend
@@ -17,6 +17,7 @@ import com.google.inject.Guice
 import com.google.inject.Inject
 import java.util.concurrent.CancellationException
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicBoolean
@@ -29,6 +30,7 @@ import org.eclipse.xtext.testing.logging.LoggingTester
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Test
 
 import static org.junit.Assert.*
@@ -137,6 +139,7 @@ class XRequestManagerTest {
 		assertEquals('Foo', Futures.getUnchecked(future))
 	}
 
+	@Ignore
 	@Test(timeout = 1000)
 	def void testRunReadConcurrent() {
 		val future = requestManager.runRead("test") [
@@ -150,6 +153,33 @@ class XRequestManagerTest {
 		]
 		future.join
 		assertEquals(2, sharedState.get)
+	}
+
+	// TODO when re-enabling concurrent execution of read-requests:
+	// delete the following test case and re-enable test #testRunReadConcurrent():
+	@Test(timeout = 2000)
+	def void testRunReadNotConcurrent() {
+		// as above in method #testRunReadConcurrent():
+		val future = requestManager.runRead("test") [
+			while (sharedState.get == 0) {
+				Uninterruptibles.sleepUninterruptibly(10, TimeUnit.MILLISECONDS)
+			}
+			sharedState.incrementAndGet
+		]
+		requestManager.runRead("test") [
+			sharedState.incrementAndGet
+		]
+		// but now we expect a timeout:
+		try {
+			Uninterruptibles.getUninterruptibly(future, 1000, TimeUnit.MILLISECONDS)
+			fail("expected timeout")
+		} catch (ExecutionException exc) {
+			fail("incorrect exception")
+		} catch(TimeoutException e) {
+			assertEquals(0, sharedState.get)
+			sharedState.incrementAndGet
+			requestManager.allRequests.join
+		}
 	}
 
 	@Test(timeout = 1000)


### PR DESCRIPTION
See #1749.

I wonder if a `java.util.concurrent.CancellationException` can even occur at the two places I changed, but haven't removed the support for it, for now.