### PR TITLE
GH-2292: As a smith I need to find a proper way of installing n4js-libs in tests with "npm install" (bonus)

### DIFF
--- a/tests/org.eclipse.n4js.integration.tests/src/org/eclipse/n4js/integration/tests/cli/compile/N4jscInitTest.java
+++ b/tests/org.eclipse.n4js.integration.tests/src/org/eclipse/n4js/integration/tests/cli/compile/N4jscInitTest.java
@@ -22,14 +22,17 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
 
 import org.eclipse.n4js.cli.N4jscTestOptions;
 import org.eclipse.n4js.cli.helper.AbstractCliCompileTest;
 import org.eclipse.n4js.cli.helper.CliCompileResult;
+import org.eclipse.n4js.cli.helper.N4jsLibsAccess;
 import org.eclipse.n4js.cli.helper.ProcessResult;
 import org.eclipse.n4js.utils.io.FileUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 /**
@@ -40,6 +43,12 @@ public class N4jscInitTest extends AbstractCliCompileTest {
 	static final String CWD_NAME = "TestInit";
 
 	File cwd;
+
+	/** Ensure we get a helpful error message when running this test locally without first starting verdaccio. */
+	@BeforeClass
+	public static void assertVerdaccioIsRunning() {
+		N4jsLibsAccess.assertVerdaccioIsRunning(6, TimeUnit.SECONDS);
+	}
 
 	/** Set current working directory. */
 	@Before


### PR DESCRIPTION
Adds a more helpful error message in case tests are run locally and developer forgot to start verdaccio first.
(without this, npm/yarn would hang extremely long before failing with a timeout)