### PR TITLE
GH-1830: Fixed regression in ResourceTaskContext wrt unloading

### DIFF
--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ResourceTaskContext.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ResourceTaskContext.java
@@ -294,11 +294,7 @@ public class ResourceTaskContext {
 
 	/** Same as {@link #refreshContext(int, Iterable, CancelIndicator)}, but without changing the source text. */
 	public void refreshContext(CancelIndicator cancelIndicator) {
-		prepareRefresh();
-
-		mainResource.relink();
-
-		resolveAndValidateResource(cancelIndicator);
+		refreshContext(0, Collections.emptyList(), cancelIndicator);
 	}
 
 	/**


### PR DESCRIPTION
Lesson learned: relink is not properly implemented on XtextResource and
all of its subclasses.

closes #1830 