### PR TITLE
GH-1858: "IllegalArgumentException: Unhandled parameter types" in N4JSElementSignatureProvider

### DIFF
--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/server/hover/N4JSElementSignatureProvider.xtend
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/server/hover/N4JSElementSignatureProvider.xtend
@@ -48,6 +48,9 @@ class N4JSElementSignatureProvider {
 			return o.typeRefAsString;
 		}
 		val id = getIdentifiableElement(o);
+		if (id === null) {
+			return null;
+		}
 		val label = doGetLabel(id, o);
 		sanitizeForHTML(label);
 		return label;


### PR DESCRIPTION
closes #1858 