### PR TITLE
Replace fireTestRunStarted/Finished by fireTestSuiteStarted/Finished in XtFileRunner

### DIFF
--- a/testhelpers/org.eclipse.n4js.ide.tests.helper/src/org/eclipse/n4js/ide/tests/helper/server/xt/XtFileRunner.java
+++ b/testhelpers/org.eclipse.n4js.ide.tests.helper/src/org/eclipse/n4js/ide/tests/helper/server/xt/XtFileRunner.java
@@ -89,7 +89,7 @@ public class XtFileRunner extends Runner {
 		}
 
 		try {
-			notifier.fireTestRunStarted(getDescription());
+			notifier.fireTestSuiteStarted(getDescription());
 
 			parent.invokeBeforeMethods(ideTest);
 
@@ -126,7 +126,7 @@ public class XtFileRunner extends Runner {
 			try {
 				parent.invokeAfterMethods(ideTest);
 
-				notifier.fireTestRunFinished(new Result());
+				notifier.fireTestSuiteFinished(getDescription());
 			} catch (Throwable t) {
 				notifier.fireTestFailure(new Failure(getDescription(), t));
 			}

--- a/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/AbstractXtParentRunnerTest.java
+++ b/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/AbstractXtParentRunnerTest.java
@@ -20,7 +20,6 @@ import org.eclipse.n4js.utils.Strings;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.runner.Description;
-import org.junit.runner.Result;
 import org.junit.runner.notification.Failure;
 import org.junit.runner.notification.RunListener;
 import org.junit.runner.notification.RunNotifier;
@@ -59,12 +58,12 @@ public abstract class AbstractXtParentRunnerTest {
 
 		@Override
 		public void testSuiteStarted(Description description) throws Exception {
-			events.put("testSuiteStarted", description);
+			events.put("testSuiteStarted - " + description.getDisplayName(), description);
 		}
 
 		@Override
 		public void testSuiteFinished(Description description) throws Exception {
-			events.put("testSuiteFinished", description);
+			events.put("testSuiteFinished - " + description.getDisplayName(), description);
 		}
 
 		@Override

--- a/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/AbstractXtParentRunnerTest.java
+++ b/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/AbstractXtParentRunnerTest.java
@@ -58,13 +58,13 @@ public abstract class AbstractXtParentRunnerTest {
 		}
 
 		@Override
-		public void testRunStarted(Description description) throws Exception {
-			events.put("testRunStarted", description);
+		public void testSuiteStarted(Description description) throws Exception {
+			events.put("testSuiteStarted", description);
 		}
 
 		@Override
-		public void testRunFinished(Result result) throws Exception {
-			events.put("testRunFinished", result);
+		public void testSuiteFinished(Description description) throws Exception {
+			events.put("testSuiteFinished", description);
 		}
 
 		@Override

--- a/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/BeforeAfterInvocationTest.java
+++ b/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/BeforeAfterInvocationTest.java
@@ -37,25 +37,27 @@ public class BeforeAfterInvocationTest extends AbstractXtParentRunnerTest {
 
 	private static List<String> invocationRecorder = null;
 
-	
+
 	@Test
 	public void test() throws Exception {
 		assertNull(invocationRecorder);
 		invocationRecorder = new ArrayList<>();
 
 		run(new BeforeAfterTestRunSimulator(), "probands/BeforeAfterInvocation");
-		assertEventNames("testRunStarted\n"
+		assertEventNames("testSuiteStarted\n"
+				+ "testSuiteStarted\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
-				+ "testRunFinished\n"
-				+ "testRunStarted\n"
+				+ "testSuiteFinished\n"
+				+ "testSuiteStarted\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
-				+ "testRunFinished");
+				+ "testSuiteFinished\n"
+				+ "testSuiteFinished");
 		assertResults("Passed: noerrors~0:  〔probands/BeforeAfterInvocation/BeforeAfterInvocation1.n4js.xt〕\n"
 				+ "Passed: noerrors~1:  〔probands/BeforeAfterInvocation/BeforeAfterInvocation1.n4js.xt〕\n"
 				+ "Passed: noerrors~0:  〔probands/BeforeAfterInvocation/BeforeAfterInvocation2.n4js.xt〕\n"
@@ -91,7 +93,7 @@ public class BeforeAfterInvocationTest extends AbstractXtParentRunnerTest {
 		invocationRecorder = null;
 	}
 
-	
+
 	public static class SuperBeforeAfterXtIdeTest extends XtIdeTest {
 
 		@BeforeClass
@@ -125,7 +127,7 @@ public class BeforeAfterInvocationTest extends AbstractXtParentRunnerTest {
 		}
 	}
 
-	
+
 	public static class SubBeforeAfterXtIdeTest extends SuperBeforeAfterXtIdeTest {
 
 		@BeforeClass

--- a/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/BeforeAfterInvocationTest.java
+++ b/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/BeforeAfterInvocationTest.java
@@ -37,27 +37,26 @@ public class BeforeAfterInvocationTest extends AbstractXtParentRunnerTest {
 
 	private static List<String> invocationRecorder = null;
 
-
 	@Test
 	public void test() throws Exception {
 		assertNull(invocationRecorder);
 		invocationRecorder = new ArrayList<>();
 
 		run(new BeforeAfterTestRunSimulator(), "probands/BeforeAfterInvocation");
-		assertEventNames("testSuiteStarted\n"
-				+ "testSuiteStarted\n"
+		assertEventNames("testSuiteStarted - org.eclipse.n4js.ide.tests.helper.server.xt.tests.XtTestSetupTestMockup\n"
+				+ "testSuiteStarted - BeforeAfterInvocation1.n4js.xt: probands/BeforeAfterInvocation\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
-				+ "testSuiteFinished\n"
-				+ "testSuiteStarted\n"
+				+ "testSuiteFinished - BeforeAfterInvocation1.n4js.xt: probands/BeforeAfterInvocation\n"
+				+ "testSuiteStarted - BeforeAfterInvocation2.n4js.xt: probands/BeforeAfterInvocation\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
-				+ "testSuiteFinished\n"
-				+ "testSuiteFinished");
+				+ "testSuiteFinished - BeforeAfterInvocation2.n4js.xt: probands/BeforeAfterInvocation\n"
+				+ "testSuiteFinished - org.eclipse.n4js.ide.tests.helper.server.xt.tests.XtTestSetupTestMockup");
 		assertResults("Passed: noerrors~0:  〔probands/BeforeAfterInvocation/BeforeAfterInvocation1.n4js.xt〕\n"
 				+ "Passed: noerrors~1:  〔probands/BeforeAfterInvocation/BeforeAfterInvocation1.n4js.xt〕\n"
 				+ "Passed: noerrors~0:  〔probands/BeforeAfterInvocation/BeforeAfterInvocation2.n4js.xt〕\n"
@@ -93,7 +92,6 @@ public class BeforeAfterInvocationTest extends AbstractXtParentRunnerTest {
 		invocationRecorder = null;
 	}
 
-
 	public static class SuperBeforeAfterXtIdeTest extends XtIdeTest {
 
 		@BeforeClass
@@ -126,7 +124,6 @@ public class BeforeAfterInvocationTest extends AbstractXtParentRunnerTest {
 			invocationRecorder.add("#someAfterClassMethod() in super class");
 		}
 	}
-
 
 	public static class SubBeforeAfterXtIdeTest extends SuperBeforeAfterXtIdeTest {
 

--- a/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/DefinitionTest.java
+++ b/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/DefinitionTest.java
@@ -19,18 +19,17 @@ import org.junit.Test;
  */
 public class DefinitionTest extends AbstractXtParentRunnerTest {
 
-
 	@Test
 	public void test() throws Exception {
 		run("probands/Definition");
-		assertEventNames("testSuiteStarted\n"
-				+ "testSuiteStarted\n"
+		assertEventNames("testSuiteStarted - org.eclipse.n4js.ide.tests.helper.server.xt.tests.XtTestSetupTestMockup\n"
+				+ "testSuiteStarted - Definition.n4js.xt: probands/Definition\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
 				+ "testStarted\n"
 				+ "testFailure\n"
-				+ "testSuiteFinished\n"
-				+ "testSuiteFinished");
+				+ "testSuiteFinished - Definition.n4js.xt: probands/Definition\n"
+				+ "testSuiteFinished - org.eclipse.n4js.ide.tests.helper.server.xt.tests.XtTestSetupTestMockup");
 		assertResults(
 				"Passed: definition~0: test-1 〔probands/Definition/Definition.n4js.xt〕\n"
 						+ "Failed: definition~1: test-2 〔probands/Definition/Definition.n4js.xt〕. expected:<[wrong expectation]> but was:<[(test-project/src/Definition.n4js, [21:4 - 21:6])]>");

--- a/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/DefinitionTest.java
+++ b/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/DefinitionTest.java
@@ -19,16 +19,18 @@ import org.junit.Test;
  */
 public class DefinitionTest extends AbstractXtParentRunnerTest {
 
-	
+
 	@Test
 	public void test() throws Exception {
 		run("probands/Definition");
-		assertEventNames("testRunStarted\n"
+		assertEventNames("testSuiteStarted\n"
+				+ "testSuiteStarted\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
 				+ "testStarted\n"
 				+ "testFailure\n"
-				+ "testRunFinished");
+				+ "testSuiteFinished\n"
+				+ "testSuiteFinished");
 		assertResults(
 				"Passed: definition~0: test-1 〔probands/Definition/Definition.n4js.xt〕\n"
 						+ "Failed: definition~1: test-2 〔probands/Definition/Definition.n4js.xt〕. expected:<[wrong expectation]> but was:<[(test-project/src/Definition.n4js, [21:4 - 21:6])]>");

--- a/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/ElementKeywordTest.java
+++ b/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/ElementKeywordTest.java
@@ -10,8 +10,8 @@
  */
 package org.eclipse.n4js.ide.tests.helper.server.xt.tests;
 
-import org.eclipse.n4js.ide.tests.helper.server.xt.XtMethodData;
 import org.eclipse.n4js.ide.tests.helper.server.xt.XtIdeTest;
+import org.eclipse.n4js.ide.tests.helper.server.xt.XtMethodData;
 import org.junit.Test;
 
 /**
@@ -19,18 +19,17 @@ import org.junit.Test;
  */
 public class ElementKeywordTest extends AbstractXtParentRunnerTest {
 
-
 	@Test
 	public void test() throws Exception {
 		run("probands/ElementKeyword");
-		assertEventNames("testSuiteStarted\n"
-				+ "testSuiteStarted\n"
+		assertEventNames("testSuiteStarted - org.eclipse.n4js.ide.tests.helper.server.xt.tests.XtTestSetupTestMockup\n"
+				+ "testSuiteStarted - ElementKeyword.n4js.xt: probands/ElementKeyword\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
 				+ "testStarted\n"
 				+ "testFailure\n"
-				+ "testSuiteFinished\n"
-				+ "testSuiteFinished");
+				+ "testSuiteFinished - ElementKeyword.n4js.xt: probands/ElementKeyword\n"
+				+ "testSuiteFinished - org.eclipse.n4js.ide.tests.helper.server.xt.tests.XtTestSetupTestMockup");
 		assertResults(
 				"Passed: elementKeyword~0: test-1 〔probands/ElementKeyword/ElementKeyword.n4js.xt〕\n"
 						+ "Failed: elementKeyword~1: test-2 〔probands/ElementKeyword/ElementKeyword.n4js.xt〕. expected:<[wrong expectation]> but was:<[method]>");

--- a/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/ElementKeywordTest.java
+++ b/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/ElementKeywordTest.java
@@ -19,16 +19,18 @@ import org.junit.Test;
  */
 public class ElementKeywordTest extends AbstractXtParentRunnerTest {
 
-	
+
 	@Test
 	public void test() throws Exception {
 		run("probands/ElementKeyword");
-		assertEventNames("testRunStarted\n"
+		assertEventNames("testSuiteStarted\n"
+				+ "testSuiteStarted\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
 				+ "testStarted\n"
 				+ "testFailure\n"
-				+ "testRunFinished");
+				+ "testSuiteFinished\n"
+				+ "testSuiteFinished");
 		assertResults(
 				"Passed: elementKeyword~0: test-1 〔probands/ElementKeyword/ElementKeyword.n4js.xt〕\n"
 						+ "Failed: elementKeyword~1: test-2 〔probands/ElementKeyword/ElementKeyword.n4js.xt〕. expected:<[wrong expectation]> but was:<[method]>");

--- a/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/IgnoreWrongRunnerTest.java
+++ b/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/IgnoreWrongRunnerTest.java
@@ -17,13 +17,15 @@ import org.junit.Test;
  */
 public class IgnoreWrongRunnerTest extends AbstractXtParentRunnerTest {
 
-	
+
 	@Test
 	public void test() throws Exception {
 		run("probands/IgnoreWrongRunner");
 		assertTestStructure("org.eclipse.n4js.ide.tests.helper.server.xt.tests.XtTestSetupTestMockup\n"
 				+ " + IgnoreWrongRunner.n4js.xt: probands/IgnoreWrongRunner: Specified runner does not match current runner");
-		assertEventNames("testIgnored");
+		assertEventNames("testSuiteStarted\n"
+			+ "testIgnored\n"
+			+ "testSuiteFinished");
 	}
 
 }

--- a/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/IgnoreWrongRunnerTest.java
+++ b/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/IgnoreWrongRunnerTest.java
@@ -17,15 +17,14 @@ import org.junit.Test;
  */
 public class IgnoreWrongRunnerTest extends AbstractXtParentRunnerTest {
 
-
 	@Test
 	public void test() throws Exception {
 		run("probands/IgnoreWrongRunner");
 		assertTestStructure("org.eclipse.n4js.ide.tests.helper.server.xt.tests.XtTestSetupTestMockup\n"
 				+ " + IgnoreWrongRunner.n4js.xt: probands/IgnoreWrongRunner: Specified runner does not match current runner");
-		assertEventNames("testSuiteStarted\n"
-			+ "testIgnored\n"
-			+ "testSuiteFinished");
+		assertEventNames("testSuiteStarted - org.eclipse.n4js.ide.tests.helper.server.xt.tests.XtTestSetupTestMockup\n"
+				+ "testIgnored\n"
+				+ "testSuiteFinished - org.eclipse.n4js.ide.tests.helper.server.xt.tests.XtTestSetupTestMockup");
 	}
 
 }

--- a/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/IssueConfigurationTest.java
+++ b/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/IssueConfigurationTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
  */
 public class IssueConfigurationTest extends AbstractXtParentRunnerTest {
 
-
 	@Test
 	public void test() throws Exception {
 
@@ -37,8 +36,8 @@ public class IssueConfigurationTest extends AbstractXtParentRunnerTest {
 		assertFalse(suppressed.contains(IssueCodes.CLF_NAME_DOES_NOT_START_LOWERCASE));
 
 		run("probands/IssueConfiguration", suppressed);
-		assertEventNames("testSuiteStarted\n"
-				+ "testSuiteStarted\n"
+		assertEventNames("testSuiteStarted - org.eclipse.n4js.ide.tests.helper.server.xt.tests.XtTestSetupTestMockup\n"
+				+ "testSuiteStarted - IssueConfiguration.n4js.xt: probands/IssueConfiguration\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
 				+ "testStarted\n"
@@ -47,8 +46,8 @@ public class IssueConfigurationTest extends AbstractXtParentRunnerTest {
 				+ "testFinished\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
-				+ "testSuiteFinished\n"
-				+ "testSuiteFinished");
+				+ "testSuiteFinished - IssueConfiguration.n4js.xt: probands/IssueConfiguration\n"
+				+ "testSuiteFinished - org.eclipse.n4js.ide.tests.helper.server.xt.tests.XtTestSetupTestMockup");
 		assertResults("Passed: nowarnings~0:  〔probands/IssueConfiguration/IssueConfiguration.n4js.xt〕\n"
 				+ "Passed: warnings~0:  〔probands/IssueConfiguration/IssueConfiguration.n4js.xt〕\n"
 				+ "Passed: warnings~1:  〔probands/IssueConfiguration/IssueConfiguration.n4js.xt〕\n"

--- a/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/IssueConfigurationTest.java
+++ b/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/IssueConfigurationTest.java
@@ -24,7 +24,7 @@ import org.junit.Test;
  */
 public class IssueConfigurationTest extends AbstractXtParentRunnerTest {
 
-	
+
 	@Test
 	public void test() throws Exception {
 
@@ -37,7 +37,8 @@ public class IssueConfigurationTest extends AbstractXtParentRunnerTest {
 		assertFalse(suppressed.contains(IssueCodes.CLF_NAME_DOES_NOT_START_LOWERCASE));
 
 		run("probands/IssueConfiguration", suppressed);
-		assertEventNames("testRunStarted\n"
+		assertEventNames("testSuiteStarted\n"
+				+ "testSuiteStarted\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
 				+ "testStarted\n"
@@ -46,7 +47,8 @@ public class IssueConfigurationTest extends AbstractXtParentRunnerTest {
 				+ "testFinished\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
-				+ "testRunFinished");
+				+ "testSuiteFinished\n"
+				+ "testSuiteFinished");
 		assertResults("Passed: nowarnings~0:  〔probands/IssueConfiguration/IssueConfiguration.n4js.xt〕\n"
 				+ "Passed: warnings~0:  〔probands/IssueConfiguration/IssueConfiguration.n4js.xt〕\n"
 				+ "Passed: warnings~1:  〔probands/IssueConfiguration/IssueConfiguration.n4js.xt〕\n"

--- a/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/ModifiersTest.java
+++ b/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/ModifiersTest.java
@@ -19,20 +19,22 @@ import org.junit.Test;
  */
 public class ModifiersTest extends AbstractXtParentRunnerTest {
 
-	
+
 	@Test
 	public void test() throws Exception {
 		run("probands/Modifiers");
-		assertEventNames("testRunStarted\n"
+		assertEventNames("testSuiteStarted\n"
+				+ "testSuiteStarted\n"
 				+ "testStarted\n"
 				+ "testFailure\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
-				+ "testRunFinished\n"
-				+ "testRunStarted\n"
+				+ "testSuiteFinished\n"
+				+ "testSuiteStarted\n"
 				+ "testIgnored\n"
 				+ "testIgnored\n"
-				+ "testRunFinished");
+				+ "testSuiteFinished\n"
+				+ "testSuiteFinished");
 		assertResults(
 				"Failed: definition~0: FIXME test-1 〔probands/Modifiers/FIXME.n4js.xt〕. Test fixed!\n"
 						+ "Passed: definition~1: FIXME test-2 〔probands/Modifiers/FIXME.n4js.xt〕\n"

--- a/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/ModifiersTest.java
+++ b/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/ModifiersTest.java
@@ -10,8 +10,8 @@
  */
 package org.eclipse.n4js.ide.tests.helper.server.xt.tests;
 
-import org.eclipse.n4js.ide.tests.helper.server.xt.XtMethodData;
 import org.eclipse.n4js.ide.tests.helper.server.xt.XtIdeTest;
+import org.eclipse.n4js.ide.tests.helper.server.xt.XtMethodData;
 import org.junit.Test;
 
 /**
@@ -19,22 +19,21 @@ import org.junit.Test;
  */
 public class ModifiersTest extends AbstractXtParentRunnerTest {
 
-
 	@Test
 	public void test() throws Exception {
 		run("probands/Modifiers");
-		assertEventNames("testSuiteStarted\n"
-				+ "testSuiteStarted\n"
+		assertEventNames("testSuiteStarted - org.eclipse.n4js.ide.tests.helper.server.xt.tests.XtTestSetupTestMockup\n"
+				+ "testSuiteStarted - FIXME.n4js.xt: probands/Modifiers\n"
 				+ "testStarted\n"
 				+ "testFailure\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
-				+ "testSuiteFinished\n"
-				+ "testSuiteStarted\n"
+				+ "testSuiteFinished - FIXME.n4js.xt: probands/Modifiers\n"
+				+ "testSuiteStarted - IGNORE.n4js.xt: probands/Modifiers\n"
 				+ "testIgnored\n"
 				+ "testIgnored\n"
-				+ "testSuiteFinished\n"
-				+ "testSuiteFinished");
+				+ "testSuiteFinished - IGNORE.n4js.xt: probands/Modifiers\n"
+				+ "testSuiteFinished - org.eclipse.n4js.ide.tests.helper.server.xt.tests.XtTestSetupTestMockup");
 		assertResults(
 				"Failed: definition~0: FIXME test-1 〔probands/Modifiers/FIXME.n4js.xt〕. Test fixed!\n"
 						+ "Passed: definition~1: FIXME test-2 〔probands/Modifiers/FIXME.n4js.xt〕\n"

--- a/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/SuppressedIssuesTest.java
+++ b/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/SuppressedIssuesTest.java
@@ -11,8 +11,8 @@
 package org.eclipse.n4js.ide.tests.helper.server.xt.tests;
 
 import org.eclipse.n4js.N4JSLanguageConstants;
-import org.eclipse.n4js.ide.tests.helper.server.xt.XtMethodData;
 import org.eclipse.n4js.ide.tests.helper.server.xt.XtIdeTest;
+import org.eclipse.n4js.ide.tests.helper.server.xt.XtMethodData;
 import org.junit.Test;
 
 /**
@@ -20,16 +20,15 @@ import org.junit.Test;
  */
 public class SuppressedIssuesTest extends AbstractXtParentRunnerTest {
 
-
 	@Test
 	public void test() throws Exception {
 		run("probands/SuppressedIssues", N4JSLanguageConstants.DEFAULT_SUPPRESSED_ISSUE_CODES_FOR_TESTS);
-		assertEventNames("testSuiteStarted\n"
-				+ "testSuiteStarted\n"
+		assertEventNames("testSuiteStarted - org.eclipse.n4js.ide.tests.helper.server.xt.tests.XtTestSetupTestMockup\n"
+				+ "testSuiteStarted - SuppressedIssues.n4js.xt: probands/SuppressedIssues\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
-				+ "testSuiteFinished\n"
-				+ "testSuiteFinished");
+				+ "testSuiteFinished - SuppressedIssues.n4js.xt: probands/SuppressedIssues\n"
+				+ "testSuiteFinished - org.eclipse.n4js.ide.tests.helper.server.xt.tests.XtTestSetupTestMockup");
 		assertResults("Passed: nowarnings~0:  〔probands/SuppressedIssues/SuppressedIssues.n4js.xt〕");
 	}
 

--- a/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/SuppressedIssuesTest.java
+++ b/tests/org.eclipse.n4js.ide.tests.helper.tests/src/org/eclipse/n4js/ide/tests/helper/server/xt/tests/SuppressedIssuesTest.java
@@ -20,14 +20,16 @@ import org.junit.Test;
  */
 public class SuppressedIssuesTest extends AbstractXtParentRunnerTest {
 
-	
+
 	@Test
 	public void test() throws Exception {
 		run("probands/SuppressedIssues", N4JSLanguageConstants.DEFAULT_SUPPRESSED_ISSUE_CODES_FOR_TESTS);
-		assertEventNames("testRunStarted\n"
+		assertEventNames("testSuiteStarted\n"
+				+ "testSuiteStarted\n"
 				+ "testStarted\n"
 				+ "testFinished\n"
-				+ "testRunFinished");
+				+ "testSuiteFinished\n"
+				+ "testSuiteFinished");
 		assertResults("Passed: nowarnings~0:  〔probands/SuppressedIssues/SuppressedIssues.n4js.xt〕");
 	}
 


### PR DESCRIPTION
This PR replaces calls to `fireTestRunStarted/Finished` by `fireTestSuiteStarted/Finished` in `XtFileRunner`. According to the [JUnit 4 docs](https://github.com/junit-team/junit4/blob/16228f3ccea3c6f1170488e0e268f3601d130f75/src/main/java/org/junit/runner/notification/RunNotifier.java#L87), `fireTestRunStarted/Finished` are not supposed to be invoked by custom runners, which should use `fireTestSuiteStarted/Finished` instead.