### PR TITLE
GH-2040: Fix output of cancelled request in Output View of VSCode 

### DIFF
--- a/plugins/org.eclipse.n4js.cli/src/org/eclipse/n4js/cli/lsp/PatchedLauncherBuilder.java
+++ b/plugins/org.eclipse.n4js.cli/src/org/eclipse/n4js/cli/lsp/PatchedLauncherBuilder.java
@@ -29,10 +29,11 @@ public class PatchedLauncherBuilder<T> extends Launcher.Builder<T> {
 		outgoingMessageStream = wrapMessageConsumer(outgoingMessageStream);
 		Endpoint localEndpoint = ServiceEndpoints.toEndpoint(localServices);
 		RemoteEndpoint remoteEndpoint;
-		if (exceptionHandler == null)
+		if (exceptionHandler == null) {
 			remoteEndpoint = new PatchedRemoteEndpoint(outgoingMessageStream, localEndpoint);
-		else
+		} else {
 			remoteEndpoint = new PatchedRemoteEndpoint(outgoingMessageStream, localEndpoint, exceptionHandler);
+		}
 		jsonHandler.setMethodProvider(remoteEndpoint);
 		return remoteEndpoint;
 	}

--- a/plugins/org.eclipse.n4js.cli/src/org/eclipse/n4js/cli/lsp/PatchedRemoteEndpoint.java
+++ b/plugins/org.eclipse.n4js.cli/src/org/eclipse/n4js/cli/lsp/PatchedRemoteEndpoint.java
@@ -168,8 +168,8 @@ public class PatchedRemoteEndpoint extends RemoteEndpoint {
 				}
 				responseMessage = createErrorResponseMessage(requestMessage, errorObject);
 				LOG.error("Server errors: " + messageId + " / " + requestMessage.getMethod());
+				out.consume(responseMessage);
 			}
-			out.consume(responseMessage);
 			return null;
 		}).thenApply((obj) -> {
 			synchronized (receivedRequestMap) {

--- a/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/server/codeActions/N4JSCodeActionService.java
+++ b/plugins/org.eclipse.n4js.ide/src/org/eclipse/n4js/ide/server/codeActions/N4JSCodeActionService.java
@@ -287,6 +287,7 @@ public class N4JSCodeActionService implements ICodeActionService2 {
 
 	private void findSourceActions(Options options, CodeActionAcceptor acceptor) {
 		for (SourceActionImplementation impl : sourceActions) {
+			cancelManager.checkCanceled(options.getCancelIndicator());
 			impl.compute(options, acceptor);
 		}
 	}

--- a/tests/org.eclipse.n4js.json.tests/src/org/eclipse/n4js/json/tests/ide/contentassist/JSONCompletionTest.xtend
+++ b/tests/org.eclipse.n4js.json.tests/src/org/eclipse/n4js/json/tests/ide/contentassist/JSONCompletionTest.xtend
@@ -14,6 +14,8 @@ import org.eclipse.xtext.testing.AbstractLanguageServerTest
 import org.junit.Test
 import org.eclipse.lsp4j.CompletionItem
 
+// FIXME: GH-2045: Tests in this bundle seem to use plain Xtext test infrastructure that differs from ours.
+// This results (sometimes) in wrong results. E.g.: The result of testNameValuePairs_01 is incomplete.
 class JSONCompletionTest extends AbstractLanguageServerTest {
 	new() {
 		super("json")


### PR DESCRIPTION
closes #2040 