### PR TITLE
GH-1884: As a smith I want debug information to be written to a file whenever an error is logged

### DIFF
--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/server/LspLogger.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/server/LspLogger.java
@@ -16,7 +16,7 @@ import java.io.StringWriter;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.MessageType;
 import org.eclipse.lsp4j.services.LanguageClient;
-import org.eclipse.n4js.ide.server.util.DiagnosisLogger;
+import org.eclipse.n4js.ide.server.util.ServerIncidentLogger;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
@@ -29,7 +29,7 @@ import com.google.inject.Singleton;
 public class LspLogger {
 
 	@Inject
-	private DiagnosisLogger diagnosisLogger;
+	private ServerIncidentLogger serverIncidentLogger;
 
 	private LanguageClient languageClient;
 
@@ -83,7 +83,7 @@ public class LspLogger {
 		lc.logMessage(message);
 
 		if (type == MessageType.Error) {
-			diagnosisLogger.reportError(messageString);
+			serverIncidentLogger.reportError(messageString);
 		}
 	}
 

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/server/util/ServerIncidentLogger.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/server/util/ServerIncidentLogger.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.eclipse.n4js.ide.xtext.server.DebugService;
+import org.eclipse.n4js.utils.N4JSLanguageUtils;
 import org.eclipse.n4js.utils.io.FileUtils;
 
 import com.google.common.base.Throwables;
@@ -35,10 +36,10 @@ import com.google.inject.Singleton;
  * This is TEMPORARY functionality for debugging that will be removed in the future.
  */
 @Singleton
-public class DiagnosisLogger {
+public class ServerIncidentLogger {
 
-	/** Name of folder where the log file is placed. */
-	public static final String FOLDER_NAME = ".n4js";
+	/** Path of the folder where the log files are placed, relative to the user's home directory. */
+	public static final Path SERVER_INCIDENTS_FOLDER = Path.of(".n4js", "server-incidents");
 	/** Base name of the log file, will be amended by a time stamp. */
 	public static final String BASE_FILE_NAME = "server-incident_.log";
 
@@ -114,12 +115,23 @@ public class DiagnosisLogger {
 		private Path getOrCreateOutputFolder() throws IOException {
 			if (outputFolder == null) {
 				Path userHomePath = FileUtils.getUserHomeFolder();
+				String languageVersion = getLanguageVersion();
 				String serverInstanceFolderName = sanitizeTimeStampForFileName(serverInstanceTimeStamp)
-						+ "_" + serverInstanceId.toString().substring(0, 6);
-				outputFolder = userHomePath.resolve(FOLDER_NAME).resolve(serverInstanceFolderName);
+						+ "__" + languageVersion
+						+ "__" + serverInstanceId.toString().substring(0, 6);
+				outputFolder = userHomePath.resolve(SERVER_INCIDENTS_FOLDER)
+						.resolve(serverInstanceFolderName);
 			}
 			Files.createDirectories(outputFolder);
 			return outputFolder;
+		}
+
+		private String getLanguageVersion() {
+			try {
+				return N4JSLanguageUtils.getLanguageVersion();
+			} catch (Throwable th) {
+				return N4JSLanguageUtils.DEFAULT_LANGUAGE_VERSION;
+			}
 		}
 	}
 }

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/server/util/ServerIncidentLogger.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/server/util/ServerIncidentLogger.java
@@ -119,8 +119,7 @@ public class ServerIncidentLogger {
 				String serverInstanceFolderName = sanitizeTimeStampForFileName(serverInstanceTimeStamp)
 						+ "__" + languageVersion
 						+ "__" + serverInstanceId.toString().substring(0, 6);
-				outputFolder = userHomePath.resolve(SERVER_INCIDENTS_FOLDER)
-						.resolve(serverInstanceFolderName);
+				outputFolder = userHomePath.resolve(SERVER_INCIDENTS_FOLDER).resolve(serverInstanceFolderName);
 			}
 			Files.createDirectories(outputFolder);
 			return outputFolder;

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/XLanguageServerImpl.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/xtext/server/XLanguageServerImpl.java
@@ -83,7 +83,7 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
 import org.eclipse.n4js.ide.server.HeadlessExtensionRegistrationHelper;
 import org.eclipse.n4js.ide.server.LspLogger;
-import org.eclipse.n4js.ide.server.util.DiagnosisLogger;
+import org.eclipse.n4js.ide.server.util.ServerIncidentLogger;
 import org.eclipse.n4js.ide.xtext.server.issues.PublishingIssueAcceptor;
 import org.eclipse.xtext.ide.server.ICapabilitiesContributor;
 import org.eclipse.xtext.ide.server.ILanguageServerAccess;
@@ -157,7 +157,7 @@ public class XLanguageServerImpl implements LanguageServer, WorkspaceService, Te
 	private LspLogger lspLogger;
 
 	@Inject
-	private DiagnosisLogger diagnosisLogger;
+	private ServerIncidentLogger serverIncidentLogger;
 
 	@Inject
 	private Provider<XtextResourceSet> resourceSetProvider;
@@ -754,8 +754,8 @@ public class XLanguageServerImpl implements LanguageServer, WorkspaceService, Te
 	/**
 	 * Getter
 	 */
-	public DiagnosisLogger getDiagnosisLogger() {
-		return diagnosisLogger;
+	public ServerIncidentLogger getServerIncidentLogger() {
+		return serverIncidentLogger;
 	}
 
 	/**


### PR DESCRIPTION
Minor improvements of the functionality introduced with #1884:
1. include language version in name of folder where debug information is written to,
2. rename `DiagnosisLogger` to `ServerIncidentLogger`.

See #1884.