### PR TITLE
GH-2462: Polyprocessor fails to confirm subtype relation in case of properties typed as union types that contain type ~Object with {}

### DIFF
--- a/plugins/org.eclipse.n4js.ts.model/emf-gen/org/eclipse/n4js/ts/typeRefs/IntersectionTypeExpression.java
+++ b/plugins/org.eclipse.n4js.ts.model/emf-gen/org/eclipse/n4js/ts/typeRefs/IntersectionTypeExpression.java
@@ -66,6 +66,18 @@ public interface IntersectionTypeExpression extends ComposedTypeRef {
 	 * <!-- end-user-doc -->
 	 * <!-- begin-model-doc -->
 	 * *
+	 * Returns true iff all composed type refs are typed either def or use site structural
+	 * <!-- end-model-doc -->
+	 * @model kind="operation" unique="false"
+	 * @generated
+	 */
+	boolean isStructuralTyping();
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * <!-- begin-model-doc -->
+	 * *
 	 * Returns the actual typing strategy, that is TypingStrategy.STRUCTURAL iff this type is def site structural typing.
 	 * <!-- end-model-doc -->
 	 * @model kind="operation" unique="false"

--- a/plugins/org.eclipse.n4js.ts.model/emf-gen/org/eclipse/n4js/ts/typeRefs/TypeRefsPackage.java
+++ b/plugins/org.eclipse.n4js.ts.model/emf-gen/org/eclipse/n4js/ts/typeRefs/TypeRefsPackage.java
@@ -2217,15 +2217,6 @@ public interface TypeRefsPackage extends EPackage {
 	int INTERSECTION_TYPE_EXPRESSION___GET_STRUCTURAL_MEMBERS = COMPOSED_TYPE_REF___GET_STRUCTURAL_MEMBERS;
 
 	/**
-	 * The operation id for the '<em>Is Structural Typing</em>' operation.
-	 * <!-- begin-user-doc -->
-	 * <!-- end-user-doc -->
-	 * @generated
-	 * @ordered
-	 */
-	int INTERSECTION_TYPE_EXPRESSION___IS_STRUCTURAL_TYPING = COMPOSED_TYPE_REF___IS_STRUCTURAL_TYPING;
-
-	/**
 	 * The operation id for the '<em>Get AST Node Optional Field Strategy</em>' operation.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -2271,13 +2262,22 @@ public interface TypeRefsPackage extends EPackage {
 	int INTERSECTION_TYPE_EXPRESSION___IS_DEF_SITE_STRUCTURAL_TYPING = COMPOSED_TYPE_REF_OPERATION_COUNT + 2;
 
 	/**
+	 * The operation id for the '<em>Is Structural Typing</em>' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 * @ordered
+	 */
+	int INTERSECTION_TYPE_EXPRESSION___IS_STRUCTURAL_TYPING = COMPOSED_TYPE_REF_OPERATION_COUNT + 3;
+
+	/**
 	 * The operation id for the '<em>Get Typing Strategy</em>' operation.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
 	 * @generated
 	 * @ordered
 	 */
-	int INTERSECTION_TYPE_EXPRESSION___GET_TYPING_STRATEGY = COMPOSED_TYPE_REF_OPERATION_COUNT + 3;
+	int INTERSECTION_TYPE_EXPRESSION___GET_TYPING_STRATEGY = COMPOSED_TYPE_REF_OPERATION_COUNT + 4;
 
 	/**
 	 * The number of operations of the '<em>Intersection Type Expression</em>' class.
@@ -2286,7 +2286,7 @@ public interface TypeRefsPackage extends EPackage {
 	 * @generated
 	 * @ordered
 	 */
-	int INTERSECTION_TYPE_EXPRESSION_OPERATION_COUNT = COMPOSED_TYPE_REF_OPERATION_COUNT + 4;
+	int INTERSECTION_TYPE_EXPRESSION_OPERATION_COUNT = COMPOSED_TYPE_REF_OPERATION_COUNT + 5;
 
 	/**
 	 * The meta object id for the '{@link org.eclipse.n4js.ts.typeRefs.impl.ThisTypeRefImpl <em>This Type Ref</em>}' class.
@@ -10444,6 +10444,16 @@ public interface TypeRefsPackage extends EPackage {
 	EOperation getIntersectionTypeExpression__IsDefSiteStructuralTyping();
 
 	/**
+	 * Returns the meta object for the '{@link org.eclipse.n4js.ts.typeRefs.IntersectionTypeExpression#isStructuralTyping() <em>Is Structural Typing</em>}' operation.
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @return the meta object for the '<em>Is Structural Typing</em>' operation.
+	 * @see org.eclipse.n4js.ts.typeRefs.IntersectionTypeExpression#isStructuralTyping()
+	 * @generated
+	 */
+	EOperation getIntersectionTypeExpression__IsStructuralTyping();
+
+	/**
 	 * Returns the meta object for the '{@link org.eclipse.n4js.ts.typeRefs.IntersectionTypeExpression#getTypingStrategy() <em>Get Typing Strategy</em>}' operation.
 	 * <!-- begin-user-doc -->
 	 * <!-- end-user-doc -->
@@ -12344,6 +12354,14 @@ public interface TypeRefsPackage extends EPackage {
 		 * @generated
 		 */
 		EOperation INTERSECTION_TYPE_EXPRESSION___IS_DEF_SITE_STRUCTURAL_TYPING = eINSTANCE.getIntersectionTypeExpression__IsDefSiteStructuralTyping();
+
+		/**
+		 * The meta object literal for the '<em><b>Is Structural Typing</b></em>' operation.
+		 * <!-- begin-user-doc -->
+		 * <!-- end-user-doc -->
+		 * @generated
+		 */
+		EOperation INTERSECTION_TYPE_EXPRESSION___IS_STRUCTURAL_TYPING = eINSTANCE.getIntersectionTypeExpression__IsStructuralTyping();
 
 		/**
 		 * The meta object literal for the '<em><b>Get Typing Strategy</b></em>' operation.

--- a/plugins/org.eclipse.n4js.ts.model/emf-gen/org/eclipse/n4js/ts/typeRefs/impl/IntersectionTypeExpressionImpl.java
+++ b/plugins/org.eclipse.n4js.ts.model/emf-gen/org/eclipse/n4js/ts/typeRefs/impl/IntersectionTypeExpressionImpl.java
@@ -102,9 +102,24 @@ public class IntersectionTypeExpressionImpl extends ComposedTypeRefImpl implemen
 	 * @generated
 	 */
 	@Override
+	public boolean isStructuralTyping() {
+		final Function1<TypeRef, Boolean> _function = new Function1<TypeRef, Boolean>() {
+			public Boolean apply(final TypeRef it) {
+				return Boolean.valueOf((it.isUseSiteStructuralTyping() || it.isDefSiteStructuralTyping()));
+			}
+		};
+		return IterableExtensions.<TypeRef>forall(this.getTypeRefs(), _function);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
 	public TypingStrategy getTypingStrategy() {
-		boolean _isDefSiteStructuralTyping = this.isDefSiteStructuralTyping();
-		if (_isDefSiteStructuralTyping) {
+		boolean _isStructuralTyping = this.isStructuralTyping();
+		if (_isStructuralTyping) {
 			return TypingStrategy.STRUCTURAL;
 		}
 		return TypingStrategy.NOMINAL;
@@ -126,6 +141,7 @@ public class IntersectionTypeExpressionImpl extends ComposedTypeRefImpl implemen
 		if (baseClass == TypeRef.class) {
 			switch (baseOperationID) {
 				case TypeRefsPackage.TYPE_REF___GET_TYPING_STRATEGY: return TypeRefsPackage.INTERSECTION_TYPE_EXPRESSION___GET_TYPING_STRATEGY;
+				case TypeRefsPackage.TYPE_REF___IS_STRUCTURAL_TYPING: return TypeRefsPackage.INTERSECTION_TYPE_EXPRESSION___IS_STRUCTURAL_TYPING;
 				case TypeRefsPackage.TYPE_REF___IS_USE_SITE_STRUCTURAL_TYPING: return TypeRefsPackage.INTERSECTION_TYPE_EXPRESSION___IS_USE_SITE_STRUCTURAL_TYPING;
 				case TypeRefsPackage.TYPE_REF___IS_DEF_SITE_STRUCTURAL_TYPING: return TypeRefsPackage.INTERSECTION_TYPE_EXPRESSION___IS_DEF_SITE_STRUCTURAL_TYPING;
 				default: return super.eDerivedOperationID(baseOperationID, baseClass);
@@ -154,6 +170,8 @@ public class IntersectionTypeExpressionImpl extends ComposedTypeRefImpl implemen
 				return isUseSiteStructuralTyping();
 			case TypeRefsPackage.INTERSECTION_TYPE_EXPRESSION___IS_DEF_SITE_STRUCTURAL_TYPING:
 				return isDefSiteStructuralTyping();
+			case TypeRefsPackage.INTERSECTION_TYPE_EXPRESSION___IS_STRUCTURAL_TYPING:
+				return isStructuralTyping();
 			case TypeRefsPackage.INTERSECTION_TYPE_EXPRESSION___GET_TYPING_STRATEGY:
 				return getTypingStrategy();
 		}

--- a/plugins/org.eclipse.n4js.ts.model/emf-gen/org/eclipse/n4js/ts/typeRefs/impl/TypeRefsPackageImpl.java
+++ b/plugins/org.eclipse.n4js.ts.model/emf-gen/org/eclipse/n4js/ts/typeRefs/impl/TypeRefsPackageImpl.java
@@ -890,8 +890,18 @@ public class TypeRefsPackageImpl extends EPackageImpl implements TypeRefsPackage
 	 * @generated
 	 */
 	@Override
-	public EOperation getIntersectionTypeExpression__GetTypingStrategy() {
+	public EOperation getIntersectionTypeExpression__IsStructuralTyping() {
 		return intersectionTypeExpressionEClass.getEOperations().get(3);
+	}
+
+	/**
+	 * <!-- begin-user-doc -->
+	 * <!-- end-user-doc -->
+	 * @generated
+	 */
+	@Override
+	public EOperation getIntersectionTypeExpression__GetTypingStrategy() {
+		return intersectionTypeExpressionEClass.getEOperations().get(4);
 	}
 
 	/**
@@ -2363,6 +2373,7 @@ public class TypeRefsPackageImpl extends EPackageImpl implements TypeRefsPackage
 		createEOperation(intersectionTypeExpressionEClass, INTERSECTION_TYPE_EXPRESSION___INTERNAL_GET_TYPE_REF_AS_STRING__BOOLEAN);
 		createEOperation(intersectionTypeExpressionEClass, INTERSECTION_TYPE_EXPRESSION___IS_USE_SITE_STRUCTURAL_TYPING);
 		createEOperation(intersectionTypeExpressionEClass, INTERSECTION_TYPE_EXPRESSION___IS_DEF_SITE_STRUCTURAL_TYPING);
+		createEOperation(intersectionTypeExpressionEClass, INTERSECTION_TYPE_EXPRESSION___IS_STRUCTURAL_TYPING);
 		createEOperation(intersectionTypeExpressionEClass, INTERSECTION_TYPE_EXPRESSION___GET_TYPING_STRATEGY);
 
 		thisTypeRefEClass = createEClass(THIS_TYPE_REF);
@@ -2703,6 +2714,8 @@ public class TypeRefsPackageImpl extends EPackageImpl implements TypeRefsPackage
 		initEOperation(getIntersectionTypeExpression__IsUseSiteStructuralTyping(), theEcorePackage.getEBoolean(), "isUseSiteStructuralTyping", 0, 1, !IS_UNIQUE, IS_ORDERED);
 
 		initEOperation(getIntersectionTypeExpression__IsDefSiteStructuralTyping(), theEcorePackage.getEBoolean(), "isDefSiteStructuralTyping", 0, 1, !IS_UNIQUE, IS_ORDERED);
+
+		initEOperation(getIntersectionTypeExpression__IsStructuralTyping(), theEcorePackage.getEBoolean(), "isStructuralTyping", 0, 1, !IS_UNIQUE, IS_ORDERED);
 
 		initEOperation(getIntersectionTypeExpression__GetTypingStrategy(), theTypesPackage.getTypingStrategy(), "getTypingStrategy", 0, 1, !IS_UNIQUE, IS_ORDERED);
 

--- a/plugins/org.eclipse.n4js.ts.model/model/TypeRefs.xcore
+++ b/plugins/org.eclipse.n4js.ts.model/model/TypeRefs.xcore
@@ -447,10 +447,17 @@ class IntersectionTypeExpression extends ComposedTypeRef {
 	}
 	
 	/**
+	 * Returns true iff all composed type refs are typed either def or use site structural
+	 */
+	op boolean isStructuralTyping() {
+		return typeRefs.forall[isUseSiteStructuralTyping || isDefSiteStructuralTyping]
+	}
+	
+	/**
 	 * Returns the actual typing strategy, that is TypingStrategy.STRUCTURAL iff this type is def site structural typing.
 	 */
 	op TypingStrategy getTypingStrategy() {
-		if (isDefSiteStructuralTyping) {
+		if (isStructuralTyping) {
 			return TypingStrategy.STRUCTURAL
 		}
 		return TypingStrategy.NOMINAL

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/PolyProcessor_ObjectLiteral.xtend
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/postprocessing/PolyProcessor_ObjectLiteral.xtend
@@ -78,8 +78,7 @@ package class PolyProcessor_ObjectLiteral extends AbstractPolyProcessor {
 		}
 
 		// quick mode as a performance tweak:
-		val haveUsableExpectedType = expectedTypeRef !== null
-				&& (expectedTypeRef.useSiteStructuralTyping || expectedTypeRef.defSiteStructuralTyping); // TODO reconsider
+		val haveUsableExpectedType = expectedTypeRef !== null && expectedTypeRef.structuralTyping; // TODO reconsider
 		val quickMode = !haveUsableExpectedType && !TypeUtils.isInferenceVariable(expectedTypeRef);
 
 		val List<TStructMember> tMembers = newArrayList;

--- a/tests/org.eclipse.n4js.spec.tests/xt-tests/polyprocessor_struc_obj_union_props.n4js.xt
+++ b/tests/org.eclipse.n4js.spec.tests/xt-tests/polyprocessor_struc_obj_union_props.n4js.xt
@@ -27,3 +27,10 @@ let utf9 : string|number = "utf9";
 let y1 : A & B = {sn : utf9};
 // XPECT noerrors -->
 let y2 : A & B = {sn : "utf9"};
+
+// XPECT noerrors -->
+let z1 : A & ~Object with {} = {sn : utf9};
+// XPECT noerrors -->
+let z2 : A & ~Object with {} = {sn : "utf9"};
+// XPECT noerrors -->
+let z3 : A & ~Object with { so?: string } = {sn : "utf8"};


### PR DESCRIPTION
closes #2462 