### PR TITLE
GH-2523: N4JS VSCode extension fails during start-up due to invalid path exception

### DIFF
--- a/plugins/org.eclipse.n4js.dts/src/org/eclipse/n4js/dts/astbuilders/AbstractDtsModuleRefBuilder.java
+++ b/plugins/org.eclipse.n4js.dts/src/org/eclipse/n4js/dts/astbuilders/AbstractDtsModuleRefBuilder.java
@@ -73,7 +73,7 @@ public abstract class AbstractDtsModuleRefBuilder<T extends ParserRuleContext, R
 		}
 
 		if (moduleSpecifier.startsWith("./")) {
-			Path relLocation = srcFolder.relativize(Path.of(resource.getURI().toFileString()));
+			Path relLocation = srcFolder.relativize(URIUtils.toPath(resource.getURI()));
 			if (relLocation.getNameCount() > 1) {
 				relLocation = relLocation.subpath(0, relLocation.getNameCount() - 1);
 			} else {
@@ -90,7 +90,7 @@ public abstract class AbstractDtsModuleRefBuilder<T extends ParserRuleContext, R
 				uri = uri.trimSegments(1); // trim one parent folder
 			}
 
-			Path absModuleSpecifierPath = Path.of(uri.toFileString(), moduleSpecifier);
+			Path absModuleSpecifierPath = URIUtils.toPath(uri).resolve(moduleSpecifier);
 			Path relModuleSpecifierPath = srcFolder.relativize(absModuleSpecifierPath);
 			moduleSpecifier = this.packageName + "/" + relModuleSpecifierPath.toString();
 		}

--- a/plugins/org.eclipse.n4js.utils/src/org/eclipse/n4js/utils/URIUtils.java
+++ b/plugins/org.eclipse.n4js.utils/src/org/eclipse/n4js/utils/URIUtils.java
@@ -302,6 +302,9 @@ public class URIUtils {
 	 * <code>null</code>.
 	 * <p>
 	 * Same as {@link URI#toFileString()}, but returns a {@link File} instance instead of a string.
+	 * <p>
+	 * <b>Attention:</b> Do not use {@link Path#of(String, String...)} since it cannot parse windows paths such as
+	 * {@code \\\c:\}.
 	 */
 	static public File toFile(URI uri) {
 		return uri != null && uri.isFile() ? new File(uri.toFileString()) : null;

--- a/plugins/org.eclipse.n4js.xtext/src/org/eclipse/n4js/xtext/workspace/WorkspaceConfigSnapshot.java
+++ b/plugins/org.eclipse.n4js.xtext/src/org/eclipse/n4js/xtext/workspace/WorkspaceConfigSnapshot.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Objects;
 
 import org.eclipse.emf.common.util.URI;
+import org.eclipse.n4js.utils.URIUtils;
 import org.eclipse.n4js.utils.UtilN4;
 import org.eclipse.xtext.workspace.IWorkspaceConfig;
 import org.eclipse.xtext.xbase.lib.Pair;
@@ -55,8 +56,8 @@ public class WorkspaceConfigSnapshot extends Snapshot {
 
 	/** Getter for the root path. */
 	public Path makeWorkspaceRelative(URI containedUri) {
-		Path p = Path.of(getPath().toFileString());
-		return p.relativize(Path.of(containedUri.toFileString()));
+		Path p = URIUtils.toPath(getPath());
+		return p.relativize(URIUtils.toPath(containedUri));
 	}
 
 	/** Tells whether this workspace is empty, i.e. does not contain any projects. */

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/scoping/utils/ProjectImportEnablingScope.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/scoping/utils/ProjectImportEnablingScope.java
@@ -257,7 +257,7 @@ public class ProjectImportEnablingScope implements IScope {
 					if (descr.getEObjectURI() != null) {
 						URI uri = descr.getEObjectURI().trimFragment();
 						URI relUri = uri.deresolve(workspaceConfigSnapshot.getPath());
-						Path relPath = Path.of(relUri.toFileString());
+						Path relPath = URIUtils.toPath(relUri);
 						relPath = relPath.subpath(1, relPath.getNameCount());
 						matchingModules += relPath.toString();
 					} else {

--- a/plugins/org.eclipse.n4js/src/org/eclipse/n4js/workspace/N4JSProjectConfigSnapshot.java
+++ b/plugins/org.eclipse.n4js/src/org/eclipse/n4js/workspace/N4JSProjectConfigSnapshot.java
@@ -10,6 +10,7 @@
  */
 package org.eclipse.n4js.workspace;
 
+import java.io.File;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
@@ -353,7 +354,7 @@ public class N4JSProjectConfigSnapshot extends ProjectConfigSnapshot {
 			if (pd.getMainModule() != null) {
 				String mainModule = pd.getMainModule();
 				for (String srcPath : sourceContainerPaths) {
-					String mainModulePath = Path.of(srcPath, mainModule).toString();
+					String mainModulePath = new File(srcPath, mainModule).toString();
 					URI main = URI.createFileURI(mainModulePath).resolve(getPath());
 
 					if (URIUtils.toFile(main).isFile()) {
@@ -370,7 +371,7 @@ public class N4JSProjectConfigSnapshot extends ProjectConfigSnapshot {
 					continue;
 				}
 				for (String srcPath : sourceContainerPaths) {
-					String mainModulePath = Path.of(srcPath, pe.getMainModule().toString("/")).toString();
+					String mainModulePath = new File(srcPath, pe.getMainModule().toString("/")).toString();
 					URI expMain = URI.createFileURI(mainModulePath).resolve(getPath());
 					if (URIUtils.toFile(expMain).isFile()) {
 						startUris.add(expMain);
@@ -402,7 +403,7 @@ public class N4JSProjectConfigSnapshot extends ProjectConfigSnapshot {
 			}
 
 			LOOP_ALL: for (URI someUri : getAllContents(fileSystemScanner)) {
-				Path somePath = Path.of(someUri.deresolve(getPath()).toFileString());
+				Path somePath = URIUtils.toPath(someUri.deresolve(getPath()));
 				for (Path file : files) {
 					if (Objects.equals(file, somePath)) {
 						startUris.add(someUri);


### PR DESCRIPTION
closes #2523 