### PR TITLE
GH-2093: Bogus error shown when exporting a type alias from an N4JSD file

### DIFF
--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/messages.properties
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/messages.properties
@@ -264,7 +264,7 @@ CLF_EXT_EXTERNAL_N4JSD=error;;;{0} declared as external have to be placed in a f
 # none
 CLF_EXT_PROVIDED_BY_RUNTIME_IN_RUNTIME_TYPE=error;;;Only runtime environments/libraries may specify elements provided by runtime.
 # no parameters required
-CLF_EXT_UNALLOWED_N4JSD=error;;;Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files.
+CLF_EXT_UNALLOWED_N4JSD=error;;;Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files.
 # no parameters required
 CLF_EXT_EXPORTED=error;;;External elements have to be exported.
 # no parameters required

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSExternalValidator.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSExternalValidator.xtend
@@ -31,6 +31,7 @@ import org.eclipse.n4js.n4JS.N4InterfaceDeclaration
 import org.eclipse.n4js.n4JS.N4JSPackage
 import org.eclipse.n4js.n4JS.N4MemberDeclaration
 import org.eclipse.n4js.n4JS.N4SetterDeclaration
+import org.eclipse.n4js.n4JS.N4TypeAliasDeclaration
 import org.eclipse.n4js.n4JS.N4TypeDeclaration
 import org.eclipse.n4js.n4JS.Script
 import org.eclipse.n4js.n4JS.TypeReferenceNode
@@ -522,6 +523,11 @@ class N4JSExternalValidator extends AbstractN4JSDeclarativeValidator {
 			}
 		}
 		if (eo instanceof N4EnumDeclaration) {
+			if (eo.external) {
+				return false;
+			}
+		}
+		if (eo instanceof N4TypeAliasDeclaration) {
 			if (eo.external) {
 				return false;
 			}

--- a/tests/org.eclipse.n4js.ide.tests/src/org/eclipse/n4js/ide/tests/builder/ProjectWithoutGenerationBuilderTest.xtend
+++ b/tests/org.eclipse.n4js.ide.tests/src/org/eclipse/n4js/ide/tests/builder/ProjectWithoutGenerationBuilderTest.xtend
@@ -61,7 +61,7 @@ class ProjectWithoutGenerationBuilderTest extends AbstractIdeTest {
 		startAndWaitForLspServer();
 		assertIssues(
 			"Test.n4jsd" -> #[
-				"(Error, [1:0 - 1:7], Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files.)"
+				"(Error, [1:0 - 1:7], Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files.)"
 			]
 		);
 	}

--- a/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch04_14__TypeAlias/TypeAlias_exportedFromN4jsd.n4jsd.xt
+++ b/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch04_14__TypeAlias/TypeAlias_exportedFromN4jsd.n4jsd.xt
@@ -12,13 +12,16 @@
 /* XPECT_SETUP org.eclipse.n4js.spec.tests.N4JSSpecTest END_SETUP */
 
 // XPECT noerrors -->
-export type A1 = string;
+export external type A1 = string;
 
 // XPECT noerrors -->
-export public type A2 = string;
+export external public type A2 = string;
 
 // XPECT noerrors -->
-@Internal export public type A3 = string;
+@Internal export external public type A3 = string;
 
-// XPECT errors --> "A type with visibility public must be marked as exported." at "A4"
+/* XPECT errors ---
+"A type with visibility public must be marked as exported." at "A4"
+"Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "A4"
+--- */
 public type A4 = string;

--- a/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/project/NoValidationIdeTest.xtend
+++ b/tests/org.eclipse.n4js.ui.tests/src/org/eclipse/n4js/tests/project/NoValidationIdeTest.xtend
@@ -132,7 +132,7 @@ class NoValidationIdeTest extends ConvertedIdeTest {
 		// assert markers
 		assertIssues(
 			"Shadowed.n4jsd" -> #[
-				"(Error, [1:20 - 1:26], Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files.)"
+				"(Error, [1:20 - 1:26], Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files.)"
 			]
 		);
 		assertEquals("file src/js/Shadowed.js should have 0 markers", 0, getIssuesInFile(fileImpl).size);

--- a/tests/org.eclipse.n4js.xpect.tests/xpect-tests/validation/IDE_657_external/UnallowedElements.n4jsd.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/xpect-tests/validation/IDE_657_external/UnallowedElements.n4jsd.xt
@@ -24,7 +24,7 @@ export public interface ~Line {
 	public end : Point;
 }
 
-// XPECT errors --> "Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "InternalPoint"
+// XPECT errors --> "Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "InternalPoint"
 export public class InternalPoint {
 }
 
@@ -48,7 +48,7 @@ export external public class InternalPoint3 {
 @Internal
 /* XPECT errors ---
 "A interface with visibility project shouldn't be annotated with @Internal." at "InternalClonable"
-"Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "InternalClonable"
+"Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "InternalClonable"
 --- */
 export interface InternalClonable {
 }
@@ -69,7 +69,7 @@ external public interface InternalClonable2 {
 export external public interface InternalClonable3 {
 }
 
-// XPECT errors --> "Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "NonStructuralTypedLine"
+// XPECT errors --> "Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "NonStructuralTypedLine"
 export public interface NonStructuralTypedLine {
 	public start : Point;
 	public end : Point;
@@ -96,59 +96,59 @@ export public interface ~NonApiStructuralTypedLine2 {
 	public end : Point;
 };
 
-// XPECT errors --> "Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "MyEnum"
+// XPECT errors --> "Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "MyEnum"
 enum MyEnum {
 	LIT1
 };
 
-// XPECT errors --> "Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "foo"
+// XPECT errors --> "Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "foo"
 export function foo() {
 };
 
 // no errors expected XPECT noerrors
 ;
 
-// XPECT errors --> "Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "{"
+// XPECT errors --> "Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "{"
 {
 
 };
 
-// XPECT errors --> "Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "LABEL"
+// XPECT errors --> "Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "LABEL"
 LABEL: undefined;
 
-// XPECT errors --> "Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "if"
+// XPECT errors --> "Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "if"
 if(true) {
 
 };
 
-// XPECT errors --> "Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "do"
+// XPECT errors --> "Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "do"
 do {
 
 } while(true);
 
-// XPECT errors --> "Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "while"
+// XPECT errors --> "Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "while"
 while(true) {
 
 };
 
-// XPECT errors --> "Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "for"
+// XPECT errors --> "Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "for"
 for(var i in {}) {
 
 };
 
-// XPECT errors --> "Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "with"
+// XPECT errors --> "Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "with"
 with (true);
 
 export var a;
-// XPECT errors --> "Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "switch"
+// XPECT errors --> "Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "switch"
 switch(a) {
 
 };
 
-// XPECT errors --> "Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "throw"
+// XPECT errors --> "Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "throw"
 throw(new Error);
 
-// XPECT errors --> "Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "try"
+// XPECT errors --> "Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "try"
 try {
 
 } catch(e) {
@@ -156,5 +156,5 @@ try {
 }
 
 // XPECT warnings --> "Dead code." at "debugger;"
-// XPECT errors --> "Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "debugger"
+// XPECT errors --> "Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "debugger"
 debugger;

--- a/tests/org.eclipse.n4js.xpect.tests/xpect-tests/validation/IDE_784_external/ExtEnum.n4jsd.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/xpect-tests/validation/IDE_784_external/ExtEnum.n4jsd.xt
@@ -19,7 +19,7 @@ export external public enum EnumWithLiteralThatHasValueAssigned {
   	"another bug"
 }
 
-// XPECT errors --> "Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "EnumWithoutExternal"
+// XPECT errors --> "Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "EnumWithoutExternal"
 export public enum EnumWithoutExternal {
   MayBug,
   Cockroach

--- a/tests/org.eclipse.n4js.xpect.tests/xpect-tests/validation/IDE_784_external/ExtFuns.n4jsd.xt
+++ b/tests/org.eclipse.n4js.xpect.tests/xpect-tests/validation/IDE_784_external/ExtFuns.n4jsd.xt
@@ -12,12 +12,12 @@
 /* XPECT_SETUP org.eclipse.n4js.xpect.tests.N4JSXpectTest END_SETUP */
 @@IgnoreImplementation
 
-// XPECT errors --> "Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "funWithoutExternal"
+// XPECT errors --> "Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "funWithoutExternal"
 export public function funWithoutExternal(s : string): number { return 0; }
 
 /* XPECT errors ---
 "Functions have to have a body." at "funWithoutExternalAndWithoutBody"
-"Only classes, interfaces, enums and functions declared as external as well as structural typed interfaces are allowed in n4jsd files." at "funWithoutExternalAndWithoutBody"
+"Only classes, interfaces, enums, type aliases and functions declared as external as well as structurally typed interfaces are allowed in n4jsd files." at "funWithoutExternalAndWithoutBody"
 ---	*/
 export public function funWithoutExternalAndWithoutBody(s : string): number
 


### PR DESCRIPTION
See #2093.