### PR TITLE
GH-2111: As a developer I'd like to use type aliases as values (esp. in JSX tags) -- preparations

### DIFF
--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/typesystem/TypeJudgment.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/typesystem/TypeJudgment.java
@@ -164,6 +164,7 @@ import org.eclipse.n4js.ts.types.TStructuralType;
 import org.eclipse.n4js.ts.types.TTypedElement;
 import org.eclipse.n4js.ts.types.TypableElement;
 import org.eclipse.n4js.ts.types.Type;
+import org.eclipse.n4js.ts.types.TypeAlias;
 import org.eclipse.n4js.ts.types.TypesPackage;
 import org.eclipse.n4js.ts.types.TypingStrategy;
 import org.eclipse.n4js.ts.types.util.TypesSwitch;
@@ -248,6 +249,15 @@ import com.google.inject.Inject;
 		@Override
 		public TypeRef caseType(Type type) {
 			return TypeUtils.wrapTypeInTypeRef(type);
+		}
+
+		/**
+		 * This override is required only to solve the ambiguity due to {@link TypeAlias} being a subtype of both
+		 * {@link Type} and {@link TTypedElement}. We choose to treat it as a {@code Type}.
+		 */
+		@Override
+		public TypeRef caseTypeAlias(TypeAlias typeAlias) {
+			return this.caseType(typeAlias);
 		}
 
 		@Override

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSXValidator.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/validation/validators/N4JSXValidator.xtend
@@ -147,8 +147,8 @@ class N4JSXValidator extends AbstractN4JSDeclarativeValidator {
 	def public void checkReactElementBinding(JSXElement jsxElem) {
 		val expr = jsxElem.jsxElementName.expression;
 		val TypeRef exprTypeRef = reactHelper.getJsxElementBindingType(jsxElem);
-		var isFunction = exprTypeRef instanceof FunctionTypeExprOrRef;
-		var isClass = exprTypeRef instanceof TypeTypeRef && (exprTypeRef as TypeTypeRef).constructorRef;
+		val isFunction = exprTypeRef instanceof FunctionTypeExprOrRef;
+		val isClass = exprTypeRef instanceof TypeTypeRef && (exprTypeRef as TypeTypeRef).constructorRef;
 
 		if (!isFunction && !isClass) {
 			val String refName = expr.refName

--- a/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch04_14__TypeAlias/TypeAlias_validation_usedAsValue2.n4jsx.xt
+++ b/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch04_14__TypeAlias/TypeAlias_validation_usedAsValue2.n4jsx.xt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.spec.tests.N4JSSpecTest END_SETUP */
+
+
+function foo(p: constructor{?}) {}
+
+class Cls {}
+
+type A = Cls;
+
+// XPECT errors --> "A type alias may not be used as a value." at "A"
+A;
+// XPECT errors --> "A type alias may not be used as a value." at "A"
+new A();
+// XPECT errors --> "A type alias may not be used as a value." at "A"
+foo(A);
+// XPECT errors ---
+// "A type alias may not be used as a value." at "A"
+// "Cannot resolve JSX implementation." at "<A/>"
+// ---
+<A/>;
+
+// note: the above also tests that we do not get unnecessary duplicate error messages.


### PR DESCRIPTION
See #2111.

This PR only includes some minor improvements of the handling of `IdentifierRef`s that point to type aliases. Since this is disallowed by a validation anyway, it does not have much impact, but improves consistency a bit and avoids some duplicate error messages. Also, might prove helpful in the future.

The actual topic of #2111 is not addressed by this PR.