### PR TITLE
GH-2014: Enable debugging of N4JS code in VS Code using the node debugger

### DIFF
--- a/lsp-clients/n4js-vscode-extension/package.json
+++ b/lsp-clients/n4js-vscode-extension/package.json
@@ -62,6 +62,62 @@
         "path": "./syntaxes/n4js.json.tmLanguage.json"
       }
     ],
+    "debuggers": [
+      {
+        "type": "n4js",
+        "label": "N4JS Debug",
+        "languages": [ "n4js" ],
+        "configurationSnippets": [
+          {
+            "label": "N4JS: Launch/Debug N4JS",
+            "description": "Launches and debugs the N4JS file in the currently active editor.",
+            "body": {
+              "type": "node",
+              "request": "launch",
+              "name": "Launch/Debug N4JS",
+              "runtimeExecutable": "/usr/local/bin/node",
+              "runtimeArgs": [ "-r", "esm" ],
+              "program": "${file}",
+              "args": [],
+              "sourceMaps": true,
+              "outFiles": [
+                "${workspaceFolder}/**/src-gen/**/*.js"
+              ],
+              "skipFiles": [
+                "<node_internals>/**",
+                "**/esm/esm.js"
+              ],
+              "console": "internalConsole"
+            }
+          }
+        ],
+        "initialConfigurations": [
+          {
+            "type": "node",
+            "request": "launch",
+            "name": "Launch/Debug N4JS",
+            "runtimeExecutable": "/usr/local/bin/node",
+            "runtimeArgs": [ "-r", "esm" ],
+            "program": "${file}",
+            "args": [],
+            "sourceMaps": true,
+            "outFiles": [
+              "${workspaceFolder}/**/src-gen/**/*.js"
+            ],
+            "skipFiles": [
+              "<node_internals>/**",
+              "**/esm/esm.js"
+            ],
+            "console": "internalConsole"
+          }
+        ]
+      }
+    ],
+    "breakpoints": [
+      {
+        "language": "n4js"
+      }
+    ],
     "commands": [
       {
         "command": "n4js.refresh",


### PR DESCRIPTION
See #2014.

To test this:

1. Open a N4JS file in VSCode and make sure its editor is active.
2. Go to the "Run" tab.
3. If you do not yet have a `.vscode/launch.json` file, then click the link "create a launch.json file" in the "Run" tab (see [1]).
   Otherwise, select "Add configuration ..." from the launch configuration drop-down menu (see [2]).
   --> this should create and select a new N4JS launch configuration; review, adjust and save it!
4. Now go back the the open N4JS editor (make sure it has focus!).
5. Set a breakpoint somewhere.
6. Press F5 to launch/debug.

[1] creating a new `.vscode/launch.json` file:
<img width="840" alt="Screenshot1" src="https://user-images.githubusercontent.com/7124687/103664697-d5fe2200-4f72-11eb-8e62-678a0177ba2e.png">

[2] adding a new launch configuration to an existing `.vscode/launch.json` file:
<img width="460" alt="Screenshot2" src="https://user-images.githubusercontent.com/7124687/103664741-e1e9e400-4f72-11eb-9bc5-a6d055a70721.png">