### PR TITLE
GH-2037: Fix unavailable maven repo fornax-platform.org/m2/repository

### DIFF
--- a/releng/org.eclipse.n4js.parent/pom.xml
+++ b/releng/org.eclipse.n4js.parent/pom.xml
@@ -420,16 +420,6 @@ Contributors:
 				<checksumPolicy>fail</checksumPolicy>
 			</snapshots>
 		</pluginRepository>
-		<pluginRepository>
-			<id>fornax</id>
-			<url>http://www.fornax-platform.org/m2/repository</url>
-			<releases>
-				<enabled>true</enabled>
-			</releases>
-			<snapshots>
-				<enabled>false</enabled>
-			</snapshots>
-		</pluginRepository>
 	</pluginRepositories>
 
 	<dependencyManagement>


### PR DESCRIPTION
closes #2037 