### PR TITLE
GH-1946: As a developer I want number-based enums

### DIFF
--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/typesystem/SubtypeJudgment.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/typesystem/SubtypeJudgment.java
@@ -249,6 +249,7 @@ import com.google.common.collect.Iterables;
 				return resultFromBoolean(enumKind == EnumKind.Normal);
 			}
 			if (rightDeclType == n4NumberBasedEnumType(G)
+					|| rightDeclType == intType(G)
 					|| rightDeclType == numberType(G)
 					|| rightDeclType == numberObjectType(G)) {
 				return resultFromBoolean(enumKind == EnumKind.NumberBased);

--- a/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch04_13_02__StringBasedEnums/Req41_NumberBasedEnums_Typing.n4js.xt
+++ b/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch04_13_02__StringBasedEnums/Req41_NumberBasedEnums_Typing.n4js.xt
@@ -29,6 +29,9 @@ var v3a : Number = E.L;
 var v3b : number = E.L;
 
 // XPECT noerrors -->
+var v3c : int = E.L;
+
+// XPECT noerrors -->
 var v4 : N4NumberBasedEnum = E.L;
 
 


### PR DESCRIPTION
See #1946.

Fix: literals of number-based enums should also be a subtype of `int`, not just `number`.

(note: so far, `int` in N4JS is just a synonym for `number`)