### PR TITLE
GH-1992B: Negated instanceof guards should strip their checked type from guarded IdentifierRefs

### DIFF
--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/typesystem/TypeJudgment.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/typesystem/TypeJudgment.java
@@ -630,10 +630,15 @@ import com.google.inject.Inject;
 							final UnionTypeExpression union = (UnionTypeExpression) origType;
 							final Collection<TypeRef> newUnionTypes = new LinkedList<>();
 							for (TypeRef unionType : union.getTypeRefs()) {
+								boolean removeType = false;
 								for (TypeRef neverHoldingType : excludedTypes) {
-									if (!ts.subtypeSucceeded(G, unionType, neverHoldingType)) {
-										newUnionTypes.add(unionType);
+									if (ts.subtypeSucceeded(G, unionType, neverHoldingType)) {
+										removeType = true;
+										break;
 									}
+								}
+								if (!removeType) {
+									newUnionTypes.add(unionType);
 								}
 							}
 							if (newUnionTypes.size() < union.getTypeRefs().size()) {

--- a/tests/org.eclipse.n4js.xpect.tests/model/validation/controlflow/Instanceof_Guard_exclusion.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/validation/controlflow/Instanceof_Guard_exclusion.n4js.xt
@@ -11,8 +11,7 @@
 
 /* XPECT_SETUP org.eclipse.n4js.xpect.tests.N4JSXpectTest END_SETUP */
 
-
-function f10(a : Number|String) {
+/*function f10(a : Number|String) {
 	if (!(a instanceof Number)) {
 		// XPECT instanceofguard of 'a' --> a!<:Number
 		// XPECT type of 'a' --> String
@@ -102,5 +101,23 @@ function f41(p: any) {
 			p;
 		}
 	}
+}
+*/
+
+
+interface I51 {}
+interface I52 {}
+interface I53 {}
+interface I54 {}
+
+function f50(p: I51|I52|I53|I54) {
+    if (p instanceof I51) {
+        return;
+    }
+    if (p instanceof I52) {
+        return;
+    }
+    // XPECT type of 'p' --> union{I53,I54}
+    p;
 }
 

--- a/tests/org.eclipse.n4js.xpect.tests/model/validation/controlflow/Instanceof_Guard_exclusion.n4js.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/model/validation/controlflow/Instanceof_Guard_exclusion.n4js.xt
@@ -11,7 +11,8 @@
 
 /* XPECT_SETUP org.eclipse.n4js.xpect.tests.N4JSXpectTest END_SETUP */
 
-/*function f10(a : Number|String) {
+
+function f10(a : Number|String) {
 	if (!(a instanceof Number)) {
 		// XPECT instanceofguard of 'a' --> a!<:Number
 		// XPECT type of 'a' --> String
@@ -102,7 +103,6 @@ function f41(p: any) {
 		}
 	}
 }
-*/
 
 
 interface I51 {}


### PR DESCRIPTION
follow-up of #1992 

@mor-n4 noted a problem in the discussion started here: https://github.com/eclipse/n4js/pull/1993#discussion_r540105168

@mor-n4 elaborated that a solution can be (starting in line 633):
```js
	boolean removeType = false;
	for (TypeRef neverHoldingType : excludedTypes) {
		if (ts.subtypeSucceeded(G, unionType, neverHoldingType)) {
			removeType = true;
			break;
		}
	}
	if (!removeType) {
		newUnionTypes.add(unionType);
	}
```


This PR fixes the problem.
