### PR TITLE
GH-1842: Using method XtextResource#reparse() when refreshing resources causes exceptions

### DIFF
--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ResourceTaskContext.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/ResourceTaskContext.java
@@ -321,12 +321,9 @@ public class ResourceTaskContext {
 
 		prepareRefresh();
 
+		int oldDocumentLength = document.getContents().length();
 		document = document.applyTextDocumentChanges(changes);
-		try {
-			mainResource.reparse(document.getContents());
-		} catch (IOException e) {
-			throw new RuntimeException(e);
-		}
+		mainResource.update(0, oldDocumentLength, document.getContents());
 
 		resolveAndValidateResource(cancelIndicator);
 	}


### PR DESCRIPTION
See #1842.