### PR TITLE
GH-1751: As a developer I want a super simple, preliminary progress indicator for the incremental build

### DIFF
--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/server/LspLogger.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/server/LspLogger.java
@@ -13,15 +13,27 @@ package org.eclipse.n4js.ide.server;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.services.LanguageClient;
-import org.eclipse.n4js.ide.xtext.server.XLanguageServerImpl;
 
-import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
-/** */
+/**
+ * Logging from the LSP server to the LSP client using LSP's {@link LanguageClient#logMessage(MessageParams)
+ * window/logMessage} notification.
+ */
+@Singleton
 public class LspLogger {
 
-	@Inject
-	XLanguageServerImpl langServer;
+	private LanguageClient languageClient;
+
+	/** Connect this logger to the given client. */
+	public void connect(LanguageClient client) {
+		this.languageClient = client;
+	}
+
+	/** Disconnect this logger from the given client. */
+	public void disconnect() {
+		this.languageClient = null;
+	}
 
 	/** */
 	public void log(String messageString) {
@@ -45,13 +57,14 @@ public class LspLogger {
 
 	/** */
 	public void log(String messageString, MessageType type) {
-		LanguageClient languageClient = langServer.getLanguageClient();
-		if (languageClient != null) {
-			MessageParams message = new MessageParams();
-			message.setMessage(messageString);
-			message.setType(type);
-			languageClient.logMessage(message);
+		final LanguageClient lc = this.languageClient;
+		if (lc == null) {
+			return;
 		}
+		MessageParams message = new MessageParams();
+		message.setMessage(messageString);
+		message.setType(type);
+		lc.logMessage(message);
 	}
 
 }

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/XLanguageServerImpl.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/XLanguageServerImpl.java
@@ -95,6 +95,7 @@ import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
 import org.eclipse.n4js.ide.server.HeadlessExtensionRegistrationHelper;
+import org.eclipse.n4js.ide.server.LspLogger;
 import org.eclipse.n4js.ide.xtext.server.XBuildManager.XBuildable;
 import org.eclipse.n4js.ide.xtext.server.build.XIndexState;
 import org.eclipse.n4js.ide.xtext.server.concurrent.XRequestManager;
@@ -183,6 +184,9 @@ public class XLanguageServerImpl implements LanguageServer, WorkspaceService, Te
 
 	@Inject
 	private IssueAcceptor issueAcceptor;
+
+	@Inject
+	private LspLogger lspLogger;
 
 	@Inject
 	private ProjectStatePersister persister;
@@ -416,12 +420,14 @@ public class XLanguageServerImpl implements LanguageServer, WorkspaceService, Te
 	public void connect(LanguageClient client) {
 		this.client = client;
 		issueAcceptor.connect(client);
+		lspLogger.connect(client);
 	}
 
 	/**
 	 * Discard all references to the language client.
 	 */
 	public void disconnect() {
+		lspLogger.disconnect();
 		issueAcceptor.disconnect();
 		this.client = null;
 	}


### PR DESCRIPTION
See #1751.

First version using ordinary logging. Maybe a second version using a separate output channel will be provided as another PR later.

By the way:
I ran into an odd exception in the Guice injector that occurred only in the maven build, caused by `LspLogger`. Should be fixed by 8fce8c87af4d0f39f2b2fa700a4f4a9991bb1e72.
```
00:10:22.209  ERROR-1 (Unexpected error):  com.google.inject.internal.util.$ComputationException: com.google.inject.internal.util.$ComputationException: 
com.google.inject.internal.util.$ComputationException: com.google.inject.internal.util.$ComputationException: 
com.google.inject.internal.util.$ComputationException: com.google.inject.internal.util.$ComputationException: 
com.google.inject.internal.util.$ComputationException: com.google.inject.internal.util.$ComputationException: 
com.google.inject.internal.util.$ComputationException: com.google.inject.internal.util.$ComputationException: 
com.google.inject.internal.util.$ComputationException: com.google.inject.internal.util.$ComputationException: 
com.google.inject.internal.util.$ComputationException: com.google.inject.internal.util.$ComputationException: 
[...]
```
cf. http://n4ide1-jenkins.service.cd-dev.consul/view/IDE/job/N4JS-Inhouse-CI/job/GH-1751/1/console