### PR TITLE
GH-1816: Type references pointing to namespaces of dynamic imports are not flagged as dynamic

### DIFF
--- a/plugins/org.eclipse.n4js.ts/src/org/eclipse/n4js/ts/utils/TypeUtils.java
+++ b/plugins/org.eclipse.n4js.ts/src/org/eclipse/n4js/ts/utils/TypeUtils.java
@@ -63,6 +63,7 @@ import org.eclipse.n4js.ts.typeRefs.Wildcard;
 import org.eclipse.n4js.ts.types.AnyType;
 import org.eclipse.n4js.ts.types.InferenceVariable;
 import org.eclipse.n4js.ts.types.MemberType;
+import org.eclipse.n4js.ts.types.ModuleNamespaceVirtualType;
 import org.eclipse.n4js.ts.types.NullType;
 import org.eclipse.n4js.ts.types.PrimitiveType;
 import org.eclipse.n4js.ts.types.TClass;
@@ -204,6 +205,9 @@ public class TypeUtils {
 		}
 		if (autoCreateTypeArgs) {
 			sanitizeRawTypeRef(ref);
+		}
+		if (declaredType instanceof ModuleNamespaceVirtualType) {
+			ref.setDynamic(((ModuleNamespaceVirtualType) declaredType).isDeclaredDynamic());
 		}
 		return ref;
 	}

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/typesystem/TypeJudgment.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/typesystem/TypeJudgment.java
@@ -939,8 +939,16 @@ import com.google.inject.Inject;
 						? TypeUtils.createTypeTypeRef(ctorTypeArg, true)
 						: unknown();
 			} else if (receiverTypeRefUB.isDynamic() && prop != null && prop.eIsProxy()) {
-				// access to an unknown property of a dynamic type
-				propTypeRef = anyTypeRefDynamic(G2);
+				if (receiverTypeRefUB.getDeclaredType() instanceof ModuleNamespaceVirtualType) {
+					// temporary special case for backward compatibility:
+					// access to an unknown property of a dynamic namespace import
+					// --> any+ would be correct but use UnknownTypeRef to not break existing code
+					// TODO GH-1814 remove this special case (i.e. use anyTypeRefDynamic(G2) instead)
+					propTypeRef = unknown();
+				} else {
+					// access to an unknown property of a dynamic type
+					propTypeRef = anyTypeRefDynamic(G2);
+				}
 			} else {
 				propTypeRef = ts.type(wrap(G2), prop);
 				if (expr.isParameterized()) {

--- a/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch09_02_04__ImportStatements/Req136_DynamicImport.n4js.xt
+++ b/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch09_02_04__ImportStatements/Req136_DynamicImport.n4js.xt
@@ -71,3 +71,17 @@ N4JSDStatic.D;
 N4JSDDynamic.D;
 // XPECT noerrors -->
 N4JSDDynamic.X;
+
+// XPECT type of 'n4jsDynamic' --> N4JSDynamic+
+let n4jsDynamic = N4JSDynamic;
+// XPECT noerrors -->
+n4jsDynamic.C;
+// XPECT noerrors -->
+n4jsDynamic.X;
+
+// XPECT type of 'n4jsdDynamic' --> N4JSDDynamic+
+let n4jsdDynamic = N4JSDDynamic;
+// XPECT noerrors -->
+n4jsdDynamic.C;
+// XPECT noerrors -->
+n4jsdDynamic.X;


### PR DESCRIPTION
See #1816.

This PR implements a minor, largely unrelated improvement done while looking into GH-1631. See GH-1816 for details.