### PR TITLE
GH-2162: Bump versions of dependencies in VSCode extension and @n4js-tools/n4jsd-generator due to vulnerabilities

### DIFF
--- a/lsp-clients/n4js-vscode-extension/package.json
+++ b/lsp-clients/n4js-vscode-extension/package.json
@@ -66,7 +66,9 @@
       {
         "type": "n4js",
         "label": "N4JS Debug",
-        "languages": [ "n4js" ],
+        "languages": [
+          "n4js"
+        ],
         "configurationSnippets": [
           {
             "label": "N4JS: Launch/Debug N4JS",
@@ -76,7 +78,10 @@
               "request": "launch",
               "name": "Launch/Debug N4JS",
               "runtimeExecutable": "/usr/local/bin/node",
-              "runtimeArgs": [ "-r", "esm" ],
+              "runtimeArgs": [
+                "-r",
+                "esm"
+              ],
               "program": "${file}",
               "args": [],
               "sourceMaps": true,
@@ -97,7 +102,10 @@
             "request": "launch",
             "name": "Launch/Debug N4JS",
             "runtimeExecutable": "/usr/local/bin/node",
-            "runtimeArgs": [ "-r", "esm" ],
+            "runtimeArgs": [
+              "-r",
+              "esm"
+            ],
             "program": "${file}",
             "args": [],
             "sourceMaps": true,
@@ -209,8 +217,8 @@
     }
   },
   "devDependencies": {
-    "json": "9.0.6",
-    "vsce": "1.71.0"
+    "json": "11.0.0",
+    "vsce": "1.95.1"
   },
   "dependencies": {
     "n4js-cli": "latest",
@@ -218,7 +226,7 @@
     "n4js-runtime-node": "latest",
     "n4js-runtime-es2015": "latest",
     "npmlog": "4.1.2",
-    "vscode-languageclient": "6.1.0"
+    "vscode-languageclient": "7.0.0"
   },
   "scripts": {},
   "n4js": {

--- a/lsp-clients/n4js-vscode-extension/src-gen/ExtensionProvider.js
+++ b/lsp-clients/n4js-vscode-extension/src-gen/ExtensionProvider.js
@@ -236,7 +236,7 @@ function onN4jscliConfigChange(vscode, vscodeLC, context, outputChannel) {
 	return null;
 }
 function requestUserReload(vscode, vscodeLC, context, outputChannel) {
-	vscode.window.showInformationMessage("The config file .n4js-cli.config changed. A reload of the N4JS Extension is necessary for changes to take effect.", "Reload Extension").then(async function(value) {
+	vscode.window.showInformationMessage("The config file n4js-cli.config changed. A reload of the N4JS Extension is necessary for changes to take effect.", "Reload Extension").then(async function(value) {
 		if (value == "Reload Extension") {
 			await reload(vscode, vscodeLC, context, outputChannel);
 		}

--- a/n4js-tools/@n4js-temp/n4jsd-generator/package-lock.json
+++ b/n4js-tools/@n4js-temp/n4jsd-generator/package-lock.json
@@ -706,6 +706,14 @@
       "requires": {
         "chalk": "~0.4.0",
         "underscore": "~1.6.0"
+      },
+      "dependencies": {
+        "underscore": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
+          "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
+          "dev": true
+        }
       }
     },
     "npmlog": {
@@ -993,12 +1001,6 @@
         "buffer": "^5.2.1",
         "through": "^2.3.8"
       }
-    },
-    "underscore": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-      "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-      "dev": true
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/n4js-tools/@n4js-temp/n4jsd-generator/package.json
+++ b/n4js-tools/@n4js-temp/n4jsd-generator/package.json
@@ -9,6 +9,7 @@
     "dts2n4jsd": "./bin/dts2n4jsd.js"
   },
   "scripts": {
+    "preinstall": "npx npm-force-resolutions",
     "build": "./npm-build.sh",
     "test": "./node_modules/.bin/n4js-mangelhaft"
   },
@@ -26,6 +27,9 @@
     "n4js-mangelhaft-cli": "^0.24.19",
     "org.eclipse.n4js.mangelhaft": "^0.24.19",
     "org.eclipse.n4js.mangelhaft.assert": "^0.24.19"
+  },
+  "resolutions": {
+    "underscore": "^1.12.1"
   },
   "n4js": {
     "projectType": "library",


### PR DESCRIPTION
closes #2162 