### PR TITLE
GH-1968: || (logical or) and ?? (nullish coalescing) operators resolve different return types for the same objects

### DIFF
--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/typesystem/TypeJudgment.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/typesystem/TypeJudgment.java
@@ -1187,9 +1187,21 @@ import com.google.inject.Inject;
 		}
 
 		@Override
-		public TypeRef caseBinaryLogicalExpression(BinaryLogicalExpression e) {
-			final Expression lhs = e.getLhs();
-			final Expression rhs = e.getRhs();
+		public TypeRef caseBinaryLogicalExpression(BinaryLogicalExpression expr) {
+			return simplifyUnionWithEmptyAnyArray(expr.getLhs(), expr.getRhs());
+		}
+
+		@Override
+		public TypeRef caseConditionalExpression(ConditionalExpression expr) {
+			return simplifyUnionWithEmptyAnyArray(expr.getTrueExpression(), expr.getFalseExpression());
+		}
+
+		@Override
+		public TypeRef caseCoalesceExpression(CoalesceExpression expr) {
+			return simplifyUnionWithEmptyAnyArray(expr.getExpression(), expr.getDefaultExpression());
+		}
+
+		private TypeRef simplifyUnionWithEmptyAnyArray(Expression lhs, Expression rhs) {
 			final boolean lhsIsEmptyArrayLiteral = lhs instanceof ArrayLiteral
 					&& ((ArrayLiteral) lhs).getElements().isEmpty();
 			final boolean rhsIsEmptyArrayLiteral = rhs instanceof ArrayLiteral
@@ -1205,22 +1217,7 @@ import com.google.inject.Inject;
 				// case: someArray || []
 				return L;
 			}
-
 			return typeSystemHelper.createUnionType(G, L, R);
-		}
-
-		@Override
-		public TypeRef caseConditionalExpression(ConditionalExpression expr) {
-			final TypeRef left = ts.type(G, expr.getTrueExpression());
-			final TypeRef right = ts.type(G, expr.getFalseExpression());
-			return typeSystemHelper.createUnionType(G, left, right);
-		}
-
-		@Override
-		public TypeRef caseCoalesceExpression(CoalesceExpression expr) {
-			final TypeRef value = ts.type(G, expr.getExpression());
-			final TypeRef dflt = ts.type(G, expr.getDefaultExpression());
-			return typeSystemHelper.createUnionType(G, value, dflt);
 		}
 
 		@Override

--- a/tests/org.eclipse.n4js.xpect.tests/model/typesystem/SimplifyUnionWithEmptyAnyArray.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/typesystem/SimplifyUnionWithEmptyAnyArray.n4js.xt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.xpect.tests.N4JSXpectTest END_SETUP  */
+
+
+
+
+// XPECT type of 'arrayOfInt' --> Array<int>
+const arrayOfInt = [1, 2, 3];
+
+
+// XPECT type of 'arrayB1' --> Array<int>
+const arrayB1 = arrayOfInt || [];
+// XPECT type of 'arrayB2' --> Array<int>
+const arrayB2 = [] || arrayOfInt;
+
+
+// XPECT type of 'arrayC1' --> Array<int>
+const arrayC1 = arrayOfInt ?? [];
+// XPECT type of 'arrayC2' --> Array<int>
+const arrayC2 = [] ?? arrayOfInt;
+
+
+// XPECT type of 'cond1' --> Array<int>
+const cond1 = "a" == "b" ? arrayOfInt : [];
+// XPECT type of 'cond2' --> Array<int>
+const cond2 = "a" == "b" ? [] : arrayOfInt;

--- a/tests/org.eclipse.n4js.xpect.tests/model/typesystem/SimplifyUnionWithEmptyAnyArray.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/typesystem/SimplifyUnionWithEmptyAnyArray.n4js.xt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 NumberFour AG.
+ * Copyright (c) 2020 NumberFour AG.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at


### PR DESCRIPTION
closes #1968