### PR TITLE
GH-2541: Transpiler misses out spec constructor initialization of fields defined in structural interfaces

### DIFF
--- a/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch05_01_04__Shapes/SpecConstructorInitializesFieldsFromShapes.n4js.xt
+++ b/tests/org.eclipse.n4js.spec.tests/xpect-tests/Ch05_01_04__Shapes/SpecConstructorInitializesFieldsFromShapes.n4js.xt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2016 NumberFour AG.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *   NumberFour AG - Initial API and implementation
+ */
+
+/* XPECT_SETUP org.eclipse.n4js.spec.tests.N4JSSpecTest END_SETUP */
+
+
+// XPECT noerrors -->
+export public interface ~Foo {
+    public foo: string;
+}
+
+export public abstract class Base {
+    public constructor(@Spec spec: ~i~this) {}
+}
+
+export public class Bar extends Base implements Foo {
+    public baz: int;
+}
+
+const bar = new Bar({foo: "", baz: 3});
+console.log(Object.getOwnPropertyNames(bar));
+
+/* XPECT output ---
+[ 'foo', 'baz' ]
+--- */


### PR DESCRIPTION
closes #2541