### PR TITLE
GH-1828: Yarn root project not found when setting the packages folder as the workspace of VSCode

### DIFF
--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/utils/NodeModulesDiscoveryHelper.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/utils/NodeModulesDiscoveryHelper.java
@@ -82,6 +82,11 @@ public class NodeModulesDiscoveryHelper {
 
 	/** @return the node_modules folder of the given project including a flag if this is a yarn workspace. */
 	public NodeModulesFolder getNodeModulesFolder(Path projectLocation, Map<Path, ProjectDescription> pdCache) {
+		final Path packgeJsonPath = projectLocation.resolve(N4JSGlobals.PACKAGE_JSON);
+		if (!packgeJsonPath.toFile().isFile()) {
+			return null; // given projectLocation must contain a package.json file
+		}
+
 		File projectLocationAsFile = projectLocation.toFile();
 
 		if (isYarnWorkspaceRoot(projectLocationAsFile, Optional.absent(), pdCache)) {
@@ -97,13 +102,8 @@ public class NodeModulesDiscoveryHelper {
 			return new NodeModulesFolder(false, true, localNMF, workspaceNMF);
 		}
 
-		final Path packgeJsonPath = projectLocation.resolve(N4JSGlobals.PACKAGE_JSON);
-		if (packgeJsonPath.toFile().isFile()) {
-			final Path nodeModulesPath = projectLocation.resolve(N4JSGlobals.NODE_MODULES);
-			return new NodeModulesFolder(false, false, nodeModulesPath.toFile(), null);
-		}
-
-		return null;
+		final Path nodeModulesPath = projectLocation.resolve(N4JSGlobals.NODE_MODULES);
+		return new NodeModulesFolder(false, false, nodeModulesPath.toFile(), null);
 	}
 
 	/** Same as {@link #findNodeModulesFolders(Collection, Map)} without cache */

--- a/tests/org.eclipse.n4js.cli.tests/PDTs/yarnDeepPackages2.pdt
+++ b/tests/org.eclipse.n4js.cli.tests/PDTs/yarnDeepPackages2.pdt
@@ -11,5 +11,6 @@ FOLDERS
 ---- D2 [PROJECT]
 
 EXPECT
+- P1
 - P1/packages/folder1/D1
 - P1/packages/folder2/D2

--- a/tests/org.eclipse.n4js.cli.tests/PDTs/yarnDeepPackages3.pdt
+++ b/tests/org.eclipse.n4js.cli.tests/PDTs/yarnDeepPackages3.pdt
@@ -11,4 +11,6 @@ FOLDERS
 ---- D2 [PROJECT]
 
 EXPECT
+- P1
 - P1/packages/folder1/D1
+- P1/packages/folder2/D2

--- a/tests/org.eclipse.n4js.cli.tests/PDTs/yarnSimple1b.pdt
+++ b/tests/org.eclipse.n4js.cli.tests/PDTs/yarnSimple1b.pdt
@@ -3,9 +3,10 @@
 
 
 FOLDERS
--*P1 [PROJECT workspaces=["packages/*"]]
+- P1 [PROJECT workspaces=["packages/*"]]
 --*packages
 --- D1 [PROJECT]
 
 EXPECT
+- P1
 - P1/packages/D1

--- a/tests/org.eclipse.n4js.cli.tests/src/org/eclipse/n4js/cli/projectdiscovery/tests/CreateProjectStructureUtils.java
+++ b/tests/org.eclipse.n4js.cli.tests/src/org/eclipse/n4js/cli/projectdiscovery/tests/CreateProjectStructureUtils.java
@@ -134,6 +134,9 @@ public class CreateProjectStructureUtils {
 
 		for (Folder folder : folders) {
 			if (folder.isWorkingDir) {
+				if (workingDir != null) {
+					throw new IllegalStateException("Multiple working directories not supported");
+				}
 				workingDir = folder;
 			}
 		}


### PR DESCRIPTION
closes #1828 