### PR TITLE
GH-1960: As a developer I want to use shorthand property names on object literals

### DIFF
--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/ASTStructureValidator.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/ASTStructureValidator.xtend
@@ -730,7 +730,7 @@ class ASTStructureValidator {
 				issueArgumentsError(model, name, constraints.isStrict, producer)
 			} else {
 				if (name != YIELD_KEYWORD && (languageHelper.getECMAKeywords.contains(name)
-					|| 'enum'.equals(name) || 'await'.equals(name) || 'let'.equals(name)
+					|| 'enum'.equals(name) || 'await'.equals(name)
 					|| 'true'.equals(name) || 'false'.equals(name) || 'null'.equals(name))) {
 					issueNameDiagnostic(model, producer, name)
 				} else if (constraints.isStrict) {

--- a/tests/org.eclipse.n4js.tests.ecmatestsuite/res/blacklist_5.0.txt
+++ b/tests/org.eclipse.n4js.tests.ecmatestsuite/res/blacklist_5.0.txt
@@ -7,3 +7,15 @@
 # E.g., some files contain illegal code in eval functions, which is
 # interpreted as string by the parser.
 #
+
+
+
+#
+# The following tests are blacklisted because they contain syntax that was
+# invalid in ES5 but is now valid as of ES6: they expect a syntax error that
+# our parser does no longer produce.
+#
+
+test262/suite/ch12/12.1/S12.1_A4_T1.js
+test262/suite/ch12/12.1/S12.1_A4_T2.js
+test262/suite/ch12/12.6/12.6.4/S12.6.4_A15.js

--- a/tests/org.eclipse.n4js.tests.ecmatestsuite/res/blacklist_6.0.txt
+++ b/tests/org.eclipse.n4js.tests.ecmatestsuite/res/blacklist_6.0.txt
@@ -1,19 +1,6 @@
-# Testcases that create the synthetic error message: Single name syntax in object literals is unsupported
+# Testcases making use of unsupported feature "class expressions"
 
 test/language/computed-property-names/class/static/generator-prototype.js
 test/language/computed-property-names/class/static/getter-prototype.js
 test/language/computed-property-names/class/static/method-prototype.js
 test/language/computed-property-names/class/static/setter-prototype.js
-test/language/object-literal/yield-non-strict-syntax.js
-test/language/object-literal/yield-non-strict-access.js
-test/language/object-literal/let-non-strict-syntax.js
-test/language/object-literal/let-non-strict-access.js
-test/language/object-literal/identifier-reference-property-get-access.js
-test/language/object-literal/descriptor.js
-test/language/object-literal/not-defined.js
-test/language/expressions/object/prop-def-id-valid.js
-test/language/expressions/object/prop-def-id-get-error.js
-test/language/expressions/object/prop-def-id-eval-error.js
-test/language/expressions/object/prop-def-id-eval-error-2.js
-test/language/statements/for-in/const-bound-names-fordecl-tdz-for-in.js
-test/language/statements/for-in/let-bound-names-fordecl-tdz-for-in.js


### PR DESCRIPTION
Fixes failing tests in ecma test suite.
(did not show up in test builds, because that test suite isn't running in CI builds)